### PR TITLE
bump dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,18 +23,18 @@ path = "./src/lib.rs"
 [dependencies]
 chrono = { version = "0.4", features = [ "serde" ] }
 data-encoding = "2.0.0-rc.2"
-derp = "0.0.4"
+derp = "0.0.10"
 hyper = "0.10"
-itoa = "0.3"
-log = "0.3"
+itoa = "0.4"
+log = "0.4"
 ring = { version = "0.12", features = [ "rsa_signing" ] }
 serde = "1"
 serde_derive = "1"
 serde_json = "1"
-tempfile = "2.1"
+tempfile = "3"
 untrusted = "0.5"
 
 [dev-dependencies]
-lazy_static = "0.2"
-maplit = "0.1"
+lazy_static = "1"
+maplit = "1"
 tempdir = "0.3"

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -824,17 +824,17 @@ fn write_spki(public: &[u8], key_type: &KeyType) -> ::std::result::Result<Vec<u8
     let mut output = Vec::new();
     {
         let mut der = Der::new(&mut output);
-        der.write_sequence(|der| {
-            der.write_sequence(|der| {
+        der.sequence(|der| {
+            der.sequence(|der| {
                 match key_type.as_oid().ok() {
                     Some(tag) => {
-                        der.write_element(Tag::Oid, tag)?;
-                        der.write_null()
+                        der.element(Tag::Oid, tag)?;
+                        der.null()
                     },
                     None => Err(derp::Error::WrongValue)
                 }
             })?;
-            der.write_bit_string(0, |der| der.write_raw(public))
+            der.bit_string(0,public)
         })?;
     }
 
@@ -878,9 +878,9 @@ fn write_pkcs1(n: &[u8], e: &[u8]) -> ::std::result::Result<Vec<u8>, derp::Error
     let mut output = Vec::new();
     {
         let mut der = Der::new(&mut output);
-        der.write_sequence(|der| {
-            der.write_positive_integer(n)?;
-            der.write_positive_integer(e)
+        der.sequence(|der| {
+            der.positive_integer(n)?;
+            der.positive_integer(e)
         })?;
     }
 


### PR DESCRIPTION
This updates the dependencies the following dependencies to the latest version: derp, itoa, log, tempfile, lazy_static, maplit

The only remaining outdated dependencies are on hyper (which is going to be a doozy to update) and untrusted, which is blocked on ring 0.13's release.