### PR TITLE
Simplify signature verification code.

### DIFF
--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -634,13 +634,10 @@ pub enum SignatureScheme {
 
 impl SignatureScheme {
     fn verify(&self, pub_key: &KeyValue, msg: &[u8], sig: &SignatureValue) -> Result<(), Error> {
-        let alg = match self {
-            &SignatureScheme::Ed25519 =>
-                &ED25519 as &ring::signature::VerificationAlgorithm,
-            &SignatureScheme::RsaSsaPssSha256 =>
-                &RSA_PSS_2048_8192_SHA256 as &ring::signature::VerificationAlgorithm,
-            &SignatureScheme::RsaSsaPssSha512 =>
-                &RSA_PSS_2048_8192_SHA512 as &ring::signature::VerificationAlgorithm,
+        let alg: &ring::signature::VerificationAlgorithm = match self {
+            &SignatureScheme::Ed25519 => &ED25519,
+            &SignatureScheme::RsaSsaPssSha256 => &RSA_PSS_2048_8192_SHA256,
+            &SignatureScheme::RsaSsaPssSha512 => &RSA_PSS_2048_8192_SHA512,
             &SignatureScheme::Unsupported(ref s) => {
                 return Err(Error::UnsupportedSignatureScheme(s.clone()));
             }

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -634,32 +634,21 @@ pub enum SignatureScheme {
 
 impl SignatureScheme {
     fn verify(&self, pub_key: &KeyValue, msg: &[u8], sig: &SignatureValue) -> Result<(), Error> {
-        match self {
-            &SignatureScheme::Ed25519 => {
-                ring::signature::verify(&ED25519,
-                                        Input::from(&pub_key.value),
-                                        Input::from(msg),
-                                        Input::from(&sig.0))
-                    .map_err(|_| Error::VerificationFailure("Bad signature".into()))
-            }
-            &SignatureScheme::RsaSsaPssSha256 => {
-                ring::signature::verify(&RSA_PSS_2048_8192_SHA256,
-                                        Input::from(&convert_to_pkcs1(&pub_key.value)),
-                                        Input::from(msg),
-                                        Input::from(&sig.0))
-                    .map_err(|_| Error::VerificationFailure("Bad signature".into()))
-            }
-            &SignatureScheme::RsaSsaPssSha512 => {
-                ring::signature::verify(&RSA_PSS_2048_8192_SHA512,
-                                        Input::from(&convert_to_pkcs1(&pub_key.value)),
-                                        Input::from(msg),
-                                        Input::from(&sig.0))
-                    .map_err(|_| Error::VerificationFailure("Bad signature".into()))
-            }
+        let alg = match self {
+            &SignatureScheme::Ed25519 =>
+                &ED25519 as &ring::signature::VerificationAlgorithm,
+            &SignatureScheme::RsaSsaPssSha256 =>
+                &RSA_PSS_2048_8192_SHA256 as &ring::signature::VerificationAlgorithm,
+            &SignatureScheme::RsaSsaPssSha512 =>
+                &RSA_PSS_2048_8192_SHA512 as &ring::signature::VerificationAlgorithm,
             &SignatureScheme::Unsupported(ref s) => {
-                Err(Error::UnsupportedSignatureScheme(s.clone()))
+                return Err(Error::UnsupportedSignatureScheme(s.clone()));
             }
-        }
+        };
+
+        ring::signature::verify(alg, Input::from(&convert_to_pkcs1(&pub_key.value)),
+                                Input::from(msg), Input::from(&sig.0))
+            .map_err(|_| Error::VerificationFailure("Bad signature".into()))
     }
 }
 


### PR DESCRIPTION
Based on an earlier conversation, I looked into changing the *ring* API
to allow you to write this:

```rust
impl SignatureScheme {
    fn verify(&self, pub_key: &KeyValue, msg: &[u8], sig: &SignatureValue)
              -> Result<(), Error> {
        let alg = match self {
            &SignatureScheme::Ed25519 => &ED25519,
            &SignatureScheme::RsaSsaPssSha256 => &RSA_PSS_2048_8192_SHA256,
            &SignatureScheme::RsaSsaPssSha512 => &RSA_PSS_2048_8192_SHA512,
            &SignatureScheme::Unsupported(ref s) => {
                return Err(Error::UnsupportedSignatureScheme(s.clone()));
            }
        };

        ring::signature::verify(alg, Input::from(&convert_to_pkcs1(&pub_key.value)),
                                Input::from(msg), Input::from(&sig.0))
            .map_err(|_| Error::VerificationFailure("Bad signature".into()))
    }
}
```

I did create a patch to *ring* where that is possible, but it requires
breaking backward compatibility. I will probably do that in the future,
but not right away. Even still, here's a workaround to get the same
effect in a way that's only slightly more messy.