### PR TITLE
Root serialization should put roles in it's own scope

### DIFF
--- a/src/interchange/mod.rs
+++ b/src/interchange/mod.rs
@@ -136,10 +136,12 @@ pub trait DataInterchange: Debug + PartialEq + Clone {
 ///   "version": NATURAL_NUMBER,
 ///   "expires": EXPIRES,
 ///   "keys": [PUB_KEY, ...]
-///   "root": ROLE_DESCRIPTION,
-///   "snapshot": ROLE_DESCRIPTION,
-///   "targets": ROLE_DESCRIPTION,
-///   "timestamp": ROLE_DESCRIPTION
+///   "roles": {
+///     "root": ROLE_DESCRIPTION,
+///     "snapshot": ROLE_DESCRIPTION,
+///     "targets": ROLE_DESCRIPTION,
+///     "timestamp": ROLE_DESCRIPTION
+///   }
 /// }
 /// ```
 ///

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -2036,21 +2036,23 @@ mod test {
                         NhZ1_7zzCKL8rKzsg==",
                 },
             ],
-            "root": {
-                "threshold": 1,
-                "key_ids": ["qfrfBrkB4lBBSDEBlZgaTGS_SrE6UfmON9kP4i3dJFY="],
-            },
-            "snapshot": {
-                "threshold": 1,
-                "key_ids": ["5WvZhiiSSUung_OhJVbPshKwD_ZNkgeg80i4oy2KAVs="],
-            },
-            "targets": {
-                "threshold": 1,
-                "key_ids": ["4hsyITLMQoWBg0ldCLKPlRZPIEf258cMg-xdAROsO6o="],
-            },
-            "timestamp": {
-                "threshold": 1,
-                "key_ids": ["C2hNB7qN99EAbHVGHPIJc5Hqa9RfEilnMqsCNJ5dGdw="],
+            "roles": {
+                "root": {
+                    "threshold": 1,
+                    "key_ids": ["qfrfBrkB4lBBSDEBlZgaTGS_SrE6UfmON9kP4i3dJFY="],
+                },
+                "snapshot": {
+                    "threshold": 1,
+                    "key_ids": ["5WvZhiiSSUung_OhJVbPshKwD_ZNkgeg80i4oy2KAVs="],
+                },
+                "targets": {
+                    "threshold": 1,
+                    "key_ids": ["4hsyITLMQoWBg0ldCLKPlRZPIEf258cMg-xdAROsO6o="],
+                },
+                "timestamp": {
+                    "threshold": 1,
+                    "key_ids": ["C2hNB7qN99EAbHVGHPIJc5Hqa9RfEilnMqsCNJ5dGdw="],
+                },
             },
         });
 

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -35,10 +35,7 @@ pub struct RootMetadata {
     consistent_snapshot: bool,
     expires: String,
     keys: Vec<crypto::PublicKey>,
-    root: metadata::RoleDefinition,
-    snapshot: metadata::RoleDefinition,
-    targets: metadata::RoleDefinition,
-    timestamp: metadata::RoleDefinition,
+    roles: RoleDefinitions,
 }
 
 impl RootMetadata {
@@ -56,10 +53,12 @@ impl RootMetadata {
             expires: format_datetime(&meta.expires()),
             consistent_snapshot: meta.consistent_snapshot(),
             keys,
-            root: meta.root().clone(),
-            snapshot: meta.snapshot().clone(),
-            targets: meta.targets().clone(),
-            timestamp: meta.timestamp().clone(),
+            roles: RoleDefinitions {
+                root: meta.root().clone(),
+                snapshot: meta.snapshot().clone(),
+                targets: meta.targets().clone(),
+                timestamp: meta.timestamp().clone(),
+            },
         })
     }
 
@@ -83,12 +82,20 @@ impl RootMetadata {
             parse_datetime(&self.expires)?,
             self.consistent_snapshot,
             keys,
-            self.root,
-            self.snapshot,
-            self.targets,
-            self.timestamp,
+            self.roles.root,
+            self.roles.snapshot,
+            self.roles.targets,
+            self.roles.timestamp,
         )
     }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct RoleDefinitions {
+    root: metadata::RoleDefinition,
+    snapshot: metadata::RoleDefinition,
+    targets: metadata::RoleDefinition,
+    timestamp: metadata::RoleDefinition,
 }
 
 #[derive(Serialize, Deserialize)]


### PR DESCRIPTION
According to 4.4.3 of the spec, the root metadata serialization has the roles defined in their own object:

https://github.com/theupdateframework/specification/blob/master/tuf-spec.md#4-document-formats