### PR TITLE
cargo: bump ring to 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ derp = "0.0.4"
 hyper = "0.10.10"
 itoa = "0.3"
 log = "0.3"
-ring = { version = "0.9.4", features = [ "rsa_signing" ] }
+ring = { version = "0.11", features = [ "rsa_signing" ] }
 serde = "1"
 serde_derive = "1"
 serde_json = "1"


### PR DESCRIPTION
This updates to latest ring to interop with crates depending on newer
versions. In particular this avoid linking errors like:
```
error: native library `ring-asm` is being linked to by more than one
version of the same package, but it can only be linked once; try updating
or pinning your dependencies to ensure that this package only shows up once

  ring v0.9.7
  ring v0.11.0
```