### PR TITLE
Move from rust-crypto to ring

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,12 +33,13 @@ chrono = { version = "0.3", features = [ "serde" ] }
 clap = { version = "2.23", optional = true }
 itoa = "0.3"
 log = "0.3"
-rust-crypto = "0.2"
+ring = "0.7"
 rustc-serialize = "0.3"
 serde = "0.9"
 serde_derive = "0.9"
 serde_json = "0.9"
 url = "1.4"
+untrusted = "0.3"
 
 [dev-dependencies]
 tempdir = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 extern crate chrono;
-extern crate crypto;
+extern crate ring;
 extern crate itoa;
 #[macro_use]
 extern crate log;
@@ -10,6 +10,7 @@ extern crate serde_derive;
 #[macro_use]
 extern crate serde_json as json;
 extern crate url;
+extern crate untrusted;
 
 mod cjson;
 mod metadata;

--- a/src/tuf.rs
+++ b/src/tuf.rs
@@ -1,6 +1,5 @@
 use chrono::UTC;
-use crypto::digest::Digest;
-use crypto::sha2::{Sha512, Sha256};
+use ring::digest::{SHA256, SHA512, Context};
 use json;
 use std::collections::{HashMap, HashSet};
 use std::fs::{File, DirBuilder};
@@ -292,13 +291,13 @@ impl Tuf {
         match hash_alg {
             HashType::Sha512 => {
                 Self::read_and_verify(&mut file,
-                                      &mut Sha512::new(),
+                                      Context::new(&SHA512),
                                       target_meta.length,
                                       &expected_hash.0)
             }
             HashType::Sha256 => {
                 Self::read_and_verify(&mut file,
-                                      &mut Sha256::new(),
+                                      Context::new(&SHA256),
                                       target_meta.length,
                                       &expected_hash.0)
             }
@@ -306,18 +305,18 @@ impl Tuf {
         }
     }
 
-    fn read_and_verify<R: Read, D: Digest>(input: &mut R,
-                                           digest: &mut D,
-                                           size: i64,
-                                           expected_hash: &[u8])
-                                           -> Result<(), Error> {
+    fn read_and_verify<R: Read>(input: &mut R,
+                                mut context: Context,
+                                size: i64,
+                                expected_hash: &[u8])
+                                -> Result<(), Error> {
         let mut buf = [0; 1024];
         let mut bytes_left = size;
 
         loop {
             match input.read(&mut buf) {
                 Ok(read_bytes) => {
-                    digest.input(&buf[0..read_bytes]);
+                    context.update(&buf[0..read_bytes]);
                     bytes_left -= read_bytes as i64;
                     if bytes_left == 0 {
                         break;
@@ -329,10 +328,9 @@ impl Tuf {
             }
         }
 
-        let mut generated_hash = vec![0; digest.output_bytes()];
-        digest.result(&mut generated_hash);
+        let generated_hash = context.finish();
 
-        if generated_hash.as_slice() == expected_hash {
+        if generated_hash.as_ref() == expected_hash {
             Ok(())
         } else {
             Err(Error::TargetHashMismatch)

--- a/src/tuf.rs
+++ b/src/tuf.rs
@@ -1,6 +1,7 @@
 use chrono::UTC;
-use ring::digest::{SHA256, SHA512, Context};
 use json;
+use ring::digest;
+use ring::digest::{SHA256, SHA512};
 use std::collections::{HashMap, HashSet};
 use std::fs::{File, DirBuilder};
 use std::io::Read;
@@ -291,13 +292,13 @@ impl Tuf {
         match hash_alg {
             HashType::Sha512 => {
                 Self::read_and_verify(&mut file,
-                                      Context::new(&SHA512),
+                                      digest::Context::new(&SHA512),
                                       target_meta.length,
                                       &expected_hash.0)
             }
             HashType::Sha256 => {
                 Self::read_and_verify(&mut file,
-                                      Context::new(&SHA256),
+                                      digest::Context::new(&SHA256),
                                       target_meta.length,
                                       &expected_hash.0)
             }
@@ -306,7 +307,7 @@ impl Tuf {
     }
 
     fn read_and_verify<R: Read>(input: &mut R,
-                                mut context: Context,
+                                mut context: digest::Context,
                                 size: i64,
                                 expected_hash: &[u8])
                                 -> Result<(), Error> {


### PR DESCRIPTION
This replaces all use of rust-crypto with ring. I think ring is a better choice, because it is better documented, more actively developed and more minimal. Besides, this is a prerequisite for #2.