### PR TITLE
Clients should locally save metadata

### DIFF
--- a/tests/simple_example.rs
+++ b/tests/simple_example.rs
@@ -59,11 +59,7 @@ where
 {
     let local = EphemeralRepository::<Json>::new();
     let mut client = Client::with_root_pinned(root_key_ids, config, local, remote)?;
-    match client.update_local() {
-        Ok(_) => (),
-        Err(e) => println!("{:?}", e),
-    }
-    let _ = client.update_remote()?;
+    let _ = client.update()?;
     client.fetch_target(&TargetPath::new("foo-bar".into())?)
 }
 


### PR DESCRIPTION
This patch merges `Client::update_local` and `Client::update_remote` in order to update `Tuf` following the pattern as described in the [spec section 5.1](https://github.com/theupdateframework/specification/blob/master/tuf-spec.md#the-client-application).

One potential problem though is I'm not sure how we can atomically update the local repository and the `Tuf` object, so for ease of implementation, this patch will update `Tuf` and could potentially error out writing the metadata to the local repository. We could instead implement some sort of rollback mechanism to `Tuf`, but I figure we can do that later if it's necessary.

Closes #153.