### PR TITLE
Simplify metadata construction with builders

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -259,7 +259,7 @@ where
             config.min_bytes_per_second,
             None,
         )?;
-        let latest_version = latest_root.signed().version();
+        let latest_version = latest_root.as_ref().version();
 
         if latest_version < tuf.root().version() {
             return Err(Error::VerificationFailure(format!(
@@ -536,7 +536,7 @@ where
                             current_depth + 1,
                             target,
                             snapshot,
-                            Some(meta.signed()),
+                            Some(meta.as_ref()),
                             local,
                             remote,
                         );

--- a/src/client.rs
+++ b/src/client.rs
@@ -54,8 +54,8 @@ use crypto::{self, KeyId};
 use error::Error;
 use interchange::DataInterchange;
 use metadata::{
-    MetadataPath, MetadataVersion, Role, RootMetadata, SnapshotMetadata, TargetDescription,
-    TargetPath, TargetsMetadata, VirtualTargetPath,
+    Metadata, MetadataPath, MetadataVersion, Role, RootMetadata, SnapshotMetadata,
+    TargetDescription, TargetPath, TargetsMetadata, VirtualTargetPath,
 };
 use repository::Repository;
 use tuf::Tuf;

--- a/src/client.rs
+++ b/src/client.rs
@@ -743,10 +743,9 @@ impl Default for ConfigBuilder<DefaultTranslator> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use chrono::prelude::*;
     use crypto::{PrivateKey, SignatureScheme};
     use interchange::Json;
-    use metadata::{MetadataPath, MetadataVersion, RoleDefinition, RootMetadata, SignedMetadata};
+    use metadata::{MetadataPath, MetadataVersion, RootMetadataBuilder};
     use repository::EphemeralRepository;
 
     lazy_static! {
@@ -768,18 +767,14 @@ mod test {
     #[test]
     fn root_chain_update() {
         let repo = EphemeralRepository::new();
-        let root = RootMetadata::new(
-            1,
-            Utc.ymd(2038, 1, 1).and_hms(0, 0, 0),
-            false,
-            vec![KEYS[0].public().clone()],
-            RoleDefinition::new(1, hashset!(KEYS[0].key_id().clone())).unwrap(),
-            RoleDefinition::new(1, hashset!(KEYS[0].key_id().clone())).unwrap(),
-            RoleDefinition::new(1, hashset!(KEYS[0].key_id().clone())).unwrap(),
-            RoleDefinition::new(1, hashset!(KEYS[0].key_id().clone())).unwrap(),
-        ).unwrap();
-        let root: SignedMetadata<Json, _> =
-            SignedMetadata::new(root, &KEYS[0]).unwrap();
+        let root = RootMetadataBuilder::new()
+            .version(1)
+            .root_key(KEYS[0].public().clone())
+            .snapshot_key(KEYS[0].public().clone())
+            .targets_key(KEYS[0].public().clone())
+            .timestamp_key(KEYS[0].public().clone())
+            .signed::<Json>(&KEYS[0])
+            .unwrap();
 
         repo.store_metadata(
             &MetadataPath::from_role(&Role::Root),
@@ -787,18 +782,14 @@ mod test {
             &root,
         ).unwrap();
 
-        let root = RootMetadata::new(
-            2,
-            Utc.ymd(2038, 1, 1).and_hms(0, 0, 0),
-            false,
-            vec![KEYS[1].public().clone()],
-            RoleDefinition::new(1, hashset!(KEYS[1].key_id().clone())).unwrap(),
-            RoleDefinition::new(1, hashset!(KEYS[1].key_id().clone())).unwrap(),
-            RoleDefinition::new(1, hashset!(KEYS[1].key_id().clone())).unwrap(),
-            RoleDefinition::new(1, hashset!(KEYS[1].key_id().clone())).unwrap(),
-        ).unwrap();
-        let mut root: SignedMetadata<Json, _> =
-            SignedMetadata::new(root, &KEYS[1]).unwrap();
+        let mut root = RootMetadataBuilder::new()
+            .version(2)
+            .root_key(KEYS[1].public().clone())
+            .snapshot_key(KEYS[1].public().clone())
+            .targets_key(KEYS[1].public().clone())
+            .timestamp_key(KEYS[1].public().clone())
+            .signed::<Json>(&KEYS[1])
+            .unwrap();
 
         root.add_signature(&KEYS[0]).unwrap();
 
@@ -808,18 +799,14 @@ mod test {
             &root,
         ).unwrap();
 
-        let root = RootMetadata::new(
-            3,
-            Utc.ymd(2038, 1, 1).and_hms(0, 0, 0),
-            false,
-            vec![KEYS[2].public().clone()],
-            RoleDefinition::new(1, hashset!(KEYS[2].key_id().clone())).unwrap(),
-            RoleDefinition::new(1, hashset!(KEYS[2].key_id().clone())).unwrap(),
-            RoleDefinition::new(1, hashset!(KEYS[2].key_id().clone())).unwrap(),
-            RoleDefinition::new(1, hashset!(KEYS[2].key_id().clone())).unwrap(),
-        ).unwrap();
-        let mut root: SignedMetadata<Json, _> =
-            SignedMetadata::new(root, &KEYS[2]).unwrap();
+        let mut root = RootMetadataBuilder::new()
+            .version(3)
+            .root_key(KEYS[2].public().clone())
+            .snapshot_key(KEYS[2].public().clone())
+            .targets_key(KEYS[2].public().clone())
+            .timestamp_key(KEYS[2].public().clone())
+            .signed::<Json>(&KEYS[2])
+            .unwrap();
 
         root.add_signature(&KEYS[1]).unwrap();
 

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -481,6 +481,22 @@ where
     }
 }
 
+impl<D, M> Metadata for SignedMetadata<D, M>
+where
+    D: Debug + PartialEq,
+    M: Metadata,
+{
+    const ROLE: Role = M::ROLE;
+
+    fn version(&self) -> u32 {
+        self.signed.version()
+    }
+
+    fn expires(&self) -> &DateTime<Utc> {
+        self.signed.expires()
+    }
+}
+
 /// Metadata for the root role.
 #[derive(Debug, Clone, PartialEq)]
 pub struct RootMetadata {

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -220,6 +220,12 @@ impl MetadataVersion {
 pub trait Metadata: Debug + PartialEq + Serialize + DeserializeOwned {
     /// The role associated with the metadata.
     const ROLE: Role;
+
+    /// The version number.
+    fn version(&self) -> u32;
+
+    /// An immutable reference to the metadata's expiration `DateTime`.
+    fn expires(&self) -> &DateTime<Utc>;
 }
 
 /// A piece of raw metadata with attached signatures.
@@ -535,16 +541,6 @@ impl RootMetadata {
         })
     }
 
-    /// The version number.
-    pub fn version(&self) -> u32 {
-        self.version
-    }
-
-    /// An immutable reference to the metadata's expiration `DateTime`.
-    pub fn expires(&self) -> &DateTime<Utc> {
-        &self.expires
-    }
-
     /// Whether or not this repository is currently implementing that TUF consistent snapshot
     /// feature.
     pub fn consistent_snapshot(&self) -> bool {
@@ -579,6 +575,14 @@ impl RootMetadata {
 
 impl Metadata for RootMetadata {
     const ROLE: Role = Role::Root;
+
+    fn version(&self) -> u32 {
+        self.version
+    }
+
+    fn expires(&self) -> &DateTime<Utc> {
+        &self.expires
+    }
 }
 
 impl Serialize for RootMetadata {
@@ -786,16 +790,6 @@ impl TimestampMetadata {
         })
     }
 
-    /// The version number.
-    pub fn version(&self) -> u32 {
-        self.version
-    }
-
-    /// An immutable reference to the metadata's expiration `DateTime`.
-    pub fn expires(&self) -> &DateTime<Utc> {
-        &self.expires
-    }
-
     /// An immutable reference to the snapshot description.
     pub fn snapshot(&self) -> &MetadataDescription {
         &self.snapshot
@@ -804,6 +798,14 @@ impl TimestampMetadata {
 
 impl Metadata for TimestampMetadata {
     const ROLE: Role = Role::Timestamp;
+
+    fn version(&self) -> u32 {
+        self.version
+    }
+
+    fn expires(&self) -> &DateTime<Utc> {
+        &self.expires
+    }
 }
 
 impl Serialize for TimestampMetadata {
@@ -942,16 +944,6 @@ impl SnapshotMetadata {
         })
     }
 
-    /// The version number.
-    pub fn version(&self) -> u32 {
-        self.version
-    }
-
-    /// An immutable reference to the metadata's expiration `DateTime`.
-    pub fn expires(&self) -> &DateTime<Utc> {
-        &self.expires
-    }
-
     /// An immutable reference to the metadata paths and descriptions.
     pub fn meta(&self) -> &HashMap<MetadataPath, MetadataDescription> {
         &self.meta
@@ -960,6 +952,14 @@ impl SnapshotMetadata {
 
 impl Metadata for SnapshotMetadata {
     const ROLE: Role = Role::Snapshot;
+
+    fn version(&self) -> u32 {
+        self.version
+    }
+
+    fn expires(&self) -> &DateTime<Utc> {
+        &self.expires
+    }
 }
 
 impl Serialize for SnapshotMetadata {
@@ -1233,16 +1233,6 @@ impl TargetsMetadata {
         })
     }
 
-    /// The version number.
-    pub fn version(&self) -> u32 {
-        self.version
-    }
-
-    /// An immutable reference to the metadata's expiration `DateTime`.
-    pub fn expires(&self) -> &DateTime<Utc> {
-        &self.expires
-    }
-
     /// An immutable reference to the descriptions of targets.
     pub fn targets(&self) -> &HashMap<VirtualTargetPath, TargetDescription> {
         &self.targets
@@ -1256,6 +1246,14 @@ impl TargetsMetadata {
 
 impl Metadata for TargetsMetadata {
     const ROLE: Role = Role::Targets;
+
+    fn version(&self) -> u32 {
+        self.version
+    }
+
+    fn expires(&self) -> &DateTime<Utc> {
+        &self.expires
+    }
 }
 
 impl Serialize for TargetsMetadata {

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -5,7 +5,7 @@ use std::collections::{HashMap, HashSet};
 
 use crypto;
 use error::Error;
-use metadata;
+use metadata::{self, Metadata};
 use Result;
 
 fn parse_datetime(ts: &str) -> Result<DateTime<Utc>> {

--- a/src/tuf.rs
+++ b/src/tuf.rs
@@ -616,7 +616,7 @@ mod test {
     use chrono::prelude::*;
     use crypto::{HashAlgorithm, PrivateKey, SignatureScheme};
     use interchange::Json;
-    use metadata::{MetadataDescription, RootMetadataBuilder};
+    use metadata::{MetadataDescription, RootMetadataBuilder, SnapshotMetadataBuilder};
 
     lazy_static! {
         static ref KEYS: Vec<PrivateKey> = {
@@ -787,10 +787,9 @@ mod test {
 
         tuf.update_timestamp(timestamp).unwrap();
 
-        let snapshot =
-            SnapshotMetadata::new(1, Utc.ymd(2038, 1, 1).and_hms(0, 0, 0), hashmap!()).unwrap();
-        let snapshot: SignedMetadata<Json, SnapshotMetadata> =
-            SignedMetadata::new(snapshot, &KEYS[1]).unwrap();
+        let snapshot = SnapshotMetadataBuilder::new()
+            .signed(&KEYS[1])
+            .unwrap();
 
         assert_eq!(tuf.update_snapshot(snapshot.clone()), Ok(true));
 
@@ -820,10 +819,9 @@ mod test {
 
         tuf.update_timestamp(timestamp).unwrap();
 
-        let snapshot =
-            SnapshotMetadata::new(1, Utc.ymd(2038, 1, 1).and_hms(0, 0, 0), hashmap!()).unwrap();
-        let snapshot: SignedMetadata<Json, SnapshotMetadata> =
-            SignedMetadata::new(snapshot, &KEYS[2]).unwrap();
+        let snapshot = SnapshotMetadataBuilder::new()
+            .signed::<Json>(&KEYS[2])
+            .unwrap();
 
         assert!(tuf.update_snapshot(snapshot).is_err());
     }
@@ -850,10 +848,9 @@ mod test {
 
         tuf.update_timestamp(timestamp).unwrap();
 
-        let snapshot =
-            SnapshotMetadata::new(1, Utc.ymd(2038, 1, 1).and_hms(0, 0, 0), hashmap!()).unwrap();
-        let snapshot: SignedMetadata<Json, SnapshotMetadata> =
-            SignedMetadata::new(snapshot, &KEYS[1]).unwrap();
+        let snapshot = SnapshotMetadataBuilder::new()
+            .signed::<Json>(&KEYS[1])
+            .unwrap();
 
         assert!(tuf.update_snapshot(snapshot).is_err());
     }
@@ -880,14 +877,13 @@ mod test {
 
         tuf.update_timestamp(timestamp).unwrap();
 
-        let meta_map = hashmap!(
-            MetadataPath::from_role(&Role::Targets) =>
+        let snapshot = SnapshotMetadataBuilder::new()
+            .insert_metadata_description(
+                MetadataPath::from_role(&Role::Targets),
                 MetadataDescription::from_reader(&*vec![], 1, &[HashAlgorithm::Sha256]).unwrap(),
-        );
-        let snapshot =
-            SnapshotMetadata::new(1, Utc.ymd(2038, 1, 1).and_hms(0, 0, 0), meta_map).unwrap();
-        let snapshot: SignedMetadata<Json, _> =
-            SignedMetadata::new(snapshot, &KEYS[1]).unwrap();
+            )
+            .signed::<Json>(&KEYS[1])
+            .unwrap();
 
         tuf.update_snapshot(snapshot).unwrap();
 
@@ -925,14 +921,13 @@ mod test {
 
         tuf.update_timestamp(timestamp).unwrap();
 
-        let meta_map = hashmap!(
-            MetadataPath::from_role(&Role::Targets) =>
+        let snapshot = SnapshotMetadataBuilder::new()
+            .insert_metadata_description(
+                MetadataPath::from_role(&Role::Targets),
                 MetadataDescription::from_reader(&*vec![], 1, &[HashAlgorithm::Sha256]).unwrap(),
-        );
-        let snapshot =
-            SnapshotMetadata::new(1, Utc.ymd(2038, 1, 1).and_hms(0, 0, 0), meta_map).unwrap();
-        let snapshot: SignedMetadata<Json, SnapshotMetadata> =
-            SignedMetadata::new(snapshot, &KEYS[1]).unwrap();
+            )
+            .signed::<Json>(&KEYS[1])
+            .unwrap();
 
         tuf.update_snapshot(snapshot).unwrap();
 
@@ -967,14 +962,13 @@ mod test {
 
         tuf.update_timestamp(timestamp).unwrap();
 
-        let meta_map = hashmap!(
-            MetadataPath::from_role(&Role::Targets) =>
+        let snapshot = SnapshotMetadataBuilder::new()
+            .insert_metadata_description(
+                MetadataPath::from_role(&Role::Targets),
                 MetadataDescription::from_reader(&*vec![], 2, &[HashAlgorithm::Sha256]).unwrap(),
-        );
-        let snapshot =
-            SnapshotMetadata::new(1, Utc.ymd(2038, 1, 1).and_hms(0, 0, 0), meta_map).unwrap();
-        let snapshot: SignedMetadata<Json, SnapshotMetadata> =
-            SignedMetadata::new(snapshot, &KEYS[1]).unwrap();
+            )
+            .signed::<Json>(&KEYS[1])
+            .unwrap();
 
         tuf.update_snapshot(snapshot).unwrap();
 

--- a/src/tuf.rs
+++ b/src/tuf.rs
@@ -8,7 +8,7 @@ use crypto::KeyId;
 use error::Error;
 use interchange::DataInterchange;
 use metadata::{
-    Delegations, MetadataPath, Role, RootMetadata, SignedMetadata, SnapshotMetadata,
+    Delegations, Metadata, MetadataPath, Role, RootMetadata, SignedMetadata, SnapshotMetadata,
     TargetDescription, TargetsMetadata, TimestampMetadata, VirtualTargetPath,
 };
 use Result;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -10,7 +10,7 @@ use tuf::crypto::{HashAlgorithm, PrivateKey, SignatureScheme};
 use tuf::interchange::Json;
 use tuf::metadata::{
     Delegation, Delegations, MetadataDescription, MetadataPath, RootMetadataBuilder,
-    SignedMetadata, SnapshotMetadata, TargetDescription, TargetsMetadata, TimestampMetadata,
+    SignedMetadata, SnapshotMetadataBuilder, TargetDescription, TargetsMetadata, TimestampMetadata,
     VirtualTargetPath,
 };
 use tuf::Tuf;
@@ -52,16 +52,18 @@ fn simple_delegation() {
     tuf.update_timestamp(signed).unwrap();
 
     //// build the snapshot ////
-    let meta_map = hashmap! {
-        MetadataPath::new("targets".into()).unwrap() =>
-            MetadataDescription::from_reader(&*vec![0u8], 1, &[HashAlgorithm::Sha256]).unwrap(),
-        MetadataPath::new("delegation".into()).unwrap() =>
-            MetadataDescription::from_reader(&*vec![0u8], 1, &[HashAlgorithm::Sha256]).unwrap(),
-    };
-    let snapshot =
-        SnapshotMetadata::new(1, Utc.ymd(2038, 1, 1).and_hms(0, 0, 0), meta_map).unwrap();
 
-    let signed = SignedMetadata::<Json, _>::new(snapshot, &snapshot_key).unwrap();
+    let signed = SnapshotMetadataBuilder::new()
+        .insert_metadata_description(
+            MetadataPath::new("targets".into()).unwrap(),
+            MetadataDescription::from_reader(&*vec![0u8], 1, &[HashAlgorithm::Sha256]).unwrap(),
+        )
+        .insert_metadata_description(
+            MetadataPath::new("delegation".into()).unwrap(),
+            MetadataDescription::from_reader(&*vec![0u8], 1, &[HashAlgorithm::Sha256]).unwrap(),
+        )
+        .signed::<Json>(&snapshot_key)
+        .unwrap();
 
     tuf.update_snapshot(signed).unwrap();
 
@@ -147,18 +149,22 @@ fn nested_delegation() {
     tuf.update_timestamp(signed).unwrap();
 
     //// build the snapshot ////
-    let meta_map = hashmap! {
-        MetadataPath::new("targets".into()).unwrap() =>
-            MetadataDescription::from_reader(&*vec![0u8], 1, &[HashAlgorithm::Sha256]).unwrap(),
-        MetadataPath::new("delegation-a".into()).unwrap() =>
-            MetadataDescription::from_reader(&*vec![0u8], 1, &[HashAlgorithm::Sha256]).unwrap(),
-        MetadataPath::new("delegation-b".into()).unwrap() =>
-            MetadataDescription::from_reader(&*vec![0u8], 1, &[HashAlgorithm::Sha256]).unwrap(),
-    };
-    let snapshot =
-        SnapshotMetadata::new(1, Utc.ymd(2038, 1, 1).and_hms(0, 0, 0), meta_map).unwrap();
 
-    let signed = SignedMetadata::<Json, _>::new(snapshot, &snapshot_key).unwrap();
+    let signed = SnapshotMetadataBuilder::new()
+        .insert_metadata_description(
+            MetadataPath::new("targets".into()).unwrap(),
+            MetadataDescription::from_reader(&*vec![0u8], 1, &[HashAlgorithm::Sha256]).unwrap(),
+        )
+        .insert_metadata_description(
+            MetadataPath::new("delegation-a".into()).unwrap(),
+            MetadataDescription::from_reader(&*vec![0u8], 1, &[HashAlgorithm::Sha256]).unwrap(),
+        )
+        .insert_metadata_description(
+            MetadataPath::new("delegation-b".into()).unwrap(),
+            MetadataDescription::from_reader(&*vec![0u8], 1, &[HashAlgorithm::Sha256]).unwrap(),
+        )
+        .signed::<Json>(&snapshot_key)
+        .unwrap();
 
     tuf.update_snapshot(signed).unwrap();
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -54,7 +54,7 @@ fn simple_delegation() {
         timestamp_def,
     ).unwrap();
 
-    let signed = SignedMetadata::<Json, RootMetadata>::new(&root, &root_key).unwrap();
+    let signed = SignedMetadata::<Json, _>::new(root, &root_key).unwrap();
 
     let mut tuf = Tuf::<Json>::from_root_pinned(signed, &[root_key.key_id().clone()]).unwrap();
 
@@ -63,9 +63,9 @@ fn simple_delegation() {
     let timestamp = TimestampMetadata::new(1, Utc.ymd(2038, 1, 1).and_hms(0, 0, 0), snap).unwrap();
 
     let signed =
-        SignedMetadata::<Json, TimestampMetadata>::new(&timestamp, &timestamp_key).unwrap();
+        SignedMetadata::<Json, _>::new(timestamp, &timestamp_key).unwrap();
 
-    tuf.update_timestamp(&signed).unwrap();
+    tuf.update_timestamp(signed).unwrap();
 
     //// build the snapshot ////
     let meta_map = hashmap! {
@@ -77,9 +77,9 @@ fn simple_delegation() {
     let snapshot =
         SnapshotMetadata::new(1, Utc.ymd(2038, 1, 1).and_hms(0, 0, 0), meta_map).unwrap();
 
-    let signed = SignedMetadata::<Json, SnapshotMetadata>::new(&snapshot, &snapshot_key).unwrap();
+    let signed = SignedMetadata::<Json, _>::new(snapshot, &snapshot_key).unwrap();
 
-    tuf.update_snapshot(&signed).unwrap();
+    tuf.update_snapshot(signed).unwrap();
 
     //// build the targets ////
     let delegations = Delegations::new(
@@ -107,9 +107,9 @@ fn simple_delegation() {
         Some(delegations),
     ).unwrap();
 
-    let signed = SignedMetadata::<Json, TargetsMetadata>::new(&targets, &targets_key).unwrap();
+    let signed = SignedMetadata::<Json, _>::new(targets, &targets_key).unwrap();
 
-    tuf.update_targets(&signed).unwrap();
+    tuf.update_targets(signed).unwrap();
 
     //// build the delegation ////
     let target_file: &[u8] = b"bar";
@@ -121,9 +121,9 @@ fn simple_delegation() {
         TargetsMetadata::new(1, Utc.ymd(2038, 1, 1).and_hms(0, 0, 0), target_map, None).unwrap();
 
     let signed =
-        SignedMetadata::<Json, TargetsMetadata>::new(&delegation, &delegation_key).unwrap();
+        SignedMetadata::<Json, _>::new(delegation, &delegation_key).unwrap();
 
-    tuf.update_delegation(&MetadataPath::new("delegation".into()).unwrap(), &signed)
+    tuf.update_delegation(&MetadataPath::new("delegation".into()).unwrap(), signed)
         .unwrap();
 
     assert!(
@@ -165,7 +165,7 @@ fn nested_delegation() {
         timestamp_def,
     ).unwrap();
 
-    let signed = SignedMetadata::<Json, RootMetadata>::new(&root, &root_key).unwrap();
+    let signed = SignedMetadata::<Json, _>::new(root, &root_key).unwrap();
 
     let mut tuf = Tuf::<Json>::from_root_pinned(signed, &[root_key.key_id().clone()]).unwrap();
 
@@ -174,9 +174,9 @@ fn nested_delegation() {
     let timestamp = TimestampMetadata::new(1, Utc.ymd(2038, 1, 1).and_hms(0, 0, 0), snap).unwrap();
 
     let signed =
-        SignedMetadata::<Json, TimestampMetadata>::new(&timestamp, &timestamp_key).unwrap();
+        SignedMetadata::<Json, _>::new(timestamp, &timestamp_key).unwrap();
 
-    tuf.update_timestamp(&signed).unwrap();
+    tuf.update_timestamp(signed).unwrap();
 
     //// build the snapshot ////
     let meta_map = hashmap! {
@@ -190,9 +190,9 @@ fn nested_delegation() {
     let snapshot =
         SnapshotMetadata::new(1, Utc.ymd(2038, 1, 1).and_hms(0, 0, 0), meta_map).unwrap();
 
-    let signed = SignedMetadata::<Json, SnapshotMetadata>::new(&snapshot, &snapshot_key).unwrap();
+    let signed = SignedMetadata::<Json, _>::new(snapshot, &snapshot_key).unwrap();
 
-    tuf.update_snapshot(&signed).unwrap();
+    tuf.update_snapshot(signed).unwrap();
 
     //// build the targets ////
     let delegations = Delegations::new(
@@ -220,9 +220,9 @@ fn nested_delegation() {
         Some(delegations),
     ).unwrap();
 
-    let signed = SignedMetadata::<Json, TargetsMetadata>::new(&targets, &targets_key).unwrap();
+    let signed = SignedMetadata::<Json, _>::new(targets, &targets_key).unwrap();
 
-    tuf.update_targets(&signed).unwrap();
+    tuf.update_targets(signed).unwrap();
 
     //// build delegation A ////
     let delegations = Delegations::new(
@@ -251,9 +251,9 @@ fn nested_delegation() {
     ).unwrap();
 
     let signed =
-        SignedMetadata::<Json, TargetsMetadata>::new(&delegation, &delegation_a_key).unwrap();
+        SignedMetadata::<Json, _>::new(delegation, &delegation_a_key).unwrap();
 
-    tuf.update_delegation(&MetadataPath::new("delegation-a".into()).unwrap(), &signed)
+    tuf.update_delegation(&MetadataPath::new("delegation-a".into()).unwrap(), signed)
         .unwrap();
 
     //// build delegation B ////
@@ -267,9 +267,9 @@ fn nested_delegation() {
         TargetsMetadata::new(1, Utc.ymd(2038, 1, 1).and_hms(0, 0, 0), target_map, None).unwrap();
 
     let signed =
-        SignedMetadata::<Json, TargetsMetadata>::new(&delegation, &delegation_b_key).unwrap();
+        SignedMetadata::<Json, _>::new(delegation, &delegation_b_key).unwrap();
 
-    tuf.update_delegation(&MetadataPath::new("delegation-b".into()).unwrap(), &signed)
+    tuf.update_delegation(&MetadataPath::new("delegation-b".into()).unwrap(), signed)
         .unwrap();
 
     assert!(

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 use tuf::crypto::{HashAlgorithm, PrivateKey, SignatureScheme};
 use tuf::interchange::Json;
 use tuf::metadata::{
-    Delegation, Delegations, MetadataDescription, MetadataPath, RoleDefinition, RootMetadata,
+    Delegation, Delegations, MetadataDescription, MetadataPath, RootMetadataBuilder,
     SignedMetadata, SnapshotMetadata, TargetDescription, TargetsMetadata, TimestampMetadata,
     VirtualTargetPath,
 };
@@ -31,30 +31,14 @@ fn simple_delegation() {
     let delegation_key = PrivateKey::from_pkcs8(ED25519_5_PK8, SignatureScheme::Ed25519).unwrap();
 
     //// build the root ////
-    let keys = vec![
-        root_key.public().clone(),
-        snapshot_key.public().clone(),
-        targets_key.public().clone(),
-        timestamp_key.public().clone(),
-    ];
 
-    let root_def = RoleDefinition::new(1, hashset!(root_key.key_id().clone())).unwrap();
-    let snapshot_def = RoleDefinition::new(1, hashset!(snapshot_key.key_id().clone())).unwrap();
-    let targets_def = RoleDefinition::new(1, hashset!(targets_key.key_id().clone())).unwrap();
-    let timestamp_def = RoleDefinition::new(1, hashset!(timestamp_key.key_id().clone())).unwrap();
-
-    let root = RootMetadata::new(
-        1,
-        Utc.ymd(2038, 1, 1).and_hms(0, 0, 0),
-        false,
-        keys,
-        root_def,
-        snapshot_def,
-        targets_def,
-        timestamp_def,
-    ).unwrap();
-
-    let signed = SignedMetadata::<Json, _>::new(root, &root_key).unwrap();
+    let signed = RootMetadataBuilder::new()
+        .root_key(root_key.public().clone())
+        .snapshot_key(snapshot_key.public().clone())
+        .targets_key(targets_key.public().clone())
+        .timestamp_key(timestamp_key.public().clone())
+        .signed::<Json>(&root_key)
+        .unwrap();
 
     let mut tuf = Tuf::<Json>::from_root_pinned(signed, &[root_key.key_id().clone()]).unwrap();
 
@@ -142,30 +126,14 @@ fn nested_delegation() {
     let delegation_b_key = PrivateKey::from_pkcs8(ED25519_6_PK8, SignatureScheme::Ed25519).unwrap();
 
     //// build the root ////
-    let keys = vec![
-        root_key.public().clone(),
-        snapshot_key.public().clone(),
-        targets_key.public().clone(),
-        timestamp_key.public().clone(),
-    ];
 
-    let root_def = RoleDefinition::new(1, hashset!(root_key.key_id().clone())).unwrap();
-    let snapshot_def = RoleDefinition::new(1, hashset!(snapshot_key.key_id().clone())).unwrap();
-    let targets_def = RoleDefinition::new(1, hashset!(targets_key.key_id().clone())).unwrap();
-    let timestamp_def = RoleDefinition::new(1, hashset!(timestamp_key.key_id().clone())).unwrap();
-
-    let root = RootMetadata::new(
-        1,
-        Utc.ymd(2038, 1, 1).and_hms(0, 0, 0),
-        false,
-        keys,
-        root_def,
-        snapshot_def,
-        targets_def,
-        timestamp_def,
-    ).unwrap();
-
-    let signed = SignedMetadata::<Json, _>::new(root, &root_key).unwrap();
+    let signed = RootMetadataBuilder::new()
+        .root_key(root_key.public().clone())
+        .snapshot_key(snapshot_key.public().clone())
+        .targets_key(targets_key.public().clone())
+        .timestamp_key(timestamp_key.public().clone())
+        .signed::<Json>(&root_key)
+        .unwrap();
 
     let mut tuf = Tuf::<Json>::from_root_pinned(signed, &[root_key.key_id().clone()]).unwrap();
 

--- a/tests/simple_example.rs
+++ b/tests/simple_example.rs
@@ -107,7 +107,7 @@ where
         timestamp_def,
     )?;
 
-    let signed = SignedMetadata::<Json, RootMetadata>::new(&root, &root_key)?;
+    let signed = SignedMetadata::<Json, _>::new(root, &root_key)?;
 
     remote.store_metadata(
         &MetadataPath::new("root".into())?,
@@ -131,7 +131,7 @@ where
         hashmap!(config.path_translator().real_to_virtual(&target_path)? => target_description);
     let targets = TargetsMetadata::new(1, Utc.ymd(2038, 1, 1).and_hms(0, 0, 0), target_map, None)?;
 
-    let signed = SignedMetadata::<Json, TargetsMetadata>::new(&targets, &targets_key)?;
+    let signed = SignedMetadata::<Json, _>::new(targets, &targets_key)?;
 
     remote.store_metadata(
         &MetadataPath::new("targets".into())?,
@@ -153,7 +153,7 @@ where
     };
     let snapshot = SnapshotMetadata::new(1, Utc.ymd(2038, 1, 1).and_hms(0, 0, 0), meta_map)?;
 
-    let signed = SignedMetadata::<Json, SnapshotMetadata>::new(&snapshot, &snapshot_key)?;
+    let signed = SignedMetadata::<Json, _>::new(snapshot, &snapshot_key)?;
 
     remote.store_metadata(
         &MetadataPath::new("snapshot".into())?,
@@ -172,7 +172,7 @@ where
     let snap = MetadataDescription::from_reader(&*snapshot_bytes, 1, &[HashAlgorithm::Sha256])?;
     let timestamp = TimestampMetadata::new(1, Utc.ymd(2038, 1, 1).and_hms(0, 0, 0), snap)?;
 
-    let signed = SignedMetadata::<Json, TimestampMetadata>::new(&timestamp, &timestamp_key)?;
+    let signed = SignedMetadata::<Json, _>::new(timestamp, &timestamp_key)?;
 
     remote.store_metadata(
         &MetadataPath::new("timestamp".into())?,


### PR DESCRIPTION
This patch series makes it a bit easier to construct metadata by wrapping the process with builders.

Additionally, to make it easier to work with generic metadata, it both moves the `version` and `expires` into the `Metadata` trait, and also rewrites the `SignedMetadata` to wrap a generic `Metadata` object. This allows us to more easily access the signed metadata state.