### PR TITLE
Switch to futures, async/await, and hyper 0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ dist: trusty
 language: rust
 cache: cargo
 rust:
-  - stable
-  - beta
   - nightly
 
 env:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ path = "./src/lib.rs"
 chrono = { version = "0.4", features = [ "serde" ] }
 data-encoding = "2.0.0-rc.2"
 derp = "0.0.11"
+futures-preview = "0.3.0-alpha.10"
 hyper = "0.10"
 itoa = "0.4"
 log = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,10 @@ path = "./src/lib.rs"
 chrono = { version = "0.4", features = [ "serde" ] }
 data-encoding = "2.0.0-rc.2"
 derp = "0.0.11"
-futures-preview = "0.3.0-alpha.10"
-hyper = "0.10"
+futures_01 = { version = "0.1", package = "futures" }
+futures-preview = { version = "0.3.0-alpha.10", features = [ "compat" ] }
+http = "0.1"
+hyper = "0.12"
 itoa = "0.4"
 log = "0.4"
 ring = { version = "0.13", features = [ "rsa_signing" ] }
@@ -35,6 +37,7 @@ serde_derive = "1"
 serde_json = "1"
 tempfile = "3"
 untrusted = "0.6"
+url = "1"
 
 [dev-dependencies]
 lazy_static = "1"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,24 +10,6 @@ matrix:
 
 environment:
   matrix:
-    # Rust - Stable
-    - TARGET: i686-pc-windows-gnu
-      RUST_VERSION: stable
-      BITS: 32
-      MSYS2: 1
-    - TARGET: x86_64-pc-windows-msvc
-      RUST_VERSION: stable
-      BITS: 64
-
-    # Rust - Beta
-    - TARGET: i686-pc-windows-gnu
-      RUST_VERSION: beta
-      BITS: 32
-      MSYS2: 1
-    - TARGET: x86_64-pc-windows-msvc
-      RUST_VERSION: beta
-      BITS: 64
-
     # Rust - Nightly
     - TARGET: i686-pc-windows-gnu
       RUST_VERSION: nightly

--- a/src/client.rs
+++ b/src/client.rs
@@ -3,51 +3,48 @@
 //! # Example
 //!
 //! ```no_run
-//! extern crate hyper;
-//! extern crate tuf;
-//!
-//! use hyper::client::Client as HttpClient;
-//! use hyper::Url;
-//! use std::path::PathBuf;
-//! use tuf::Tuf;
-//! use tuf::crypto::KeyId;
-//! use tuf::client::{Client, Config};
-//! use tuf::metadata::{RootMetadata, SignedMetadata, Role, MetadataPath,
-//!     MetadataVersion};
-//! use tuf::interchange::Json;
-//! use tuf::repository::{Repository, FileSystemRepository, HttpRepository};
-//!
+//! # use hyper::client::Client as HttpClient;
+//! # use hyper::Url;
+//! # use std::path::PathBuf;
+//! # use tuf::Tuf;
+//! # use tuf::crypto::KeyId;
+//! # use tuf::client::{Client, Config};
+//! # use tuf::metadata::{RootMetadata, SignedMetadata, Role, MetadataPath,
+//! #     MetadataVersion};
+//! # use tuf::interchange::Json;
+//! # use tuf::repository::{Repository, FileSystemRepository, HttpRepository};
 //! static TRUSTED_ROOT_KEY_IDS: &'static [&str] = &[
 //!     "diNfThTFm0PI8R-Bq7NztUIvZbZiaC_weJBgcqaHlWw=",
 //!     "ar9AgoRsmeEcf6Ponta_1TZu1ds5uXbDemBig30O7ck=",
 //!     "T5vfRrM1iHpgzGwAHe7MbJH_7r4chkOAphV3OPCCv0I=",
 //! ];
 //!
-//! fn main() {
-//!     let key_ids: Vec<KeyId> = TRUSTED_ROOT_KEY_IDS.iter()
-//!         .map(|k| KeyId::from_string(k).unwrap())
-//!         .collect();
+//! # fn main() {
+//! let key_ids: Vec<KeyId> = TRUSTED_ROOT_KEY_IDS.iter()
+//!     .map(|k| KeyId::from_string(k).unwrap())
+//!     .collect();
 //!
-//!     let local = FileSystemRepository::<Json>::new(PathBuf::from("~/.rustup"))
-//!         .unwrap();
+//! let local = FileSystemRepository::<Json>::new(PathBuf::from("~/.rustup"))
+//!     .unwrap();
 //!
-//!     let remote = HttpRepository::new(
-//!         Url::parse("https://static.rust-lang.org/").unwrap(),
-//!         HttpClient::new(),
-//!         Some("rustup/1.4.0".into()),
-//!         None);
+//! let remote = HttpRepository::new(
+//!     Url::parse("https://static.rust-lang.org/").unwrap(),
+//!     HttpClient::new(),
+//!     Some("rustup/1.4.0".into()),
+//!     None);
 //!
-//!     let mut client = Client::with_root_pinned(
-//!         &key_ids,
-//!         Config::default(),
-//!         local,
-//!         remote,
-//!     ).unwrap();
-//!     let _ = client.update().unwrap();
-//! }
+//! let mut client = Client::with_root_pinned(
+//!     &key_ids,
+//!     Config::default(),
+//!     local,
+//!     remote,
+//! ).unwrap();
+//! let _ = client.update().unwrap();
+//! # }
 //! ```
 
 use chrono::offset::Utc;
+use log::{error, warn};
 use std::io::{Read, Write};
 
 use crate::crypto::{self, KeyId};
@@ -774,6 +771,7 @@ mod test {
     };
     use crate::repository::EphemeralRepository;
     use chrono::prelude::*;
+    use lazy_static::lazy_static;
     use std::u32;
 
     lazy_static! {

--- a/src/client.rs
+++ b/src/client.rs
@@ -6,7 +6,6 @@
 //! #![feature(async_await, await_macro, futures_api, pin)]
 //! # use futures::executor::block_on;
 //! # use hyper::client::Client as HttpClient;
-//! # use hyper::Url;
 //! # use std::path::PathBuf;
 //! # use tuf::{Result, Tuf};
 //! # use tuf::crypto::KeyId;
@@ -15,6 +14,7 @@
 //! #     MetadataVersion};
 //! # use tuf::interchange::Json;
 //! # use tuf::repository::{Repository, FileSystemRepository, HttpRepository};
+//!
 //! static TRUSTED_ROOT_KEY_IDS: &'static [&str] = &[
 //!     "diNfThTFm0PI8R-Bq7NztUIvZbZiaC_weJBgcqaHlWw=",
 //!     "ar9AgoRsmeEcf6Ponta_1TZu1ds5uXbDemBig30O7ck=",
@@ -30,7 +30,7 @@
 //! let local = FileSystemRepository::<Json>::new(PathBuf::from("~/.rustup"))?;
 //!
 //! let remote = HttpRepository::new(
-//!     Url::parse("https://static.rust-lang.org/").unwrap(),
+//!     url::Url::parse("https://static.rust-lang.org/").unwrap(),
 //!     HttpClient::new(),
 //!     Some("rustup/1.4.0".into()),
 //!     None);

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -11,6 +11,7 @@ use ring::signature::{
 };
 use serde::de::{Deserialize, Deserializer, Error as DeserializeError};
 use serde::ser::{Error as SerializeError, Serialize, Serializer};
+use serde_derive::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::fmt::{self, Debug, Display};
@@ -378,17 +379,15 @@ impl PrivateKey {
     /// ```
     ///
     /// ```no_run
-    /// extern crate ring;
-    /// use ring::rand::SystemRandom;
-    /// use ring::signature::Ed25519KeyPair;
-    /// use std::fs::File;
-    /// use std::io::Write;
-    ///
-    /// fn main() {
-    ///     let mut file = File::open("ed25519-private-key.pk8").unwrap();
-    ///     let key = Ed25519KeyPair::generate_pkcs8(&SystemRandom::new()).unwrap();
-    ///     file.write_all(&key).unwrap()
-    /// }
+    /// # use ring::rand::SystemRandom;
+    /// # use ring::signature::Ed25519KeyPair;
+    /// # use std::fs::File;
+    /// # use std::io::Write;
+    /// # fn main() {
+    /// let mut file = File::open("ed25519-private-key.pk8").unwrap();
+    /// let key = Ed25519KeyPair::generate_pkcs8(&SystemRandom::new()).unwrap();
+    /// file.write_all(&key).unwrap()
+    /// # }
     /// ```
     ///
     /// ## RSA

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,6 +2,7 @@
 
 use data_encoding::DecodeError;
 use derp;
+use http;
 use hyper;
 use serde_json;
 use std::fmt;
@@ -89,14 +90,14 @@ impl From<io::Error> for Error {
     }
 }
 
-impl From<hyper::error::Error> for Error {
-    fn from(err: hyper::error::Error) -> Error {
-        Error::Opaque(format!("Hyper: {:?}", err))
+impl From<http::Error> for Error {
+    fn from(err: http::Error) -> Error {
+        Error::Opaque(format!("Http: {:?}", err))
     }
 }
 
-impl From<hyper::error::ParseError> for Error {
-    fn from(err: hyper::error::ParseError) -> Error {
+impl From<hyper::Error> for Error {
+    fn from(err: hyper::Error) -> Error {
         Error::Opaque(format!("Hyper: {:?}", err))
     }
 }

--- a/src/interchange/mod.rs
+++ b/src/interchange/mod.rs
@@ -46,6 +46,11 @@ pub trait DataInterchange: Debug + PartialEq + Clone {
     where
         R: Read,
         T: DeserializeOwned;
+
+    /// Read a struct from a stream.
+    fn from_slice<T>(slice: &[u8]) -> Result<T>
+    where
+        T: DeserializeOwned;
 }
 
 /// JSON data interchange.
@@ -322,5 +327,18 @@ impl DataInterchange for Json {
         T: DeserializeOwned,
     {
         Ok(serde_json::from_reader(rdr)?)
+    }
+
+    /// ```
+    /// # use tuf::interchange::{DataInterchange, Json};
+    /// # use std::collections::HashMap;
+    /// let jsn: &[u8] = br#"{"foo": "bar", "baz": "quux"}"#;
+    /// let _: HashMap<String, String> = Json::from_slice(&jsn).unwrap();
+    /// ```
+    fn from_slice<T>(slice: &[u8]) -> Result<T>
+    where
+        T: DeserializeOwned,
+    {
+        Ok(serde_json::from_slice(slice)?)
     }
 }

--- a/src/interchange/mod.rs
+++ b/src/interchange/mod.rs
@@ -242,13 +242,10 @@ impl DataInterchange for Json {
     }
 
     /// ```
-    /// # #[macro_use]
-    /// # extern crate serde_derive;
-    /// # #[macro_use]
-    /// # extern crate serde_json;
-    /// # extern crate tuf;
-    /// # use tuf::interchange::{DataInterchange, Json};
+    /// # use serde_derive::Deserialize;
+    /// # use serde_json::json;
     /// # use std::collections::HashMap;
+    /// # use tuf::interchange::{DataInterchange, Json};
     /// #
     /// #[derive(Deserialize, Debug, PartialEq)]
     /// struct Thing {
@@ -271,13 +268,10 @@ impl DataInterchange for Json {
     }
 
     /// ```
-    /// # #[macro_use]
-    /// # extern crate serde_derive;
-    /// # #[macro_use]
-    /// # extern crate serde_json;
-    /// # extern crate tuf;
-    /// # use tuf::interchange::{DataInterchange, Json};
+    /// # use serde_derive::Serialize;
+    /// # use serde_json::json;
     /// # use std::collections::HashMap;
+    /// # use tuf::interchange::{DataInterchange, Json};
     /// #
     /// #[derive(Serialize)]
     /// struct Thing {

--- a/src/into_async_read.rs
+++ b/src/into_async_read.rs
@@ -1,0 +1,93 @@
+// FIXME: remove once https://github.com/rust-lang-nursery/futures-rs/pull/1367 lands in a release.
+
+use futures::io::AsyncRead;
+use futures::ready;
+use futures::stream::TryStream;
+use futures::task::{LocalWaker, Poll};
+use std::cmp;
+use std::io::{Error, Result};
+use std::marker::Unpin;
+use std::pin::Pin;
+
+pub struct IntoAsyncRead<St>
+where
+    St: TryStream<Error = Error> + Unpin,
+    St::Ok: AsRef<[u8]>,
+{
+    stream: St,
+    state: ReadState<St::Ok>,
+}
+
+impl<St> Unpin for IntoAsyncRead<St>
+where
+    St: TryStream<Error = Error> + Unpin,
+    St::Ok: AsRef<[u8]>,
+{
+}
+
+#[derive(Debug)]
+enum ReadState<T: AsRef<[u8]>> {
+    Ready { chunk: T, chunk_start: usize },
+    PendingChunk,
+    Eof,
+}
+
+impl<St> IntoAsyncRead<St>
+where
+    St: TryStream<Error = Error> + Unpin,
+    St::Ok: AsRef<[u8]>,
+{
+    pub(super) fn new(stream: St) -> Self {
+        IntoAsyncRead {
+            stream,
+            state: ReadState::PendingChunk,
+        }
+    }
+}
+
+impl<St> AsyncRead for IntoAsyncRead<St>
+where
+    St: TryStream<Error = Error> + Unpin,
+    St::Ok: AsRef<[u8]>,
+{
+    fn poll_read(&mut self, lw: &LocalWaker, buf: &mut [u8]) -> Poll<Result<usize>> {
+        loop {
+            match &mut self.state {
+                ReadState::Ready { chunk, chunk_start } => {
+                    let chunk = chunk.as_ref();
+                    let len = cmp::min(buf.len(), chunk.len() - *chunk_start);
+
+                    buf[..len].copy_from_slice(&chunk[*chunk_start..*chunk_start + len]);
+                    *chunk_start += len;
+
+                    if chunk.len() == *chunk_start {
+                        self.state = ReadState::PendingChunk;
+                    }
+
+                    return Poll::Ready(Ok(len));
+                }
+                ReadState::PendingChunk => {
+                    match ready!(Pin::new(&mut self.stream).try_poll_next(lw)) {
+                        Some(Ok(chunk)) => {
+                            self.state = ReadState::Ready {
+                                chunk,
+                                chunk_start: 0,
+                            };
+                            continue;
+                        }
+                        Some(Err(err)) => {
+                            return Poll::Ready(Err(err));
+                        }
+                        None => {
+                            self.state = ReadState::Eof;
+                            return Poll::Ready(Ok(0));
+                        }
+                    }
+                }
+                ReadState::Eof => {
+                    return Poll::Ready(Ok(0));
+                }
+            }
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,6 +119,7 @@ pub mod metadata;
 pub mod repository;
 pub mod tuf;
 
+mod into_async_read;
 mod shims;
 mod util;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,6 +109,7 @@
     clippy::op_ref,
     clippy::too_many_arguments
 )]
+#![feature(async_await, await_macro, futures_api, pin)]
 
 pub mod client;
 pub mod crypto;
@@ -123,7 +124,9 @@ mod util;
 
 pub use crate::error::*;
 pub use crate::tuf::*;
-pub use crate::util::*;
 
 /// Alias for `Result<T, Error>`.
 pub type Result<T> = std::result::Result<T, Error>;
+
+/// Alias for `Pin<Box<dyn Future<Output = T> + 'a>>`.
+pub type TufFuture<'a, T> = std::pin::Pin<Box<dyn futures::Future<Output = T> + 'a>>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,53 +102,28 @@
 //! metadata on every update.
 
 #![deny(missing_docs)]
-#![cfg_attr(
-    feature = "cargo-clippy",
-    allow(
-        collapsible_if,
-        implicit_hasher,
-        new_ret_no_self,
-        op_ref,
-        too_many_arguments
-    )
+#![allow(
+    clippy::collapsible_if,
+    clippy::implicit_hasher,
+    clippy::new_ret_no_self,
+    clippy::op_ref,
+    clippy::too_many_arguments
 )]
-
-extern crate chrono;
-extern crate data_encoding;
-extern crate derp;
-extern crate hyper;
-extern crate itoa;
-#[cfg(test)]
-#[macro_use]
-extern crate lazy_static;
-#[macro_use]
-extern crate log;
-#[cfg(test)]
-#[macro_use]
-extern crate maplit;
-extern crate ring;
-extern crate serde;
-#[macro_use]
-extern crate serde_derive;
-extern crate serde_json;
-
-extern crate tempfile;
-extern crate untrusted;
-
-pub mod error;
-
-/// Alias for `Result<T, Error>`.
-pub type Result<T> = ::std::result::Result<T, Error>;
 
 pub mod client;
 pub mod crypto;
+pub mod error;
 pub mod interchange;
 pub mod metadata;
 pub mod repository;
-mod shims;
 pub mod tuf;
+
+mod shims;
 mod util;
 
 pub use crate::error::*;
 pub use crate::tuf::*;
 pub use crate::util::*;
+
+/// Alias for `Result<T, Error>`.
+pub type Result<T> = std::result::Result<T, Error>;

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -2,8 +2,10 @@
 
 use chrono::offset::Utc;
 use chrono::{DateTime, Duration};
+use log::{debug, warn};
 use serde::de::{Deserialize, DeserializeOwned, Deserializer, Error as DeserializeError};
 use serde::ser::{Error as SerializeError, Serialize, Serializer};
+use serde_derive::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::fmt::{self, Debug, Display};
 use std::io::Read;
@@ -15,14 +17,14 @@ use crate::interchange::DataInterchange;
 use crate::shims;
 use crate::Result;
 
-#[cfg_attr(rustfmt, rustfmt_skip)]
+#[rustfmt::skip]
 static PATH_ILLEGAL_COMPONENTS: &'static [&str] = &[
     ".", // current dir
     "..", // parent dir
          // TODO ? "0", // may translate to nul in windows
 ];
 
-#[cfg_attr(rustfmt, rustfmt_skip)]
+#[rustfmt::skip]
 static PATH_ILLEGAL_COMPONENTS_CASE_INSENSITIVE: &'static [&str] = &[
     // DOS device files
     "CON",
@@ -54,7 +56,7 @@ static PATH_ILLEGAL_COMPONENTS_CASE_INSENSITIVE: &'static [&str] = &[
     "CONFIG$",
 ];
 
-#[cfg_attr(rustfmt, rustfmt_skip)]
+#[rustfmt::skip]
 static PATH_ILLEGAL_STRINGS: &'static [&str] = &[
     ":", // for *nix compatibility
     "\\", // for windows compatibility
@@ -254,9 +256,6 @@ where
     /// bytes of the provided metadata with the provided scheme.
     ///
     /// ```
-    /// # extern crate chrono;
-    /// # extern crate tuf;
-    /// #
     /// # use chrono::prelude::*;
     /// # use tuf::crypto::{PrivateKey, SignatureScheme, HashAlgorithm};
     /// # use tuf::interchange::Json;
@@ -290,9 +289,6 @@ where
     /// to perform the "append" operations.
     ///
     /// ```
-    /// # extern crate chrono;
-    /// # extern crate tuf;
-    /// #
     /// # use chrono::prelude::*;
     /// # use tuf::crypto::{PrivateKey, SignatureScheme, HashAlgorithm};
     /// # use tuf::interchange::Json;
@@ -367,11 +363,6 @@ where
     /// Verify this metadata.
     ///
     /// ```
-    /// # extern crate chrono;
-    /// # #[macro_use]
-    /// # extern crate maplit;
-    /// # extern crate tuf;
-    ///
     /// # use chrono::prelude::*;
     /// # use tuf::crypto::{PrivateKey, SignatureScheme, HashAlgorithm};
     /// # use tuf::interchange::Json;
@@ -625,6 +616,12 @@ impl RootMetadataBuilder {
         D: DataInterchange,
     {
         Ok(SignedMetadata::new(self.build()?, private_key)?)
+    }
+}
+
+impl Default for RootMetadataBuilder {
+    fn default() -> Self {
+        RootMetadataBuilder::new()
     }
 }
 
@@ -1199,7 +1196,7 @@ impl SnapshotMetadataBuilder {
         path: MetadataPath,
         description: MetadataDescription,
     ) -> Self {
-        self.meta.insert(path.into(), description);
+        self.meta.insert(path, description);
         self
     }
 
@@ -1214,6 +1211,12 @@ impl SnapshotMetadataBuilder {
         D: DataInterchange,
     {
         Ok(SignedMetadata::new(self.build()?, private_key)?)
+    }
+}
+
+impl Default for SnapshotMetadataBuilder {
+    fn default() -> Self {
+        SnapshotMetadataBuilder::new()
     }
 }
 
@@ -1458,8 +1461,6 @@ impl TargetDescription {
     /// Read the from the given reader and calculate the size and hash values.
     ///
     /// ```
-    /// extern crate data_encoding;
-    /// extern crate tuf;
     /// use data_encoding::BASE64URL;
     /// use tuf::crypto::{HashAlgorithm,HashValue};
     /// use tuf::metadata::TargetDescription;
@@ -1666,6 +1667,12 @@ impl TargetsMetadataBuilder {
     }
 }
 
+impl Default for TargetsMetadataBuilder {
+    fn default() -> Self {
+        TargetsMetadataBuilder::new()
+    }
+}
+
 /// Wrapper to described a collections of delegations.
 #[derive(Debug, PartialEq, Clone)]
 pub struct Delegations {
@@ -1833,6 +1840,7 @@ mod test {
     use crate::crypto::SignatureScheme;
     use crate::interchange::Json;
     use chrono::prelude::*;
+    use maplit::{hashmap, hashset};
     use serde_json::json;
 
     const ED25519_1_PK8: &'static [u8] = include_bytes!("../tests/ed25519/ed25519-1.pk8.der");

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -4,6 +4,7 @@ use hyper::client::response::Response;
 use hyper::header::{Headers, UserAgent};
 use hyper::status::StatusCode;
 use hyper::{Client, Url};
+use log::debug;
 use std::collections::HashMap;
 use std::fs::{DirBuilder, File};
 use std::io::{self, Cursor, Read, Write};
@@ -382,13 +383,15 @@ where
     }
 }
 
+type ArcHashMap<K, V> = Arc<RwLock<HashMap<K, V>>>;
+
 /// An ephemeral repository contained solely in memory.
 pub struct EphemeralRepository<D>
 where
     D: DataInterchange,
 {
-    metadata: Arc<RwLock<HashMap<(MetadataPath, MetadataVersion), Vec<u8>>>>,
-    targets: Arc<RwLock<HashMap<TargetPath, Vec<u8>>>>,
+    metadata: ArcHashMap<(MetadataPath, MetadataVersion), Vec<u8>>,
+    targets: ArcHashMap<TargetPath, Vec<u8>>,
     interchange: PhantomData<D>,
 }
 

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -1,5 +1,6 @@
 //! Interfaces for interacting with different types of TUF repositories.
 
+use futures::io::{AllowStdIo, AsyncRead, AsyncReadExt};
 use hyper::client::response::Response;
 use hyper::header::{Headers, UserAgent};
 use hyper::status::StatusCode;
@@ -7,7 +8,7 @@ use hyper::{Client, Url};
 use log::debug;
 use std::collections::HashMap;
 use std::fs::{DirBuilder, File};
-use std::io::{self, Cursor, Read, Write};
+use std::io::Cursor;
 use std::marker::PhantomData;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
@@ -20,7 +21,7 @@ use crate::metadata::{
     Metadata, MetadataPath, MetadataVersion, SignedMetadata, TargetDescription, TargetPath,
 };
 use crate::util::SafeReader;
-use crate::Result;
+use crate::{Result, TufFuture};
 
 /// Top-level trait that represents a TUF repository and contains all the ways it can be interacted
 /// with.
@@ -28,46 +29,47 @@ pub trait Repository<D>
 where
     D: DataInterchange,
 {
-    /// The type returned when reading a target.
-    type TargetRead: Read;
-
     /// Store signed metadata.
     ///
     /// Note: This **MUST** canonicalize the bytes before storing them as a read will expect the
     /// hashes of the metadata to match.
-    fn store_metadata<M>(
-        &self,
-        meta_path: &MetadataPath,
-        version: &MetadataVersion,
-        metadata: &SignedMetadata<D, M>,
-    ) -> Result<()>
+    fn store_metadata<'a, M>(
+        &'a self,
+        meta_path: &'a MetadataPath,
+        version: &'a MetadataVersion,
+        metadata: &'a SignedMetadata<D, M>,
+    ) -> TufFuture<'a, Result<()>>
     where
-        M: Metadata;
+        M: Metadata + 'static;
 
     /// Fetch signed metadata.
-    fn fetch_metadata<M>(
-        &self,
-        meta_path: &MetadataPath,
-        version: &MetadataVersion,
-        max_size: &Option<usize>,
+    fn fetch_metadata<'a, M>(
+        &'a self,
+        meta_path: &'a MetadataPath,
+        version: &'a MetadataVersion,
+        max_size: &'a Option<usize>,
         min_bytes_per_second: u32,
-        hash_data: Option<(&HashAlgorithm, HashValue)>,
-    ) -> Result<SignedMetadata<D, M>>
+        hash_data: Option<(&'static HashAlgorithm, HashValue)>,
+    ) -> TufFuture<'a, Result<SignedMetadata<D, M>>>
     where
-        M: Metadata;
+        M: Metadata + 'static;
 
     /// Store the given target.
-    fn store_target<R>(&self, read: R, target_path: &TargetPath) -> Result<()>
+    fn store_target<'a, R>(
+        &'a self,
+        read: R,
+        target_path: &'a TargetPath,
+    ) -> TufFuture<'a, Result<()>>
     where
-        R: Read;
+        R: AsyncRead + 'a;
 
     /// Fetch the given target.
-    fn fetch_target(
-        &self,
-        target_path: &TargetPath,
-        target_description: &TargetDescription,
+    fn fetch_target<'a>(
+        &'a self,
+        target_path: &'a TargetPath,
+        target_description: &'a TargetDescription,
         min_bytes_per_second: u32,
-    ) -> Result<SafeReader<Self::TargetRead>>;
+    ) -> TufFuture<'a, Result<Box<dyn AsyncRead>>>;
 
     /// Perform a sanity check that `M`, `Role`, and `MetadataPath` all desrcribe the same entity.
     fn check<M>(meta_path: &MetadataPath) -> Result<()>
@@ -118,120 +120,137 @@ impl<D> Repository<D> for FileSystemRepository<D>
 where
     D: DataInterchange,
 {
-    type TargetRead = File;
-
-    fn store_metadata<M>(
-        &self,
-        meta_path: &MetadataPath,
-        version: &MetadataVersion,
-        metadata: &SignedMetadata<D, M>,
-    ) -> Result<()>
+    fn store_metadata<'a, M>(
+        &'a self,
+        meta_path: &'a MetadataPath,
+        version: &'a MetadataVersion,
+        metadata: &'a SignedMetadata<D, M>,
+    ) -> TufFuture<'a, Result<()>>
     where
-        M: Metadata,
+        M: Metadata + 'static,
     {
-        Self::check::<M>(meta_path)?;
+        Box::pinned(
+            async move {
+                Self::check::<M>(meta_path)?;
 
-        let mut path = self.local_path.join("metadata");
-        path.extend(meta_path.components::<D>(version));
+                let mut path = self.local_path.join("metadata");
+                path.extend(meta_path.components::<D>(version));
 
-        if path.exists() {
-            debug!("Metadata path exists. Overwriting: {:?}", path);
-        }
+                if path.exists() {
+                    debug!("Metadata path exists. Overwriting: {:?}", path);
+                }
 
-        atomically_write(&path, |write| {
-            D::to_writer(write, metadata)?;
-            Ok(())
-        })
+                let mut temp_file = create_temp_file(&path)?;
+                D::to_writer(&mut temp_file, metadata)?;
+                temp_file.persist(&path)?;
+
+                Ok(())
+            },
+        )
     }
 
     /// Fetch signed metadata.
-    fn fetch_metadata<M>(
-        &self,
-        meta_path: &MetadataPath,
-        version: &MetadataVersion,
-        max_size: &Option<usize>,
+    fn fetch_metadata<'a, M>(
+        &'a self,
+        meta_path: &'a MetadataPath,
+        version: &'a MetadataVersion,
+        max_size: &'a Option<usize>,
         min_bytes_per_second: u32,
-        hash_data: Option<(&HashAlgorithm, HashValue)>,
-    ) -> Result<SignedMetadata<D, M>>
+        hash_data: Option<(&'static HashAlgorithm, HashValue)>,
+    ) -> TufFuture<'a, Result<SignedMetadata<D, M>>>
     where
-        M: Metadata,
+        M: Metadata + 'static,
     {
-        Self::check::<M>(meta_path)?;
+        Box::pinned(
+            async move {
+                Self::check::<M>(&meta_path)?;
 
-        let mut path = self.local_path.join("metadata");
-        path.extend(meta_path.components::<D>(&version));
+                let mut path = self.local_path.join("metadata");
+                path.extend(meta_path.components::<D>(&version));
 
-        let read = SafeReader::new(
-            File::open(&path)?,
-            max_size.unwrap_or(::std::usize::MAX) as u64,
-            min_bytes_per_second,
-            hash_data,
-        )?;
+                let mut reader = SafeReader::new(
+                    AllowStdIo::new(File::open(&path)?),
+                    max_size.unwrap_or(::std::usize::MAX) as u64,
+                    min_bytes_per_second,
+                    hash_data,
+                )?;
 
-        Ok(D::from_reader(read)?)
+                let mut buf = Vec::with_capacity(max_size.unwrap_or(0));
+                await!(reader.read_to_end(&mut buf))?;
+
+                Ok(D::from_slice(&buf)?)
+            },
+        )
     }
 
-    fn store_target<R>(&self, mut read: R, target_path: &TargetPath) -> Result<()>
+    fn store_target<'a, R>(
+        &'a self,
+        mut read: R,
+        target_path: &'a TargetPath,
+    ) -> TufFuture<'a, Result<()>>
     where
-        R: Read,
+        R: AsyncRead + 'a,
     {
-        let mut path = self.local_path.join("targets");
-        path.extend(target_path.components());
+        Box::pinned(
+            async move {
+                let mut path = self.local_path.join("targets");
+                path.extend(target_path.components());
 
-        if path.exists() {
-            debug!("Target path exists. Overwriting: {:?}", path);
-        }
+                if path.exists() {
+                    debug!("Target path exists. Overwriting: {:?}", path);
+                }
 
-        atomically_write(&path, |write| {
-            io::copy(&mut read, write)?;
-            Ok(())
-        })
+                let mut temp_file = AllowStdIo::new(create_temp_file(&path)?);
+                await!(read.copy_into(&mut temp_file))?;
+                temp_file.into_inner().persist(&path)?;
+
+                Ok(())
+            },
+        )
     }
 
-    fn fetch_target(
-        &self,
-        target_path: &TargetPath,
-        target_description: &TargetDescription,
+    fn fetch_target<'a>(
+        &'a self,
+        target_path: &'a TargetPath,
+        target_description: &'a TargetDescription,
         min_bytes_per_second: u32,
-    ) -> Result<SafeReader<Self::TargetRead>> {
-        let mut path = self.local_path.join("targets");
-        path.extend(target_path.components());
+    ) -> TufFuture<'a, Result<Box<dyn AsyncRead>>> {
+        Box::pinned(
+            async move {
+                let mut path = self.local_path.join("targets");
+                path.extend(target_path.components());
 
-        if !path.exists() {
-            return Err(Error::NotFound);
-        }
+                if !path.exists() {
+                    return Err(Error::NotFound);
+                }
 
-        let (alg, value) = crypto::hash_preference(target_description.hashes())?;
+                let (alg, value) = crypto::hash_preference(target_description.hashes())?;
 
-        SafeReader::new(
-            File::open(&path)?,
-            target_description.size(),
-            min_bytes_per_second,
-            Some((alg, value.clone())),
+                let reader: Box<dyn AsyncRead> = Box::new(SafeReader::new(
+                    AllowStdIo::new(File::open(&path)?),
+                    target_description.size(),
+                    min_bytes_per_second,
+                    Some((alg, value.clone())),
+                )?);
+
+                Ok(reader)
+            },
         )
     }
 }
 
-fn atomically_write<F>(path: &Path, mut f: F) -> Result<()>
-where
-    F: FnMut(&mut Write) -> Result<()>,
-{
-    // We want to atomically write the file to make sure clients can never see a partially written file.
-    // In order to do this, we'll write to a temporary file in the same directory as our target, otherwise
-    // we risk writing the temporary file to one mountpoint, and then non-atomically copying the file to another mountpoint.
+fn create_temp_file(path: &Path) -> Result<NamedTempFile> {
+    // We want to atomically write the file to make sure clients can never see a partially written
+    // file.  In order to do this, we'll write to a temporary file in the same directory as our
+    // target, otherwise we risk writing the temporary file to one mountpoint, and then
+    // non-atomically copying the file to another mountpoint.
 
-    let mut temp_file = if let Some(parent) = path.parent() {
+    if let Some(parent) = path.parent() {
         DirBuilder::new().recursive(true).create(parent)?;
-        NamedTempFile::new_in(parent)?
+        Ok(NamedTempFile::new_in(parent)?)
     } else {
-        NamedTempFile::new_in(".")?
-    };
-
-    f(&mut temp_file)?;
-
-    temp_file.persist(&path)?;
-
-    Ok(())
+        Ok(NamedTempFile::new_in(".")?)
+    }
 }
 
 /// A repository accessible over HTTP.
@@ -317,69 +336,85 @@ impl<D> Repository<D> for HttpRepository<D>
 where
     D: DataInterchange,
 {
-    type TargetRead = Response;
+    /// This always returns `Err` as storing over HTTP is not yet supported.
+    fn store_metadata<'a, M>(
+        &'a self,
+        _: &'a MetadataPath,
+        _: &'a MetadataVersion,
+        _: &'a SignedMetadata<D, M>,
+    ) -> TufFuture<'a, Result<()>>
+    where
+        M: Metadata + 'static,
+    {
+        Box::pinned(
+            async {
+                Err(Error::Opaque(
+                    "Http repo store metadata not implemented".to_string(),
+                ))
+            },
+        )
+    }
+
+    fn fetch_metadata<'a, M>(
+        &'a self,
+        meta_path: &'a MetadataPath,
+        version: &'a MetadataVersion,
+        max_size: &'a Option<usize>,
+        min_bytes_per_second: u32,
+        hash_data: Option<(&'static HashAlgorithm, HashValue)>,
+    ) -> TufFuture<'a, Result<SignedMetadata<D, M>>>
+    where
+        M: Metadata + 'static,
+    {
+        Box::pinned(
+            async move {
+                Self::check::<M>(meta_path)?;
+
+                let resp = self.get(&self.metadata_prefix, &meta_path.components::<D>(&version))?;
+
+                let mut reader = SafeReader::new(
+                    AllowStdIo::new(resp),
+                    max_size.unwrap_or(::std::usize::MAX) as u64,
+                    min_bytes_per_second,
+                    hash_data,
+                )?;
+
+                let mut buf = Vec::new();
+                await!(reader.read_to_end(&mut buf))?;
+
+                Ok(D::from_slice(&buf)?)
+            },
+        )
+    }
 
     /// This always returns `Err` as storing over HTTP is not yet supported.
-    fn store_metadata<M>(
-        &self,
-        _: &MetadataPath,
-        _: &MetadataVersion,
-        _: &SignedMetadata<D, M>,
-    ) -> Result<()>
+    fn store_target<'a, R>(&'a self, _: R, _: &'a TargetPath) -> TufFuture<'a, Result<()>>
     where
-        M: Metadata,
+        R: AsyncRead + 'a,
     {
-        Err(Error::Opaque(
-            "Http repo store metadata not implemented".to_string(),
-        ))
+        Box::pinned(async { Err(Error::Opaque("Http repo store not implemented".to_string())) })
     }
 
-    fn fetch_metadata<M>(
-        &self,
-        meta_path: &MetadataPath,
-        version: &MetadataVersion,
-        max_size: &Option<usize>,
+    fn fetch_target<'a>(
+        &'a self,
+        target_path: &'a TargetPath,
+        target_description: &'a TargetDescription,
         min_bytes_per_second: u32,
-        hash_data: Option<(&HashAlgorithm, HashValue)>,
-    ) -> Result<SignedMetadata<D, M>>
-    where
-        M: Metadata,
-    {
-        Self::check::<M>(meta_path)?;
+    ) -> TufFuture<'a, Result<Box<dyn AsyncRead>>> {
+        Box::pinned(
+            async move {
+                let resp = self.get(&None, &target_path.components())?;
+                let (alg, value) = crypto::hash_preference(target_description.hashes())?;
+                let reader = SafeReader::new(
+                    AllowStdIo::new(resp),
+                    target_description.size(),
+                    min_bytes_per_second,
+                    Some((alg, value.clone())),
+                )?;
 
-        let resp = self.get(&self.metadata_prefix, &meta_path.components::<D>(&version))?;
-
-        let read = SafeReader::new(
-            resp,
-            max_size.unwrap_or(::std::usize::MAX) as u64,
-            min_bytes_per_second,
-            hash_data,
-        )?;
-        Ok(D::from_reader(read)?)
-    }
-
-    /// This always returns `Err` as storing over HTTP is not yet supported.
-    fn store_target<R>(&self, _: R, _: &TargetPath) -> Result<()>
-    where
-        R: Read,
-    {
-        Err(Error::Opaque("Http repo store not implemented".to_string()))
-    }
-
-    fn fetch_target(
-        &self,
-        target_path: &TargetPath,
-        target_description: &TargetDescription,
-        min_bytes_per_second: u32,
-    ) -> Result<SafeReader<Self::TargetRead>> {
-        let resp = self.get(&None, &target_path.components())?;
-        let (alg, value) = crypto::hash_preference(target_description.hashes())?;
-        Ok(SafeReader::new(
-            resp,
-            target_description.size(),
-            min_bytes_per_second,
-            Some((alg, value.clone())),
-        )?)
+                Ok(Box::new(reader) as Box<dyn AsyncRead>)
+            },
+        )
     }
 }
 
@@ -422,85 +457,110 @@ impl<D> Repository<D> for EphemeralRepository<D>
 where
     D: DataInterchange,
 {
-    type TargetRead = Cursor<Vec<u8>>;
-
-    fn store_metadata<M>(
-        &self,
-        meta_path: &MetadataPath,
-        version: &MetadataVersion,
-        metadata: &SignedMetadata<D, M>,
-    ) -> Result<()>
+    fn store_metadata<'a, M>(
+        &'a self,
+        meta_path: &'a MetadataPath,
+        version: &'a MetadataVersion,
+        metadata: &'a SignedMetadata<D, M>,
+    ) -> TufFuture<'a, Result<()>>
     where
-        M: Metadata,
+        M: Metadata + 'static,
     {
-        Self::check::<M>(meta_path)?;
-        let mut buf = Vec::new();
-        D::to_writer(&mut buf, metadata)?;
-        let mut metadata = self.metadata.write().unwrap();
-        let _ = metadata.insert((meta_path.clone(), version.clone()), buf);
-        Ok(())
+        Box::pinned(
+            async move {
+                Self::check::<M>(meta_path)?;
+                let mut buf = Vec::new();
+                D::to_writer(&mut buf, metadata)?;
+                let mut metadata = self.metadata.write().unwrap();
+                let _ = metadata.insert((meta_path.clone(), version.clone()), buf);
+                Ok(())
+            },
+        )
     }
 
-    fn fetch_metadata<M>(
-        &self,
-        meta_path: &MetadataPath,
-        version: &MetadataVersion,
-        max_size: &Option<usize>,
+    fn fetch_metadata<'a, M>(
+        &'a self,
+        meta_path: &'a MetadataPath,
+        version: &'a MetadataVersion,
+        max_size: &'a Option<usize>,
         min_bytes_per_second: u32,
-        hash_data: Option<(&HashAlgorithm, HashValue)>,
-    ) -> Result<SignedMetadata<D, M>>
+        hash_data: Option<(&'static HashAlgorithm, HashValue)>,
+    ) -> TufFuture<'a, Result<SignedMetadata<D, M>>>
     where
-        M: Metadata,
+        M: Metadata + 'static,
     {
-        Self::check::<M>(meta_path)?;
+        Box::pinned(
+            async move {
+                Self::check::<M>(meta_path)?;
 
-        let metadata = self.metadata.read().unwrap();
-        match metadata.get(&(meta_path.clone(), version.clone())) {
-            Some(bytes) => {
-                let reader = SafeReader::new(
-                    &**bytes,
-                    max_size.unwrap_or(::std::usize::MAX) as u64,
-                    min_bytes_per_second,
-                    hash_data,
-                )?;
-                D::from_reader(reader)
-            }
-            None => Err(Error::NotFound),
-        }
+                let metadata = self.metadata.read().unwrap();
+                match metadata.get(&(meta_path.clone(), version.clone())) {
+                    Some(bytes) => {
+                        let mut reader = SafeReader::new(
+                            &**bytes,
+                            max_size.unwrap_or(::std::usize::MAX) as u64,
+                            min_bytes_per_second,
+                            hash_data,
+                        )?;
+
+                        let mut buf = Vec::with_capacity(max_size.unwrap_or(0));
+                        await!(reader.read_to_end(&mut buf))?;
+
+                        D::from_slice(&buf)
+                    }
+                    None => Err(Error::NotFound),
+                }
+            },
+        )
     }
 
-    fn store_target<R>(&self, mut read: R, target_path: &TargetPath) -> Result<()>
+    fn store_target<'a, R>(
+        &'a self,
+        mut read: R,
+        target_path: &'a TargetPath,
+    ) -> TufFuture<'a, Result<()>>
     where
-        R: Read,
+        R: AsyncRead + 'a,
     {
-        let mut buf = Vec::new();
-        read.read_to_end(&mut buf)?;
-        let mut targets = self.targets.write().unwrap();
-        let _ = targets.insert(target_path.clone(), buf);
-        Ok(())
+        Box::pinned(
+            async move {
+                println!("EphemeralRepository.store_target: {:?}", target_path);
+                let mut buf = Vec::new();
+                await!(read.read_to_end(&mut buf))?;
+                let mut targets = self.targets.write().unwrap();
+                let _ = targets.insert(target_path.clone(), buf);
+                Ok(())
+            },
+        )
     }
 
-    fn fetch_target(
-        &self,
-        target_path: &TargetPath,
-        target_description: &TargetDescription,
+    fn fetch_target<'a>(
+        &'a self,
+        target_path: &'a TargetPath,
+        target_description: &'a TargetDescription,
         min_bytes_per_second: u32,
-    ) -> Result<SafeReader<Self::TargetRead>> {
-        let targets = self.targets.read().unwrap();
-        match targets.get(target_path) {
-            Some(bytes) => {
-                let cur = Cursor::new(bytes.clone());
-                let (alg, value) = crypto::hash_preference(target_description.hashes())?;
-                let read = SafeReader::new(
-                    cur,
-                    target_description.size(),
-                    min_bytes_per_second,
-                    Some((alg, value.clone())),
-                )?;
-                Ok(read)
-            }
-            None => Err(Error::NotFound),
-        }
+    ) -> TufFuture<'a, Result<Box<dyn AsyncRead>>> {
+        Box::pinned(
+            async move {
+                let targets = self.targets.read().unwrap();
+                match targets.get(target_path) {
+                    Some(bytes) => {
+                        let cur = Cursor::new(bytes.clone());
+                        let (alg, value) = crypto::hash_preference(target_description.hashes())?;
+
+                        let reader: Box<dyn AsyncRead> = Box::new(SafeReader::new(
+                            cur,
+                            target_description.size(),
+                            min_bytes_per_second,
+                            Some((alg, value.clone())),
+                        )?);
+
+                        Ok(reader)
+                    }
+                    None => Err(Error::NotFound),
+                }
+            },
+        )
     }
 }
 
@@ -508,69 +568,81 @@ where
 mod test {
     use super::*;
     use crate::interchange::Json;
+    use futures::executor::block_on;
+    use futures::io::AsyncReadExt;
     use tempfile;
 
     #[test]
     fn ephemeral_repo_targets() {
-        let repo = EphemeralRepository::<Json>::new();
+        block_on(
+            async {
+                let repo = EphemeralRepository::<Json>::new();
 
-        let data: &[u8] = b"like tears in the rain";
-        let target_description =
-            TargetDescription::from_reader(data, &[HashAlgorithm::Sha256]).unwrap();
-        let path = TargetPath::new("batty".into()).unwrap();
-        repo.store_target(data, &path).unwrap();
+                let data: &[u8] = b"like tears in the rain";
+                let target_description =
+                    TargetDescription::from_reader(data, &[HashAlgorithm::Sha256]).unwrap();
+                let path = TargetPath::new("batty".into()).unwrap();
+                await!(repo.store_target(data, &path)).unwrap();
 
-        let mut read = repo.fetch_target(&path, &target_description, 0).unwrap();
-        let mut buf = Vec::new();
-        read.read_to_end(&mut buf).unwrap();
-        assert_eq!(buf.as_slice(), data);
+                let mut read = await!(repo.fetch_target(&path, &target_description, 0)).unwrap();
+                let mut buf = Vec::new();
+                await!(read.read_to_end(&mut buf)).unwrap();
+                assert_eq!(buf.as_slice(), data);
 
-        let bad_data: &[u8] = b"you're in a desert";
-        repo.store_target(bad_data, &path).unwrap();
-        let mut read = repo.fetch_target(&path, &target_description, 0).unwrap();
-        assert!(read.read_to_end(&mut buf).is_err());
+                let bad_data: &[u8] = b"you're in a desert";
+                await!(repo.store_target(bad_data, &path)).unwrap();
+                let mut read = await!(repo.fetch_target(&path, &target_description, 0)).unwrap();
+                assert!(await!(read.read_to_end(&mut buf)).is_err());
+            },
+        )
     }
 
     #[test]
     fn file_system_repo_targets() {
-        let temp_dir = tempfile::Builder::new()
-            .prefix("rust-tuf")
-            .tempdir()
-            .unwrap();
-        let repo = FileSystemRepository::<Json>::new(temp_dir.path().to_path_buf()).unwrap();
+        block_on(
+            async {
+                let temp_dir = tempfile::Builder::new()
+                    .prefix("rust-tuf")
+                    .tempdir()
+                    .unwrap();
+                let repo =
+                    FileSystemRepository::<Json>::new(temp_dir.path().to_path_buf()).unwrap();
 
-        // test that init worked
-        assert!(temp_dir.path().join("metadata").exists());
-        assert!(temp_dir.path().join("targets").exists());
-        assert!(temp_dir.path().join("temp").exists());
+                // test that init worked
+                assert!(temp_dir.path().join("metadata").exists());
+                assert!(temp_dir.path().join("targets").exists());
+                assert!(temp_dir.path().join("temp").exists());
 
-        let data: &[u8] = b"like tears in the rain";
-        let target_description =
-            TargetDescription::from_reader(data, &[HashAlgorithm::Sha256]).unwrap();
-        let path = TargetPath::new("foo/bar/baz".into()).unwrap();
-        repo.store_target(data, &path).unwrap();
-        assert!(temp_dir
-            .path()
-            .join("targets")
-            .join("foo")
-            .join("bar")
-            .join("baz")
-            .exists());
+                let data: &[u8] = b"like tears in the rain";
+                let target_description =
+                    TargetDescription::from_reader(data, &[HashAlgorithm::Sha256]).unwrap();
+                let path = TargetPath::new("foo/bar/baz".into()).unwrap();
+                await!(repo.store_target(data, &path)).unwrap();
+                assert!(temp_dir
+                    .path()
+                    .join("targets")
+                    .join("foo")
+                    .join("bar")
+                    .join("baz")
+                    .exists());
 
-        let mut buf = Vec::new();
+                let mut buf = Vec::new();
 
-        // Enclose `fetch_target` in a scope to make sure the file is closed.
-        // This is needed for `tempfile` on Windows, which doesn't open the
-        // files in a mode that allows the file to be opened multiple times.
-        {
-            let mut read = repo.fetch_target(&path, &target_description, 0).unwrap();
-            read.read_to_end(&mut buf).unwrap();
-            assert_eq!(buf.as_slice(), data);
-        }
+                // Enclose `fetch_target` in a scope to make sure the file is closed.
+                // This is needed for `tempfile` on Windows, which doesn't open the
+                // files in a mode that allows the file to be opened multiple times.
+                {
+                    let mut read =
+                        await!(repo.fetch_target(&path, &target_description, 0)).unwrap();
+                    await!(read.read_to_end(&mut buf)).unwrap();
+                    assert_eq!(buf.as_slice(), data);
+                }
 
-        let bad_data: &[u8] = b"you're in a desert";
-        repo.store_target(bad_data, &path).unwrap();
-        let mut read = repo.fetch_target(&path, &target_description, 0).unwrap();
-        assert!(read.read_to_end(&mut buf).is_err());
+                let bad_data: &[u8] = b"you're in a desert";
+                await!(repo.store_target(bad_data, &path)).unwrap();
+                let mut read = await!(repo.fetch_target(&path, &target_description, 0)).unwrap();
+                assert!(await!(read.read_to_end(&mut buf)).is_err());
+            },
+        )
     }
 }

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -1,6 +1,7 @@
 use chrono::offset::Utc;
 use chrono::prelude::*;
 use data_encoding::BASE64URL;
+use serde_derive::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::iter::FromIterator;
 

--- a/src/tuf.rs
+++ b/src/tuf.rs
@@ -1,6 +1,7 @@
 //! Components needed to verify TUF metadata and targets.
 
 use chrono::offset::Utc;
+use log::info;
 use std::collections::{HashMap, HashSet};
 use std::marker::PhantomData;
 
@@ -628,6 +629,7 @@ mod test {
         RootMetadataBuilder, SnapshotMetadataBuilder, TargetsMetadataBuilder,
         TimestampMetadataBuilder,
     };
+    use lazy_static::lazy_static;
 
     lazy_static! {
         static ref KEYS: Vec<PrivateKey> = {


### PR DESCRIPTION
This is an experiment on porting rust-tuf over to async/await, which is what we use on Fuchsia. This is in contrast with #151, which uses futures 0.1, which is compatible with stable rust, but dramatically more invasive of a change, which is why I haven't rebased it on top of remotes/origin/develop yet.
    
The downside of this is that landing this patch would make rust-tuf require nightly until async/await is stablized. Unfortunately there is no clear date on when that is going to occur.