### PR TITLE
Bump derp, ring, and untrusted

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,16 +23,16 @@ path = "./src/lib.rs"
 [dependencies]
 chrono = { version = "0.4", features = [ "serde" ] }
 data-encoding = "2.0.0-rc.2"
-derp = "0.0.10"
+derp = "0.0.11"
 hyper = "0.10"
 itoa = "0.4"
 log = "0.4"
-ring = { version = "0.12", features = [ "rsa_signing" ] }
+ring = { version = "0.13", features = [ "rsa_signing" ] }
 serde = "1"
 serde_derive = "1"
 serde_json = "1"
 tempfile = "3"
-untrusted = "0.5"
+untrusted = "0.6"
 
 [dev-dependencies]
 lazy_static = "1"


### PR DESCRIPTION
This is blocked on https://github.com/heartsucker/derp/pull/4 and a derp release. Hopefully this will fix appveyor.