### PR TITLE
Migrate over to futures 0.1 and hyper 0.12 (don't merge yet)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,10 +21,15 @@ name = "tuf"
 path = "./src/lib.rs"
 
 [dependencies]
+bytes = "0.4"
 chrono = { version = "0.4", features = [ "serde" ] }
 data-encoding = "2.0.0-rc.2"
 derp = "0.0.10"
-hyper = "0.10"
+futures = "0.1"
+futures-cpupool = "0.1"
+futures-fs = "0.0.4"
+http = "0.1"
+hyper = "0.12"
 itoa = "0.4"
 log = "0.4"
 ring = { version = "0.12", features = [ "rsa_signing" ] }
@@ -32,7 +37,10 @@ serde = "1"
 serde_derive = "1"
 serde_json = "1"
 tempfile = "3"
+tokio = "0.1"
+tokio-serde = "0.2"
 untrusted = "0.5"
+url = "1"
 
 [dev-dependencies]
 lazy_static = "1"

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,6 +2,7 @@
 
 use data_encoding::DecodeError;
 use derp;
+use http;
 use hyper;
 use json;
 use std::fmt;
@@ -89,14 +90,14 @@ impl From<io::Error> for Error {
     }
 }
 
-impl From<hyper::error::Error> for Error {
-    fn from(err: hyper::error::Error) -> Error {
-        Error::Opaque(format!("Hyper: {:?}", err))
+impl From<http::Error> for Error {
+    fn from(err: http::Error) -> Error {
+        Error::Opaque(format!("Http: {:?}", err))
     }
 }
 
-impl From<hyper::error::ParseError> for Error {
-    fn from(err: hyper::error::ParseError) -> Error {
+impl From<hyper::Error> for Error {
+    fn from(err: hyper::Error) -> Error {
         Error::Opaque(format!("Hyper: {:?}", err))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,9 +107,15 @@
     allow(collapsible_if, implicit_hasher, new_ret_no_self, op_ref, too_many_arguments)
 )]
 
+extern crate bytes;
 extern crate chrono;
 extern crate data_encoding;
 extern crate derp;
+#[macro_use]
+extern crate futures;
+extern crate futures_cpupool;
+extern crate futures_fs;
+extern crate http;
 extern crate hyper;
 extern crate itoa;
 #[cfg(test)]
@@ -134,12 +140,24 @@ extern crate serde_json as json;
 #[cfg(test)]
 extern crate tempdir;
 extern crate tempfile;
+extern crate tokio;
+extern crate tokio_serde;
 extern crate untrusted;
+extern crate url;
+
+#[macro_use]
+mod macros;
 
 pub mod error;
 
 /// Alias for `Result<T, Error>`.
 pub type Result<T> = ::std::result::Result<T, Error>;
+
+/// Alias for `Box<Future<T, Error>>`.
+pub type TufFuture<T> = Box<futures::Future<Item = T, Error = Error>>;
+
+/// Alias for `Box<Stream<T, Error>>`.
+pub type TufStream<T> = Box<futures::Stream<Item = T, Error = Error>>;
 
 pub mod client;
 pub mod crypto;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,21 @@
+macro_rules! try_future {
+    ($e:expr) => {
+        match $e {
+            Ok(value) => value,
+            Err(err) => {
+                return Box::new(::futures::future::err(err.into()));
+            }
+        }
+    }
+}
+
+macro_rules! try_stream {
+    ($e:expr) => {
+        match $e {
+            Ok(value) => value,
+            Err(err) => {
+                return Box::new(::futures::stream::once(Err(err.into()))); //::std::from::From::from(err))));
+            }
+        }
+    }
+}

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -54,7 +54,7 @@ static PATH_ILLEGAL_COMPONENTS_CASE_INSENSITIVE: &'static [&str] = &[
 ];
 
 static PATH_ILLEGAL_STRINGS: &'static [&str] = &[
-    ":", // for *nix compatibility
+    ":",  // for *nix compatibility
     "\\", // for windows compatibility
     "<",
     ">",

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,7 +1,9 @@
+use bytes::Bytes;
 use chrono::offset::Utc;
 use chrono::DateTime;
+use futures::{Async, Future, Poll, Stream, future, stream};
 use ring::digest::{self, SHA256, SHA512};
-use std::io::{self, ErrorKind, Read};
+use std::io::{self, ErrorKind};
 
 use crypto::{HashAlgorithm, HashValue};
 use error::Error;
@@ -9,7 +11,7 @@ use Result;
 
 /// Wrapper to verify a byte stream as it is read.
 ///
-/// Wraps a `Read` to ensure that the consumer can't read more than a capped maximum number of
+/// Wraps a `Stream` to ensure that the consumer can't read more than a capped maximum number of
 /// bytes. Also, this ensures that a minimum bitrate and returns an `Err` if it is not. Finally,
 /// when the underlying `Read` is fully consumed, the hash of the data is optionally calculated. If
 /// the calculated hash does not match the given hash, it will return an `Err`. Consumers of a
@@ -17,8 +19,73 @@ use Result;
 ///
 /// It is **critical** that none of the bytes from this struct are used until it has been fully
 /// consumed as the data is untrusted.
-pub struct SafeReader<R: Read> {
-    inner: R,
+pub trait SafeStreamExt: Stream<Item = Bytes, Error = Error> + Sized {
+    /// Wrap a byte stream.
+    fn safe_stream(
+        self,
+        max_size: u64,
+        min_bytes_per_second: u32,
+        hash_data: Option<(&HashAlgorithm, HashValue)>,
+    ) -> Result<SafeStream<Self>> {
+        SafeStream::new(self, max_size, min_bytes_per_second, hash_data)
+    }
+}
+
+impl<T: Stream<Item = Bytes, Error = Error>> SafeStreamExt for T {}
+
+/// Wrapper to verify a byte stream as it is read.
+///
+/// Wraps a `Stream` to ensure that the consumer can't read more than a capped maximum number of
+/// bytes. Also, this ensures that a minimum bitrate and returns an `Err` if it is not. Finally,
+/// when the underlying `Read` is fully consumed, the hash of the data is optionally calculated. If
+/// the calculated hash does not match the given hash, it will return an `Err`. Consumers of a
+/// `SafeReader` should purge and untrust all read bytes if this ever returns an `Err`.
+///
+/// It is **critical** that none of the bytes from this struct are used until it has been fully
+/// consumed as the data is untrusted.
+pub struct SafeStream<T: Stream<Item = Bytes, Error = Error>> {
+    inner: T,
+    hasher: SafeHasher,
+}
+
+impl<T: Stream<Item = Bytes, Error = Error>> SafeStream<T> {
+    /// Create a new `SafeStream`.
+    ///
+    /// The argument `hash_data` takes a `HashAlgorithm` and expected `HashValue`. The given
+    /// algorithm is used to hash the data as it is read. At the end of the stream, the digest is
+    /// calculated and compared against `HashValue`. If the two are not equal, it means the data
+    /// stream has been tampered with in some way.
+    pub fn new(
+        stream: T,
+        max_size: u64,
+        min_bytes_per_second: u32,
+        hash_data: Option<(&HashAlgorithm, HashValue)>,
+    ) -> Result<Self> {
+        let hasher = SafeHasher::new(max_size, min_bytes_per_second, hash_data)?;
+
+        Ok(SafeStream {
+            inner: stream,
+            hasher: hasher,
+        })
+    }
+}
+
+impl<T: Stream<Item = Bytes, Error = Error>> Stream for SafeStream<T> {
+    type Item = Bytes;
+    type Error = Error;
+
+    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+        if let Some(bytes) = try_ready!(self.inner.poll()) {
+            self.hasher.update(&*bytes)?;
+            Ok(Async::Ready(Some(bytes)))
+        } else {
+            self.hasher.finish()?;
+            Ok(Async::Ready(None))
+        }
+    }
+}
+
+struct SafeHasher {
     max_size: u64,
     min_bytes_per_second: u32,
     hasher: Option<(digest::Context, HashValue)>,
@@ -26,15 +93,8 @@ pub struct SafeReader<R: Read> {
     bytes_read: u64,
 }
 
-impl<R: Read> SafeReader<R> {
-    /// Create a new `SafeReader`.
-    ///
-    /// The argument `hash_data` takes a `HashAlgorithm` and expected `HashValue`. The given
-    /// algorithm is used to hash the data as it is read. At the end of the stream, the digest is
-    /// calculated and compared against `HashValue`. If the two are not equal, it means the data
-    /// stream has been tampered with in some way.
-    pub fn new(
-        read: R,
+impl SafeHasher {
+    fn new(
         max_size: u64,
         min_bytes_per_second: u32,
         hash_data: Option<(&HashAlgorithm, HashValue)>,
@@ -56,8 +116,7 @@ impl<R: Read> SafeReader<R> {
             None => None,
         };
 
-        Ok(SafeReader {
-            inner: read,
+        Ok(SafeHasher {
             max_size,
             min_bytes_per_second,
             hasher,
@@ -65,109 +124,139 @@ impl<R: Read> SafeReader<R> {
             bytes_read: 0,
         })
     }
+
+    fn update(&mut self, buf: &[u8]) -> io::Result<()> {
+        if self.start_time.is_none() {
+            self.start_time = Some(Utc::now())
+        }
+
+        match self.bytes_read.checked_add(buf.len() as u64) {
+            Some(sum) if sum <= self.max_size => self.bytes_read = sum,
+            _ => {
+                return Err(io::Error::new(
+                    ErrorKind::InvalidData,
+                    "Read exceeded the maximum allowed bytes.",
+                ));
+            }
+        }
+
+        let duration = Utc::now().signed_duration_since(self.start_time.unwrap());
+        // 30 second grace period before we start checking the bitrate
+        if duration.num_seconds() >= 30 {
+            if self.bytes_read as f32 / (duration.num_seconds() as f32)
+                < self.min_bytes_per_second as f32
+            {
+                return Err(io::Error::new(
+                    ErrorKind::TimedOut,
+                    "Read aborted. Bitrate too low.",
+                ));
+            }
+        }
+
+        if let Some((ref mut context, _)) = self.hasher {
+            context.update(buf);
+        }
+
+        Ok(())
+    }
+
+    fn finish(&mut self) -> io::Result<()> {
+        if let Some((context, expected_hash)) = self.hasher.take() {
+            let generated_hash = context.finish();
+            if generated_hash.as_ref() != expected_hash.value() {
+                return Err(io::Error::new(
+                    ErrorKind::InvalidData,
+                    "Calculated hash did not match the required hash.",
+                ));
+            }
+        }
+
+        Ok(())
+    }
 }
 
-impl<R: Read> Read for SafeReader<R> {
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        match self.inner.read(buf) {
-            Ok(read_bytes) => {
-                if self.start_time.is_none() {
-                    self.start_time = Some(Utc::now())
-                }
+/// Helper function to convert an ok type into a future.
+pub fn future_ok<T: 'static, E: 'static>(value: T) -> Box<Future<Item=T, Error=E>> {
+    Box::new(future::ok(value))
+}
 
-                if read_bytes == 0 {
-                    if let Some((context, expected_hash)) = self.hasher.take() {
-                        let generated_hash = context.finish();
-                        if generated_hash.as_ref() != expected_hash.value() {
-                            return Err(io::Error::new(
-                                ErrorKind::InvalidData,
-                                "Calculated hash did not match the required hash.",
-                            ));
-                        }
-                    }
+/// Helper function to convert a error type into a future.
+pub fn future_err<T: 'static, E: 'static>(err: E) -> Box<Future<Item=T, Error=E>> {
+    Box::new(future::err(err))
+}
 
-                    return Ok(0);
-                }
-
-                match self.bytes_read.checked_add(read_bytes as u64) {
-                    Some(sum) if sum <= self.max_size => self.bytes_read = sum,
-                    _ => {
-                        return Err(io::Error::new(
-                            ErrorKind::InvalidData,
-                            "Read exceeded the maximum allowed bytes.",
-                        ));
-                    }
-                }
-
-                let duration = Utc::now().signed_duration_since(self.start_time.unwrap());
-                // 30 second grace period before we start checking the bitrate
-                if duration.num_seconds() >= 30 {
-                    if self.bytes_read as f32 / (duration.num_seconds() as f32)
-                        < self.min_bytes_per_second as f32
-                    {
-                        return Err(io::Error::new(
-                            ErrorKind::TimedOut,
-                            "Read aborted. Bitrate too low.",
-                        ));
-                    }
-                }
-
-                if let Some((ref mut context, _)) = self.hasher {
-                    context.update(&buf[..(read_bytes)]);
-                }
-
-                Ok(read_bytes)
-            }
-            e @ Err(_) => e,
-        }
-    }
+/// Helper function to convert an error type into a stream.
+pub fn stream_err<T: 'static, E: 'static>(err: E) -> Box<Stream<Item=T, Error=E>> {
+    Box::new(stream::once(Err::<T, E>(err)))
 }
 
 #[cfg(test)]
 mod test {
+    use futures::stream;
+    use bytes::Bytes;
     use super::*;
 
     #[test]
     fn valid_read() {
         let bytes: &[u8] = &[0x00, 0x01, 0x02, 0x03];
-        let mut reader = SafeReader::new(bytes, bytes.len() as u64, 0, None).unwrap();
-        let mut buf = Vec::new();
-        assert!(reader.read_to_end(&mut buf).is_ok());
+        let reader = SafeStream::new(
+            stream::once(Ok(Bytes::from_static(bytes))),
+            bytes.len() as u64,
+            0,
+            None,
+        ).unwrap();
+        let buf = reader.concat2().wait().unwrap();
         assert_eq!(buf, bytes);
     }
 
     #[test]
     fn valid_read_large_data() {
         let bytes: &[u8] = &[0x00; 64 * 1024];
-        let mut reader = SafeReader::new(bytes, bytes.len() as u64, 0, None).unwrap();
-        let mut buf = Vec::new();
-        assert!(reader.read_to_end(&mut buf).is_ok());
+        let reader = SafeStream::new(
+            stream::once(Ok(Bytes::from_static(bytes))),
+            bytes.len() as u64,
+            0,
+            None,
+        ).unwrap();
+        let buf = reader.concat2().wait().unwrap();
         assert_eq!(buf, bytes);
     }
 
     #[test]
     fn valid_read_below_max_size() {
         let bytes: &[u8] = &[0x00, 0x01, 0x02, 0x03];
-        let mut reader = SafeReader::new(bytes, (bytes.len() as u64) + 1, 0, None).unwrap();
-        let mut buf = Vec::new();
-        assert!(reader.read_to_end(&mut buf).is_ok());
+        let reader = SafeStream::new(
+            stream::once(Ok(Bytes::from_static(bytes))),
+            (bytes.len() as u64) + 1,
+            0,
+            None,
+        ).unwrap();
+        let buf = reader.concat2().wait().unwrap();
         assert_eq!(buf, bytes);
     }
 
     #[test]
     fn invalid_read_above_max_size() {
         let bytes: &[u8] = &[0x00, 0x01, 0x02, 0x03];
-        let mut reader = SafeReader::new(bytes, (bytes.len() as u64) - 1, 0, None).unwrap();
-        let mut buf = Vec::new();
-        assert!(reader.read_to_end(&mut buf).is_err());
+        let reader = SafeStream::new(
+            stream::once(Ok(Bytes::from_static(bytes))),
+            (bytes.len() as u64) - 1,
+            0,
+            None,
+        ).unwrap();
+        assert!(reader.concat2().wait().is_err());
     }
 
     #[test]
     fn invalid_read_above_max_size_large_data() {
         let bytes: &[u8] = &[0x00; 64 * 1024];
-        let mut reader = SafeReader::new(bytes, (bytes.len() as u64) - 1, 0, None).unwrap();
-        let mut buf = Vec::new();
-        assert!(reader.read_to_end(&mut buf).is_err());
+        let reader = SafeStream::new(
+            stream::once(Ok(Bytes::from_static(bytes))),
+            (bytes.len() as u64) - 1,
+            0,
+            None,
+        ).unwrap();
+        assert!(reader.concat2().wait().is_err());
     }
 
     #[test]
@@ -176,14 +265,14 @@ mod test {
         let mut context = digest::Context::new(&SHA256);
         context.update(&bytes);
         let hash_value = HashValue::new(context.finish().as_ref().to_vec());
-        let mut reader = SafeReader::new(
-            bytes,
+        let reader = SafeStream::new(
+            stream::once(Ok(Bytes::from_static(bytes))),
             bytes.len() as u64,
             0,
             Some((&HashAlgorithm::Sha256, hash_value)),
         ).unwrap();
-        let mut buf = Vec::new();
-        assert!(reader.read_to_end(&mut buf).is_ok());
+
+        let buf = reader.concat2().wait().unwrap();
         assert_eq!(buf, bytes);
     }
 
@@ -194,14 +283,13 @@ mod test {
         context.update(&bytes);
         context.update(&[0xFF]); // evil bytes
         let hash_value = HashValue::new(context.finish().as_ref().to_vec());
-        let mut reader = SafeReader::new(
-            bytes,
+        let reader = SafeStream::new(
+            stream::once(Ok(Bytes::from_static(bytes))),
             bytes.len() as u64,
             0,
             Some((&HashAlgorithm::Sha256, hash_value)),
         ).unwrap();
-        let mut buf = Vec::new();
-        assert!(reader.read_to_end(&mut buf).is_err());
+        assert!(reader.concat2().wait().is_err());
     }
 
     #[test]
@@ -210,14 +298,14 @@ mod test {
         let mut context = digest::Context::new(&SHA256);
         context.update(&bytes);
         let hash_value = HashValue::new(context.finish().as_ref().to_vec());
-        let mut reader = SafeReader::new(
-            bytes,
+        let reader = SafeStream::new(
+            stream::once(Ok(Bytes::from_static(bytes))),
             bytes.len() as u64,
             0,
             Some((&HashAlgorithm::Sha256, hash_value)),
         ).unwrap();
-        let mut buf = Vec::new();
-        assert!(reader.read_to_end(&mut buf).is_ok());
+
+        let buf = reader.concat2().wait().unwrap();
         assert_eq!(buf, bytes);
     }
 
@@ -228,13 +316,12 @@ mod test {
         context.update(&bytes);
         context.update(&[0xFF]); // evil bytes
         let hash_value = HashValue::new(context.finish().as_ref().to_vec());
-        let mut reader = SafeReader::new(
-            bytes,
+        let reader = SafeStream::new(
+            stream::once(Ok(Bytes::from_static(bytes))),
             bytes.len() as u64,
             0,
             Some((&HashAlgorithm::Sha256, hash_value)),
         ).unwrap();
-        let mut buf = Vec::new();
-        assert!(reader.read_to_end(&mut buf).is_err());
+        assert!(reader.concat2().wait().is_err());
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -56,7 +56,7 @@ fn simple_delegation() {
 
     let signed = SignedMetadata::<Json, RootMetadata>::new(&root, &root_key).unwrap();
 
-    let mut tuf = Tuf::<Json>::from_root_pinned(signed, &[root_key.key_id().clone()]).unwrap();
+    let mut tuf = Tuf::<Json>::from_root_pinned(signed, vec![root_key.key_id().clone()]).unwrap();
 
     //// build the timestamp ////
     let snap = MetadataDescription::from_reader(&*vec![0u8], 1, &[HashAlgorithm::Sha256]).unwrap();
@@ -167,7 +167,7 @@ fn nested_delegation() {
 
     let signed = SignedMetadata::<Json, RootMetadata>::new(&root, &root_key).unwrap();
 
-    let mut tuf = Tuf::<Json>::from_root_pinned(signed, &[root_key.key_id().clone()]).unwrap();
+    let mut tuf = Tuf::<Json>::from_root_pinned(signed, vec![root_key.key_id().clone()]).unwrap();
 
     //// build the timestamp ////
     let snap = MetadataDescription::from_reader(&*vec![0u8], 1, &[HashAlgorithm::Sha256]).unwrap();


### PR DESCRIPTION
This patch rewrites tuf to be asynchronous and concurrent, which requires a substantial amount of changes that frankly make some things a lot uglier. Async/Await however should really clean this up, but I wasn't sure if you would want to depend on an unstable feature that won't ship for at least a couple months.

I'm marking this as don't merge because I think there's still some more cleanup I can do to get it nicer, but I wanted to put it in front of you first to see what you think.

This patch depends on #139, and closes #98.