### PR TITLE
Don't include the version of rust-tuf in the user agent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ dist: trusty
 language: rust
 cache: cargo
 rust:
-  - nightly
+  - nightly-2019-01-09
 
 env:
   global:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,11 +12,11 @@ environment:
   matrix:
     # Rust - Nightly
     - TARGET: i686-pc-windows-gnu
-      RUST_VERSION: nightly
+      RUST_VERSION: nightly-2019-01-09
       BITS: 32
       MSYS2: 1
     - TARGET: x86_64-pc-windows-msvc
-      RUST_VERSION: nightly
+      RUST_VERSION: nightly-2019-01-09
       BITS: 64
 
 install:

--- a/src/client.rs
+++ b/src/client.rs
@@ -33,7 +33,7 @@
 //!     url::Url::parse("https://static.rust-lang.org/").unwrap(),
 //!     HttpClient::new(),
 //! )
-//! .user_agent_prefix("rustup/1.4.0")
+//! .user_agent("rustup/1.4.0")
 //! .build();
 //!
 //! let mut client = await!(Client::with_root_pinned(

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -263,7 +263,7 @@ where
     url: Url,
     client: Client<C>,
     interchange: PhantomData<D>,
-    user_agent_prefix: Option<String>,
+    user_agent: Option<String>,
     metadata_prefix: Option<Vec<String>>,
     min_bytes_per_second: u32,
 }
@@ -279,7 +279,7 @@ where
             url: url,
             client: client,
             interchange: PhantomData,
-            user_agent_prefix: None,
+            user_agent: None,
             metadata_prefix: None,
             min_bytes_per_second: 4096,
         }
@@ -290,8 +290,8 @@ where
     /// Callers *should* include a custom User-Agent prefix to help maintainers of TUF repositories
     /// keep track of which client versions exist in the field.
     ///
-    pub fn user_agent_prefix<T: Into<String>>(mut self, user_agent_prefix: T) -> Self {
-        self.user_agent_prefix = Some(user_agent_prefix.into());
+    pub fn user_agent<T: Into<String>>(mut self, user_agent: T) -> Self {
+        self.user_agent = Some(user_agent.into());
         self
     }
 
@@ -313,9 +313,9 @@ where
 
     /// Build a `HttpRepository`.
     pub fn build(self) -> HttpRepository<C, D> {
-        let user_agent = match self.user_agent_prefix {
-            Some(ua) => format!("{} (rust-tuf/{})", ua, env!("CARGO_PKG_VERSION")),
-            None => format!("rust-tuf/{}", env!("CARGO_PKG_VERSION")),
+        let user_agent = match self.user_agent {
+            Some(user_agent) => user_agent,
+            None => "rust-tuf".into(),
         };
 
         HttpRepository {


### PR DESCRIPTION
The fuchsia build system does not use cargo to build libraries, and at
the moment it is unable to convey environment variables. As a stopgap,
this removes the use of `env!("CARGO_PKG_VERSION")` until we can add
support for this.