### PR TITLE
split path in TargetPath and VirtualTargetPath

### DIFF
--- a/src/bin/tuf.rs
+++ b/src/bin/tuf.rs
@@ -1,6 +1,5 @@
 extern crate clap;
 extern crate ring;
-extern crate tuf;
 
 use clap::{App, AppSettings, SubCommand, Arg, ArgMatches};
 use ring::rand::SystemRandom;

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -100,7 +100,7 @@ where
     D: DataInterchange,
 {
     local_path: PathBuf,
-    _interchange: PhantomData<D>,
+    interchange: PhantomData<D>,
 }
 
 impl<D> FileSystemRepository<D>
@@ -111,7 +111,7 @@ where
     pub fn new(local_path: PathBuf) -> Self {
         FileSystemRepository {
             local_path: local_path,
-            _interchange: PhantomData,
+            interchange: PhantomData,
         }
     }
 }
@@ -241,7 +241,7 @@ where
     client: Client,
     user_agent: String,
     metadata_prefix: Option<Vec<String>>,
-    _interchange: PhantomData<D>,
+    interchange: PhantomData<D>,
 }
 
 impl<D> HttpRepository<D>
@@ -274,7 +274,7 @@ where
             client: client,
             user_agent: user_agent,
             metadata_prefix: metadata_prefix,
-            _interchange: PhantomData,
+            interchange: PhantomData,
         }
     }
 
@@ -399,7 +399,7 @@ where
 {
     metadata: HashMap<(MetadataPath, MetadataVersion), Vec<u8>>,
     targets: HashMap<TargetPath, Vec<u8>>,
-    _interchange: PhantomData<D>,
+    interchange: PhantomData<D>,
 }
 
 impl<D> EphemeralRepository<D>
@@ -411,7 +411,7 @@ where
         EphemeralRepository {
             metadata: HashMap::new(),
             targets: HashMap::new(),
-            _interchange: PhantomData,
+            interchange: PhantomData,
         }
     }
 }

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -196,7 +196,7 @@ pub struct TargetsMetadata {
     typ: metadata::Role,
     version: u32,
     expires: String,
-    targets: HashMap<metadata::TargetPath, metadata::TargetDescription>,
+    targets: HashMap<metadata::VirtualTargetPath, metadata::TargetDescription>,
     #[serde(skip_serializing_if = "Option::is_none")]
     delegations: Option<metadata::Delegations>,
 }
@@ -269,7 +269,7 @@ pub struct Delegation {
     terminating: bool,
     threshold: u32,
     key_ids: Vec<crypto::KeyId>,
-    paths: Vec<metadata::TargetPath>,
+    paths: Vec<metadata::VirtualTargetPath>,
 }
 
 impl Delegation {
@@ -277,7 +277,7 @@ impl Delegation {
         let mut paths = meta.paths()
             .iter()
             .cloned()
-            .collect::<Vec<metadata::TargetPath>>();
+            .collect::<Vec<metadata::VirtualTargetPath>>();
         paths.sort();
         let mut key_ids = meta.key_ids()
             .iter()
@@ -298,7 +298,7 @@ impl Delegation {
         let paths = self.paths
             .iter()
             .cloned()
-            .collect::<HashSet<metadata::TargetPath>>();
+            .collect::<HashSet<metadata::VirtualTargetPath>>();
         if paths.len() != self.paths.len() {
             return Err(Error::Encoding("Non-unique delegation paths.".into()));
         }

--- a/src/tuf.rs
+++ b/src/tuf.rs
@@ -9,7 +9,7 @@ use crypto::KeyId;
 use error::Error;
 use interchange::DataInterchange;
 use metadata::{SignedMetadata, RootMetadata, TimestampMetadata, Role, SnapshotMetadata,
-               MetadataPath, TargetsMetadata, TargetPath, TargetDescription, Delegations};
+               MetadataPath, TargetsMetadata, VirtualTargetPath, TargetDescription, Delegations};
 
 /// Contains trusted TUF metadata and can be used to verify other metadata and targets.
 #[derive(Debug)]
@@ -19,7 +19,7 @@ pub struct Tuf<D: DataInterchange> {
     targets: Option<TargetsMetadata>,
     timestamp: Option<TimestampMetadata>,
     delegations: HashMap<MetadataPath, TargetsMetadata>,
-    _interchange: PhantomData<D>,
+    interchange: PhantomData<D>,
 }
 
 impl<D: DataInterchange> Tuf<D> {
@@ -65,7 +65,7 @@ impl<D: DataInterchange> Tuf<D> {
             targets: None,
             timestamp: None,
             delegations: HashMap::new(),
-            _interchange: PhantomData,
+            interchange: PhantomData,
         })
     }
 
@@ -439,10 +439,10 @@ impl<D: DataInterchange> Tuf<D> {
     }
 
     /// Get a reference to the description needed to verify the target defined by the given
-    /// `TargetPath`. Returns an `Error` if the target is not defined in the trusted metadata. This
-    /// may mean the target exists somewhere in the metadata, but the chain of trust to that target
-    /// may be invalid or incomplete.
-    pub fn target_description(&self, target_path: &TargetPath) -> Result<TargetDescription> {
+    /// `VirtualTargetPath`. Returns an `Error` if the target is not defined in the trusted
+    /// metadata. This may mean the target exists somewhere in the metadata, but the chain of trust
+    /// to that target may be invalid or incomplete.
+    pub fn target_description(&self, target_path: &VirtualTargetPath) -> Result<TargetDescription> {
         let _ = self.safe_root_ref()?;
         let _ = self.safe_snapshot_ref()?;
         let targets = self.safe_targets_ref()?;
@@ -456,9 +456,9 @@ impl<D: DataInterchange> Tuf<D> {
             tuf: &Tuf<D>,
             default_terminate: bool,
             current_depth: u32,
-            target_path: &TargetPath,
+            target_path: &VirtualTargetPath,
             delegations: &Delegations,
-            parents: Vec<HashSet<TargetPath>>,
+            parents: Vec<HashSet<VirtualTargetPath>>,
             visited: &mut HashSet<MetadataPath>,
         ) -> (bool, Option<TargetDescription>) {
             for delegation in delegations.roles() {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -10,7 +10,7 @@ use tuf::Tuf;
 use tuf::crypto::{PrivateKey, SignatureScheme, HashAlgorithm};
 use tuf::interchange::Json;
 use tuf::metadata::{RoleDefinition, RootMetadata, MetadataPath, SignedMetadata, TargetDescription,
-                    TargetPath, TargetsMetadata, MetadataDescription, SnapshotMetadata,
+                    VirtualTargetPath, TargetsMetadata, MetadataDescription, SnapshotMetadata,
                     TimestampMetadata, Delegation, Delegations};
 
 const ED25519_1_PK8: &'static [u8] = include_bytes!("./ed25519/ed25519-1.pk8.der");
@@ -92,7 +92,7 @@ fn simple_delegation() {
                     .iter()
                     .cloned()
                     .collect(),
-                vec![TargetPath::new("foo".into()).unwrap()]
+                vec![VirtualTargetPath::new("foo".into()).unwrap()]
                     .iter()
                     .cloned()
                     .collect()
@@ -114,7 +114,7 @@ fn simple_delegation() {
     let target_file: &[u8] = b"bar";
     let target_map =
         hashmap! {
-        TargetPath::new("foo".into()).unwrap() =>
+        VirtualTargetPath::new("foo".into()).unwrap() =>
             TargetDescription::from_reader(target_file, &[HashAlgorithm::Sha256]).unwrap(),
     };
     let delegation =
@@ -127,7 +127,7 @@ fn simple_delegation() {
         .unwrap();
 
     assert!(
-        tuf.target_description(&TargetPath::new("foo".into()).unwrap())
+        tuf.target_description(&VirtualTargetPath::new("foo".into()).unwrap())
             .is_ok()
     );
 }
@@ -207,7 +207,7 @@ fn nested_delegation() {
                     .iter()
                     .cloned()
                     .collect(),
-                vec![TargetPath::new("foo".into()).unwrap()]
+                vec![VirtualTargetPath::new("foo".into()).unwrap()]
                     .iter()
                     .cloned()
                     .collect()
@@ -237,7 +237,7 @@ fn nested_delegation() {
                     .iter()
                     .cloned()
                     .collect(),
-                vec![TargetPath::new("foo".into()).unwrap()]
+                vec![VirtualTargetPath::new("foo".into()).unwrap()]
                     .iter()
                     .cloned()
                     .collect()
@@ -261,7 +261,7 @@ fn nested_delegation() {
     let target_file: &[u8] = b"bar";
     let target_map =
         hashmap! {
-        TargetPath::new("foo".into()).unwrap() =>
+        VirtualTargetPath::new("foo".into()).unwrap() =>
             TargetDescription::from_reader(target_file, &[HashAlgorithm::Sha256]).unwrap(),
     };
 
@@ -275,7 +275,7 @@ fn nested_delegation() {
         .unwrap();
 
     assert!(
-        tuf.target_description(&TargetPath::new("foo".into()).unwrap())
+        tuf.target_description(&VirtualTargetPath::new("foo".into()).unwrap())
             .is_ok()
     );
 }


### PR DESCRIPTION
to allow for hierarchical addressing of targets when their real names
don't fit such a schema

e.g., foo-bar-1.2.3 could be addressed as foo/bar/1.2.3 so that foo
could delegate bar and so on

this happens because delegations are done on an exact target basis or
recursively or everything under a "dir" like "foo/"

fixes #129, assists with https://github.com/rust-lang-nursery/rustup.rs/issues/1217

@alexcrichton, since this is something you requested, can you take a peek and let me know if this looks like a good solution.