### PR TITLE
Remove duplicate code when creating client

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -141,16 +141,7 @@ where
                 &config.max_root_size,
                 config.min_bytes_per_second,
                 None,
-            )
-            .or_else(|_| {
-                local.fetch_metadata(
-                    &MetadataPath::from_role(&Role::Root),
-                    &MetadataVersion::Number(1),
-                    &config.max_root_size,
-                    config.min_bytes_per_second,
-                    None,
-                )
-            })?;
+            )?;
 
         let tuf = Tuf::from_root(&root)?;
 


### PR DESCRIPTION
This block of code is either redundant, or was supposed to
fetch the metadata from the remote server if it wasn't present
locally. The documentation suggests that it will only try
loading from the local server, so I erred on just removing
this chunk of code, rather than doing the less-safe thing
of downloading the initial metadata from an unverified
server.