### PR TITLE
Actually ignore warnings

### DIFF
--- a/src/cjson.rs
+++ b/src/cjson.rs
@@ -9,7 +9,7 @@ use std::io;
 pub fn canonicalize(jsn: json::Value) -> Result<Vec<u8>, String> {
     let converted = convert(jsn)?;
     let mut buf = Vec::new();
-    converted.write(&mut buf);
+    let _ = converted.write(&mut buf);  // Vec<u8> impl always succeeds (or panics).
     Ok(buf)
 }
 
@@ -102,7 +102,6 @@ fn convert(jsn: json::Value) -> Result<Value, String> {
             Ok(Value::Object(out))
         }
         json::Value::String(s) => Ok(Value::String(s)),
-        x => Err(format!("Value not supported: {}", x)),
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code, unused_variables, unused_imports)] // TODO remove when stable
+
 extern crate chrono;
 extern crate crypto;
 extern crate itoa;
@@ -9,8 +11,6 @@ extern crate serde;
 extern crate serde_derive;
 extern crate serde_json as json;
 extern crate url;
-
-#[ignore(dead_code, unused_variables)] // TODO remove when stable
 
 mod cjson;
 mod metadata;


### PR DESCRIPTION
Use the correct attribute, move it to the crate root. Also fix a couple
of legitimate warnings in cjson.