### PR TITLE
Upgrade to futures-preview 0.3.0-alpha.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,12 +25,13 @@ path = "./src/lib.rs"
 chrono = { version = "0.4", features = [ "serde" ] }
 data-encoding = "2.0.0-rc.2"
 derp = "0.0.11"
-futures-preview = { version = "=0.3.0-alpha.13", features = [ "compat" ] }
+futures-preview = { version = "=0.3.0-alpha.15", features = [ "compat" ] }
 http = "0.1"
 hyper = { version = "0.12", default-features = false }
 itoa = "0.4"
 log = "0.4"
 ring = { version = "0.14" }
+parking_lot = "0.7.1"
 serde = "1"
 serde_derive = "1"
 serde_json = "1"

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -6,7 +6,7 @@ use ring;
 use ring::digest::{self, SHA256, SHA512};
 use ring::rand::SystemRandom;
 use ring::signature::{
-    Ed25519KeyPair, RsaKeyPair, KeyPair, ED25519, RSA_PSS_2048_8192_SHA256,
+    Ed25519KeyPair, KeyPair, RsaKeyPair, ED25519, RSA_PSS_2048_8192_SHA256,
     RSA_PSS_2048_8192_SHA512, RSA_PSS_SHA256, RSA_PSS_SHA512,
 };
 use serde::de::{Deserialize, Deserializer, Error as DeserializeError};
@@ -68,9 +68,7 @@ pub fn calculate_hashes<R: Read>(
     hash_algs: &[HashAlgorithm],
 ) -> Result<(u64, HashMap<HashAlgorithm, HashValue>)> {
     if hash_algs.is_empty() {
-        return Err(Error::IllegalArgument(
-            "Cannot provide empty set of hash algorithms".into(),
-        ));
+        return Err(Error::IllegalArgument("Cannot provide empty set of hash algorithms".into()));
     }
 
     let mut size = 0;
@@ -80,10 +78,7 @@ pub fn calculate_hashes<R: Read>(
             HashAlgorithm::Sha256 => digest::Context::new(&SHA256),
             HashAlgorithm::Sha512 => digest::Context::new(&SHA512),
             HashAlgorithm::Unknown(ref s) => {
-                return Err(Error::IllegalArgument(format!(
-                    "Unknown hash algorithm: {}",
-                    s
-                )));
+                return Err(Error::IllegalArgument(format!("Unknown hash algorithm: {}", s)));
             }
         };
 
@@ -167,9 +162,7 @@ impl KeyId {
     /// Parse a key ID from a base64url string.
     pub fn from_string(string: &str) -> Result<Self> {
         if string.len() != 44 {
-            return Err(Error::IllegalArgument(
-                "Base64 key ID must be 44 characters long".into(),
-            ));
+            return Err(Error::IllegalArgument("Base64 key ID must be 44 characters long".into()));
         }
         Ok(KeyId(BASE64URL.decode(string.as_bytes())?))
     }
@@ -323,9 +316,7 @@ impl Serialize for KeyType {
 impl<'de> Deserialize<'de> for KeyType {
     fn deserialize<D: Deserializer<'de>>(de: D) -> ::std::result::Result<Self, D::Error> {
         let string: String = Deserialize::deserialize(de)?;
-        string
-            .parse()
-            .map_err(|e| DeserializeError::custom(format!("{:?}", e)))
+        string.parse().map_err(|e| DeserializeError::custom(format!("{:?}", e)))
     }
 }
 
@@ -474,16 +465,14 @@ impl PrivateKey {
             (&PrivateKeyType::Rsa(ref rsa), &SignatureScheme::RsaSsaPssSha256) => {
                 let rng = SystemRandom::new();
                 let mut buf = vec![0; rsa.public_modulus_len()];
-                rsa
-                    .sign(&RSA_PSS_SHA256, &rng, msg, &mut buf)
+                rsa.sign(&RSA_PSS_SHA256, &rng, msg, &mut buf)
                     .map_err(|_| Error::Opaque("Failed to sign message.".into()))?;
                 SignatureValue(buf)
             }
             (&PrivateKeyType::Rsa(ref rsa), &SignatureScheme::RsaSsaPssSha512) => {
                 let rng = SystemRandom::new();
                 let mut buf = vec![0; rsa.public_modulus_len()];
-                rsa
-                    .sign(&RSA_PSS_SHA512, &rng, msg, &mut buf)
+                rsa.sign(&RSA_PSS_SHA512, &rng, msg, &mut buf)
                     .map_err(|_| Error::Opaque("Failed to sign message.".into()))?;
                 SignatureValue(buf)
             }
@@ -498,10 +487,7 @@ impl PrivateKey {
             }
         };
 
-        Ok(Signature {
-            key_id: self.key_id().clone(),
-            value,
-        })
+        Ok(Signature { key_id: self.key_id().clone(), value })
     }
 
     fn rsa_gen() -> Result<Vec<u8>> {
@@ -520,9 +506,7 @@ impl PrivateKey {
             .output()?;
 
         let mut pk8 = Command::new("openssl")
-            .args(&[
-                "pkcs8", "-inform", "der", "-topk8", "-nocrypt", "-outform", "der",
-            ])
+            .args(&["pkcs8", "-inform", "der", "-topk8", "-nocrypt", "-outform", "der"])
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .spawn()?;
@@ -580,12 +564,7 @@ impl PublicKey {
         })?;
 
         let key_id = calculate_key_id(der_bytes);
-        Ok(PublicKey {
-            typ,
-            key_id,
-            scheme,
-            value: PublicKeyValue(value),
-        })
+        Ok(PublicKey { typ, key_id, scheme, value: PublicKeyValue(value) })
     }
 
     /// Write the public key as SPKI DER bytes.
@@ -617,10 +596,7 @@ impl PublicKey {
             SignatureScheme::RsaSsaPssSha256 => &RSA_PSS_2048_8192_SHA256,
             SignatureScheme::RsaSsaPssSha512 => &RSA_PSS_2048_8192_SHA512,
             SignatureScheme::Unknown(ref s) => {
-                return Err(Error::IllegalArgument(format!(
-                    "Unknown signature scheme: {}",
-                    s
-                )));
+                return Err(Error::IllegalArgument(format!("Unknown signature scheme: {}", s)));
             }
         };
 

--- a/src/interchange/cjson.rs
+++ b/src/interchange/cjson.rs
@@ -33,12 +33,12 @@ impl Value {
                 buf.extend(b"false");
                 Ok(())
             }
-            Value::Number(Number::I64(n)) => itoa::write(buf, n)
-                .map(|_| ())
-                .map_err(|err| format!("Write error: {}", err)),
-            Value::Number(Number::U64(n)) => itoa::write(buf, n)
-                .map(|_| ())
-                .map_err(|err| format!("Write error: {}", err)),
+            Value::Number(Number::I64(n)) => {
+                itoa::write(buf, n).map(|_| ()).map_err(|err| format!("Write error: {}", err))
+            }
+            Value::Number(Number::U64(n)) => {
+                itoa::write(buf, n).map(|_| ()).map_err(|err| format!("Write error: {}", err))
+            }
             Value::String(ref s) => {
                 // this mess is abusing serde_json to get json escaping
                 let s = serde_json::Value::String(s.clone());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,7 @@
     clippy::op_ref,
     clippy::too_many_arguments
 )]
-#![feature(async_await, await_macro, futures_api)]
+#![feature(async_await, await_macro)]
 
 pub mod client;
 pub mod crypto;
@@ -127,6 +127,3 @@ pub use crate::tuf::*;
 
 /// Alias for `Result<T, Error>`.
 pub type Result<T> = std::result::Result<T, Error>;
-
-/// Alias for `Pin<Box<dyn Future<Output = T> + 'a>>`.
-pub type TufFuture<'a, T> = std::pin::Pin<Box<dyn futures::Future<Output = T> + 'a>>;

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -113,10 +113,7 @@ fn safe_path(path: &str) -> Result<()> {
 
     for bad_str in PATH_ILLEGAL_STRINGS {
         if path.contains(bad_str) {
-            return Err(Error::IllegalArgument(format!(
-                "Path cannot contain {:?}",
-                bad_str
-            )));
+            return Err(Error::IllegalArgument(format!("Path cannot contain {:?}", bad_str)));
         }
     }
 
@@ -273,11 +270,7 @@ where
         let raw = D::serialize(&metadata)?;
         let bytes = D::canonicalize(&raw)?;
         let sig = private_key.sign(&bytes)?;
-        Ok(SignedMetadata {
-            signatures: vec![sig],
-            metadata,
-            _interchage: PhantomData,
-        })
+        Ok(SignedMetadata { signatures: vec![sig], metadata, _interchage: PhantomData })
     }
 
     /// Append a signature to this signed metadata. Will overwrite signature by keys with the same
@@ -317,8 +310,7 @@ where
         let raw = D::serialize(&self.metadata)?;
         let bytes = D::canonicalize(&raw)?;
         let sig = private_key.sign(&bytes)?;
-        self.signatures
-            .retain(|s| s.key_id() != private_key.key_id());
+        self.signatures.retain(|s| s.key_id() != private_key.key_id());
         self.signatures.push(sig);
         Ok(())
     }
@@ -328,24 +320,14 @@ where
     /// key ID, then the signatures from `self` will replace the signatures from `other`.
     pub fn merge_signatures(&mut self, other: &Self) -> Result<()> {
         if self.metadata != other.metadata {
-            return Err(Error::IllegalArgument(
-                "Attempted to merge unequal metadata".into(),
-            ));
+            return Err(Error::IllegalArgument("Attempted to merge unequal metadata".into()));
         }
 
-        let key_ids = self
-            .signatures
-            .iter()
-            .map(|s| s.key_id().clone())
-            .collect::<HashSet<KeyId>>();
+        let key_ids =
+            self.signatures.iter().map(|s| s.key_id().clone()).collect::<HashSet<KeyId>>();
 
-        self.signatures.extend(
-            other
-                .signatures
-                .iter()
-                .filter(|s| !key_ids.contains(s.key_id()))
-                .cloned(),
-        );
+        self.signatures
+            .extend(other.signatures.iter().filter(|s| !key_ids.contains(s.key_id())).cloned());
 
         Ok(())
     }
@@ -437,10 +419,7 @@ where
                     }
                 },
                 None => {
-                    warn!(
-                        "Key ID {:?} was not found in the set of authorized keys.",
-                        sig.key_id()
-                    );
+                    warn!("Key ID {:?} was not found in the set of authorized keys.", sig.key_id());
                 }
             }
             if signatures_needed == 0 {
@@ -746,9 +725,7 @@ impl Serialize for RootMetadata {
 impl<'de> Deserialize<'de> for RootMetadata {
     fn deserialize<D: Deserializer<'de>>(de: D) -> ::std::result::Result<Self, D::Error> {
         let intermediate: shims::RootMetadata = Deserialize::deserialize(de)?;
-        intermediate
-            .try_into()
-            .map_err(|e| DeserializeError::custom(format!("{:?}", e)))
+        intermediate.try_into().map_err(|e| DeserializeError::custom(format!("{:?}", e)))
     }
 }
 
@@ -808,9 +785,7 @@ impl Serialize for RoleDefinition {
 impl<'de> Deserialize<'de> for RoleDefinition {
     fn deserialize<D: Deserializer<'de>>(de: D) -> ::std::result::Result<Self, D::Error> {
         let intermediate: shims::RoleDefinition = Deserialize::deserialize(de)?;
-        intermediate
-            .try_into()
-            .map_err(|e| DeserializeError::custom(format!("{:?}", e)))
+        intermediate.try_into().map_err(|e| DeserializeError::custom(format!("{:?}", e)))
     }
 }
 
@@ -995,11 +970,7 @@ impl TimestampMetadata {
             )));
         }
 
-        Ok(TimestampMetadata {
-            version,
-            expires,
-            snapshot,
-        })
+        Ok(TimestampMetadata { version, expires, snapshot })
     }
 
     /// An immutable reference to the snapshot description.
@@ -1034,9 +1005,7 @@ impl Serialize for TimestampMetadata {
 impl<'de> Deserialize<'de> for TimestampMetadata {
     fn deserialize<D: Deserializer<'de>>(de: D) -> ::std::result::Result<Self, D::Error> {
         let intermediate: shims::TimestampMetadata = Deserialize::deserialize(de)?;
-        intermediate
-            .try_into()
-            .map_err(|e| DeserializeError::custom(format!("{:?}", e)))
+        intermediate.try_into().map_err(|e| DeserializeError::custom(format!("{:?}", e)))
     }
 }
 
@@ -1056,24 +1025,16 @@ impl MetadataDescription {
         hash_algs: &[HashAlgorithm],
     ) -> Result<Self> {
         if version < 1 {
-            return Err(Error::IllegalArgument(
-                "Version must be greater than zero".into(),
-            ));
+            return Err(Error::IllegalArgument("Version must be greater than zero".into()));
         }
 
         let (length, hashes) = crypto::calculate_hashes(read, hash_algs)?;
 
         if length > ::std::usize::MAX as u64 {
-            return Err(Error::IllegalArgument(
-                "Calculated length exceeded usize".into(),
-            ));
+            return Err(Error::IllegalArgument("Calculated length exceeded usize".into()));
         }
 
-        Ok(MetadataDescription {
-            version,
-            length: length as usize,
-            hashes,
-        })
+        Ok(MetadataDescription { version, length: length as usize, hashes })
     }
 
     /// Create a new `MetadataDescription`.
@@ -1090,16 +1051,10 @@ impl MetadataDescription {
         }
 
         if hashes.is_empty() {
-            return Err(Error::IllegalArgument(
-                "Cannot have empty set of hashes".into(),
-            ));
+            return Err(Error::IllegalArgument("Cannot have empty set of hashes".into()));
         }
 
-        Ok(MetadataDescription {
-            version,
-            length,
-            hashes,
-        })
+        Ok(MetadataDescription { version, length, hashes })
     }
 
     /// The version of the described metadata.
@@ -1121,9 +1076,7 @@ impl MetadataDescription {
 impl<'de> Deserialize<'de> for MetadataDescription {
     fn deserialize<D: Deserializer<'de>>(de: D) -> ::std::result::Result<Self, D::Error> {
         let intermediate: shims::MetadataDescription = Deserialize::deserialize(de)?;
-        intermediate
-            .try_into()
-            .map_err(|e| DeserializeError::custom(format!("{:?}", e)))
+        intermediate.try_into().map_err(|e| DeserializeError::custom(format!("{:?}", e)))
     }
 }
 
@@ -1222,11 +1175,7 @@ impl Default for SnapshotMetadataBuilder {
 
 impl From<SnapshotMetadata> for SnapshotMetadataBuilder {
     fn from(meta: SnapshotMetadata) -> Self {
-        SnapshotMetadataBuilder {
-            version: meta.version,
-            expires: meta.expires,
-            meta: meta.meta,
-        }
+        SnapshotMetadataBuilder { version: meta.version, expires: meta.expires, meta: meta.meta }
     }
 }
 
@@ -1252,11 +1201,7 @@ impl SnapshotMetadata {
             )));
         }
 
-        Ok(SnapshotMetadata {
-            version,
-            expires,
-            meta,
-        })
+        Ok(SnapshotMetadata { version, expires, meta })
     }
 
     /// An immutable reference to the metadata paths and descriptions.
@@ -1291,9 +1236,7 @@ impl Serialize for SnapshotMetadata {
 impl<'de> Deserialize<'de> for SnapshotMetadata {
     fn deserialize<D: Deserializer<'de>>(de: D) -> ::std::result::Result<Self, D::Error> {
         let intermediate: shims::SnapshotMetadata = Deserialize::deserialize(de)?;
-        intermediate
-            .try_into()
-            .map_err(|e| DeserializeError::custom(format!("{:?}", e)))
+        intermediate.try_into().map_err(|e| DeserializeError::custom(format!("{:?}", e)))
     }
 }
 
@@ -1376,11 +1319,7 @@ impl VirtualTargetPath {
             .map(|group| {
                 group
                     .iter()
-                    .filter(|parent| {
-                        parents[0]
-                            .iter()
-                            .any(|p| parent.is_child(p) || parent == &p)
-                    })
+                    .filter(|parent| parents[0].iter().any(|p| parent.is_child(p) || parent == &p))
                     .cloned()
                     .collect::<HashSet<_>>()
             })
@@ -1450,9 +1389,7 @@ impl TargetDescription {
     /// preferred.
     pub fn new(length: u64, hashes: HashMap<HashAlgorithm, HashValue>) -> Result<Self> {
         if hashes.is_empty() {
-            return Err(Error::IllegalArgument(
-                "Cannot have empty set of hashes".into(),
-            ));
+            return Err(Error::IllegalArgument("Cannot have empty set of hashes".into()));
         }
 
         Ok(TargetDescription { length, hashes })
@@ -1508,9 +1445,7 @@ impl TargetDescription {
 impl<'de> Deserialize<'de> for TargetDescription {
     fn deserialize<D: Deserializer<'de>>(de: D) -> ::std::result::Result<Self, D::Error> {
         let intermediate: shims::TargetDescription = Deserialize::deserialize(de)?;
-        intermediate
-            .try_into()
-            .map_err(|e| DeserializeError::custom(format!("{:?}", e)))
+        intermediate.try_into().map_err(|e| DeserializeError::custom(format!("{:?}", e)))
     }
 }
 
@@ -1538,12 +1473,7 @@ impl TargetsMetadata {
             )));
         }
 
-        Ok(TargetsMetadata {
-            version,
-            expires,
-            targets,
-            delegations,
-        })
+        Ok(TargetsMetadata { version, expires, targets, delegations })
     }
 
     /// An immutable reference to the descriptions of targets.
@@ -1583,9 +1513,7 @@ impl Serialize for TargetsMetadata {
 impl<'de> Deserialize<'de> for TargetsMetadata {
     fn deserialize<D: Deserializer<'de>>(de: D) -> ::std::result::Result<Self, D::Error> {
         let intermediate: shims::TargetsMetadata = Deserialize::deserialize(de)?;
-        intermediate
-            .try_into()
-            .map_err(|e| DeserializeError::custom(format!("{:?}", e)))
+        intermediate.try_into().map_err(|e| DeserializeError::custom(format!("{:?}", e)))
     }
 }
 
@@ -1693,24 +1621,14 @@ impl Delegations {
             return Err(Error::IllegalArgument("Roles cannot be empty.".into()));
         }
 
-        if roles.len()
-            != roles
-                .iter()
-                .map(|r| &r.role)
-                .collect::<HashSet<&MetadataPath>>()
-                .len()
-        {
+        if roles.len() != roles.iter().map(|r| &r.role).collect::<HashSet<&MetadataPath>>().len() {
             return Err(Error::IllegalArgument(
                 "Cannot have duplicated roles in delegations.".into(),
             ));
         }
 
         Ok(Delegations {
-            keys: keys
-                .iter()
-                .cloned()
-                .map(|k| (k.key_id().clone(), k))
-                .collect(),
+            keys: keys.iter().cloned().map(|k| (k.key_id().clone(), k)).collect(),
             roles,
         })
     }
@@ -1738,9 +1656,7 @@ impl Serialize for Delegations {
 impl<'de> Deserialize<'de> for Delegations {
     fn deserialize<D: Deserializer<'de>>(de: D) -> ::std::result::Result<Self, D::Error> {
         let intermediate: shims::Delegations = Deserialize::deserialize(de)?;
-        intermediate
-            .try_into()
-            .map_err(|e| DeserializeError::custom(format!("{:?}", e)))
+        intermediate.try_into().map_err(|e| DeserializeError::custom(format!("{:?}", e)))
     }
 }
 
@@ -1781,13 +1697,7 @@ impl Delegation {
             ));
         }
 
-        Ok(Delegation {
-            role,
-            terminating,
-            threshold,
-            key_ids,
-            paths,
-        })
+        Ok(Delegation { role, terminating, threshold, key_ids, paths })
     }
 
     /// An immutable reference to the delegations's metadata path (role).
@@ -1828,9 +1738,7 @@ impl Serialize for Delegation {
 impl<'de> Deserialize<'de> for Delegation {
     fn deserialize<D: Deserializer<'de>>(de: D) -> ::std::result::Result<Self, D::Error> {
         let intermediate: shims::Delegation = Deserialize::deserialize(de)?;
-        intermediate
-            .try_into()
-            .map_err(|e| DeserializeError::custom(format!("{:?}", e)))
+        intermediate.try_into().map_err(|e| DeserializeError::custom(format!("{:?}", e)))
     }
 }
 
@@ -1850,13 +1758,7 @@ mod test {
 
     #[test]
     fn no_pardir_in_target_path() {
-        let bad_paths = &[
-            "..",
-            "../some/path",
-            "../some/path/",
-            "some/../path",
-            "some/../path/..",
-        ];
+        let bad_paths = &["..", "../some/path", "../some/path/", "some/../path", "some/../path/.."];
 
         for path in bad_paths.iter() {
             assert!(safe_path(*path).is_err());
@@ -1882,11 +1784,7 @@ mod test {
             // target illegally nested
             (false, "foo/bar", &[&["baz/"], &["foo/bar"]]),
             // target illegally deeply nested
-            (
-                false,
-                "foo/bar/baz",
-                &[&["foo/"], &["foo/quux/"], &["foo/bar/baz"]],
-            ),
+            (false, "foo/bar/baz", &[&["foo/"], &["foo/quux/"], &["foo/bar/baz"]]),
             // empty
             (false, "foo", &[&[]]),
             // empty 2
@@ -1908,10 +1806,7 @@ mod test {
                         .collect::<HashSet<_>>()
                 })
                 .collect::<Vec<_>>();
-            println!(
-                "CASE: expect: {} path: {:?} parents: {:?}",
-                expected, target, parents
-            );
+            println!("CASE: expect: {} path: {:?} parents: {:?}", expected, target, parents);
             assert_eq!(target.matches_chain(&parents), expected);
         }
     }
@@ -2402,14 +2297,8 @@ mod test {
     #[test]
     fn deserialize_json_root_duplicate_keys() {
         let mut root_json = make_root();
-        let dupe = root_json
-            .as_object()
-            .unwrap()
-            .get("keys")
-            .unwrap()
-            .as_array()
-            .unwrap()[0]
-            .clone();
+        let dupe =
+            root_json.as_object().unwrap().get("keys").unwrap().as_array().unwrap()[0].clone();
         root_json
             .as_object_mut()
             .unwrap()
@@ -2435,12 +2324,10 @@ mod test {
     fn deserialize_json_role_definition_illegal_threshold() {
         let role_def = RoleDefinition::new(
             1,
-            hashset!(
-                PrivateKey::from_pkcs8(ED25519_1_PK8, SignatureScheme::Ed25519)
-                    .unwrap()
-                    .key_id()
-                    .clone()
-            ),
+            hashset!(PrivateKey::from_pkcs8(ED25519_1_PK8, SignatureScheme::Ed25519)
+                .unwrap()
+                .key_id()
+                .clone()),
         )
         .unwrap();
 
@@ -2476,10 +2363,7 @@ mod test {
     #[test]
     fn deserialize_json_root_bad_type() {
         let mut root = make_root();
-        let _ = root
-            .as_object_mut()
-            .unwrap()
-            .insert("type".into(), json!("snapshot"));
+        let _ = root.as_object_mut().unwrap().insert("type".into(), json!("snapshot"));
         assert!(serde_json::from_value::<RootMetadata>(root).is_err());
     }
 
@@ -2520,10 +2404,7 @@ mod test {
     #[test]
     fn deserialize_json_snapshot_bad_type() {
         let mut snapshot = make_snapshot();
-        let _ = snapshot
-            .as_object_mut()
-            .unwrap()
-            .insert("type".into(), json!("root"));
+        let _ = snapshot.as_object_mut().unwrap().insert("type".into(), json!("root"));
         assert!(serde_json::from_value::<SnapshotMetadata>(snapshot).is_err());
     }
 
@@ -2543,10 +2424,7 @@ mod test {
     #[test]
     fn deserialize_json_timestamp_bad_type() {
         let mut timestamp = make_timestamp();
-        let _ = timestamp
-            .as_object_mut()
-            .unwrap()
-            .insert("type".into(), json!("root"));
+        let _ = timestamp.as_object_mut().unwrap().insert("type".into(), json!("root"));
         assert!(serde_json::from_value::<TimestampMetadata>(timestamp).is_err());
     }
 
@@ -2566,10 +2444,7 @@ mod test {
     #[test]
     fn deserialize_json_targets_bad_type() {
         let mut targets = make_targets();
-        let _ = targets
-            .as_object_mut()
-            .unwrap()
-            .insert("type".into(), json!("root"));
+        let _ = targets.as_object_mut().unwrap().insert("type".into(), json!("root"));
         assert!(serde_json::from_value::<TargetsMetadata>(targets).is_err());
     }
 
@@ -2607,14 +2482,9 @@ mod test {
     #[test]
     fn deserialize_json_delegations_duplicated_roles() {
         let mut delegations = make_delegations();
-        let dupe = delegations
-            .as_object()
-            .unwrap()
-            .get("roles".into())
-            .unwrap()
-            .as_array()
-            .unwrap()[0]
-            .clone();
+        let dupe =
+            delegations.as_object().unwrap().get("roles".into()).unwrap().as_array().unwrap()[0]
+                .clone();
         delegations
             .as_object_mut()
             .unwrap()
@@ -2642,14 +2512,9 @@ mod test {
     #[test]
     fn deserialize_json_delegation_duplicate_key_ids() {
         let mut delegation = make_delegation();
-        let dupe = delegation
-            .as_object()
-            .unwrap()
-            .get("key_ids".into())
-            .unwrap()
-            .as_array()
-            .unwrap()[0]
-            .clone();
+        let dupe =
+            delegation.as_object().unwrap().get("key_ids".into()).unwrap().as_array().unwrap()[0]
+                .clone();
         delegation
             .as_object_mut()
             .unwrap()
@@ -2665,14 +2530,9 @@ mod test {
     #[test]
     fn deserialize_json_delegation_duplicate_paths() {
         let mut delegation = make_delegation();
-        let dupe = delegation
-            .as_object()
-            .unwrap()
-            .get("paths".into())
-            .unwrap()
-            .as_array()
-            .unwrap()[0]
-            .clone();
+        let dupe = delegation.as_object().unwrap().get("paths".into()).unwrap().as_array().unwrap()
+            [0]
+        .clone();
         delegation
             .as_object_mut()
             .unwrap()
@@ -2705,14 +2565,9 @@ mod test {
         .unwrap();
         let mut delegations = serde_json::to_value(delegations).unwrap();
 
-        let dupe = delegations
-            .as_object()
-            .unwrap()
-            .get("keys".into())
-            .unwrap()
-            .as_array()
-            .unwrap()[0]
-            .clone();
+        let dupe = delegations.as_object().unwrap().get("keys".into()).unwrap().as_array().unwrap()
+            [0]
+        .clone();
         delegations
             .as_object_mut()
             .unwrap()

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -40,11 +40,8 @@ pub struct RootMetadata {
 
 impl RootMetadata {
     pub fn from(meta: &metadata::RootMetadata) -> Result<Self> {
-        let mut keys = meta
-            .keys()
-            .iter()
-            .map(|(_, v)| v.clone())
-            .collect::<Vec<crypto::PublicKey>>();
+        let mut keys =
+            meta.keys().iter().map(|(_, v)| v.clone()).collect::<Vec<crypto::PublicKey>>();
         keys.sort_by_key(|k| k.key_id().clone());
 
         Ok(RootMetadata {
@@ -106,35 +103,23 @@ pub struct RoleDefinition {
 
 impl RoleDefinition {
     pub fn from(role: &metadata::RoleDefinition) -> Result<Self> {
-        let mut key_ids = role
-            .key_ids()
-            .iter()
-            .cloned()
-            .collect::<Vec<crypto::KeyId>>();
+        let mut key_ids = role.key_ids().iter().cloned().collect::<Vec<crypto::KeyId>>();
         key_ids.sort();
 
-        Ok(RoleDefinition {
-            threshold: role.threshold(),
-            key_ids,
-        })
+        Ok(RoleDefinition { threshold: role.threshold(), key_ids })
     }
 
     pub fn try_into(mut self) -> Result<metadata::RoleDefinition> {
         let vec_len = self.key_ids.len();
         if vec_len < 1 {
-            return Err(Error::Encoding(
-                "Role defined with no assoiciated key IDs.".into(),
-            ));
+            return Err(Error::Encoding("Role defined with no assoiciated key IDs.".into()));
         }
 
         let key_ids = self.key_ids.drain(0..).collect::<HashSet<crypto::KeyId>>();
         let dupes = vec_len - key_ids.len();
 
         if dupes != 0 {
-            return Err(Error::Encoding(format!(
-                "Found {} duplicate key IDs.",
-                dupes
-            )));
+            return Err(Error::Encoding(format!("Found {} duplicate key IDs.", dupes)));
         }
 
         Ok(metadata::RoleDefinition::new(self.threshold, key_ids)?)
@@ -260,11 +245,7 @@ impl PublicKey {
         scheme: crypto::SignatureScheme,
         public_key_bytes: &[u8],
     ) -> Self {
-        PublicKey {
-            typ,
-            scheme,
-            public_key: BASE64URL.encode(public_key_bytes),
-        }
+        PublicKey { typ, scheme, public_key: BASE64URL.encode(public_key_bytes) }
     }
 
     pub fn public_key(&self) -> &String {
@@ -291,17 +272,9 @@ pub struct Delegation {
 
 impl Delegation {
     pub fn from(meta: &metadata::Delegation) -> Self {
-        let mut paths = meta
-            .paths()
-            .iter()
-            .cloned()
-            .collect::<Vec<metadata::VirtualTargetPath>>();
+        let mut paths = meta.paths().iter().cloned().collect::<Vec<metadata::VirtualTargetPath>>();
         paths.sort();
-        let mut key_ids = meta
-            .key_ids()
-            .iter()
-            .cloned()
-            .collect::<Vec<crypto::KeyId>>();
+        let mut key_ids = meta.key_ids().iter().cloned().collect::<Vec<crypto::KeyId>>();
         key_ids.sort();
 
         Delegation {
@@ -314,20 +287,12 @@ impl Delegation {
     }
 
     pub fn try_into(self) -> Result<metadata::Delegation> {
-        let paths = self
-            .paths
-            .iter()
-            .cloned()
-            .collect::<HashSet<metadata::VirtualTargetPath>>();
+        let paths = self.paths.iter().cloned().collect::<HashSet<metadata::VirtualTargetPath>>();
         if paths.len() != self.paths.len() {
             return Err(Error::Encoding("Non-unique delegation paths.".into()));
         }
 
-        let key_ids = self
-            .key_ids
-            .iter()
-            .cloned()
-            .collect::<HashSet<crypto::KeyId>>();
+        let key_ids = self.key_ids.iter().cloned().collect::<HashSet<crypto::KeyId>>();
         if key_ids.len() != self.key_ids.len() {
             return Err(Error::Encoding("Non-unique delegation key IDs.".into()));
         }
@@ -344,17 +309,11 @@ pub struct Delegations {
 
 impl Delegations {
     pub fn from(delegations: &metadata::Delegations) -> Delegations {
-        let mut keys = delegations
-            .keys()
-            .iter()
-            .map(|(_, k)| k.clone())
-            .collect::<Vec<crypto::PublicKey>>();
+        let mut keys =
+            delegations.keys().iter().map(|(_, k)| k.clone()).collect::<Vec<crypto::PublicKey>>();
         keys.sort();
 
-        Delegations {
-            keys,
-            roles: delegations.roles().clone(),
-        }
+        Delegations { keys, roles: delegations.roles().clone() }
     }
 
     pub fn try_into(mut self) -> Result<metadata::Delegations> {

--- a/src/tuf.rs
+++ b/src/tuf.rs
@@ -37,9 +37,7 @@ impl<D: DataInterchange> Tuf<D> {
     {
         let root_key_ids = root_key_ids.into_iter().collect::<HashSet<&KeyId>>();
 
-        signed_root
-            .signatures_mut()
-            .retain(|s| root_key_ids.contains(s.key_id()));
+        signed_root.signatures_mut().retain(|s| root_key_ids.contains(s.key_id()));
         Self::from_root(signed_root)
     }
 
@@ -117,31 +115,19 @@ impl<D: DataInterchange> Tuf<D> {
     }
 
     fn current_timestamp_version(&self) -> u32 {
-        self.timestamp
-            .as_ref()
-            .map(|t| t.as_ref().version())
-            .unwrap_or(0)
+        self.timestamp.as_ref().map(|t| t.as_ref().version()).unwrap_or(0)
     }
 
     fn current_snapshot_version(&self) -> u32 {
-        self.snapshot
-            .as_ref()
-            .map(|t| t.as_ref().version())
-            .unwrap_or(0)
+        self.snapshot.as_ref().map(|t| t.as_ref().version()).unwrap_or(0)
     }
 
     fn current_targets_version(&self) -> u32 {
-        self.targets
-            .as_ref()
-            .map(|t| t.as_ref().version())
-            .unwrap_or(0)
+        self.targets.as_ref().map(|t| t.as_ref().version()).unwrap_or(0)
     }
 
     fn current_delegation_version(&self, role: &MetadataPath) -> u32 {
-        self.delegations
-            .get(role)
-            .map(|t| t.as_ref().version())
-            .unwrap_or(0)
+        self.delegations.get(role).map(|t| t.as_ref().version()).unwrap_or(0)
     }
 
     /// Verify and update the root metadata.
@@ -290,11 +276,7 @@ impl<D: DataInterchange> Tuf<D> {
             // regardless so we can prevent rollback attacks againsts targets/delegations.
         };
 
-        if self
-            .targets
-            .as_ref()
-            .map(|s| s.as_ref().version())
-            .unwrap_or(0)
+        if self.targets.as_ref().map(|s| s.as_ref().version()).unwrap_or(0)
             != signed_snapshot
                 .as_ref()
                 .meta()
@@ -345,10 +327,8 @@ impl<D: DataInterchange> Tuf<D> {
         {
             let root = self.safe_root_ref()?;
             let snapshot = self.safe_snapshot_ref()?;
-            let targets_description = snapshot
-                .meta()
-                .get(&MetadataPath::from_role(&Role::Targets))
-                .ok_or_else(|| {
+            let targets_description =
+                snapshot.meta().get(&MetadataPath::from_role(&Role::Targets)).ok_or_else(|| {
                     Error::VerificationFailure(
                         "Snapshot metadata had no description of the targets metadata".into(),
                     )
@@ -410,9 +390,7 @@ impl<D: DataInterchange> Tuf<D> {
             let targets_delegations = match targets.delegations() {
                 Some(d) => d,
                 None => {
-                    return Err(Error::VerificationFailure(
-                        "Delegations not authorized".into(),
-                    ));
+                    return Err(Error::VerificationFailure("Delegations not authorized".into()));
                 }
             };
 
@@ -739,9 +717,7 @@ mod test {
 
         let mut tuf = Tuf::from_root(root).unwrap();
 
-        let snapshot = SnapshotMetadataBuilder::new()
-            .signed::<Json>(&KEYS[1])
-            .unwrap();
+        let snapshot = SnapshotMetadataBuilder::new().signed::<Json>(&KEYS[1]).unwrap();
 
         let timestamp =
             TimestampMetadataBuilder::from_snapshot(&snapshot, &[HashAlgorithm::Sha256])
@@ -767,9 +743,7 @@ mod test {
 
         let mut tuf = Tuf::from_root(root).unwrap();
 
-        let snapshot = SnapshotMetadataBuilder::new()
-            .signed::<Json>(&KEYS[1])
-            .unwrap();
+        let snapshot = SnapshotMetadataBuilder::new().signed::<Json>(&KEYS[1]).unwrap();
 
         let timestamp =
             TimestampMetadataBuilder::from_snapshot(&snapshot, &[HashAlgorithm::Sha256])
@@ -821,9 +795,7 @@ mod test {
 
         let mut tuf = Tuf::from_root(root).unwrap();
 
-        let snapshot = SnapshotMetadataBuilder::new()
-            .signed::<Json>(&KEYS[2])
-            .unwrap();
+        let snapshot = SnapshotMetadataBuilder::new().signed::<Json>(&KEYS[2]).unwrap();
 
         let timestamp =
             TimestampMetadataBuilder::from_snapshot(&snapshot, &[HashAlgorithm::Sha256])
@@ -849,10 +821,7 @@ mod test {
 
         let mut tuf = Tuf::from_root(root).unwrap();
 
-        let snapshot = SnapshotMetadataBuilder::new()
-            .version(2)
-            .signed::<Json>(&KEYS[2])
-            .unwrap();
+        let snapshot = SnapshotMetadataBuilder::new().version(2).signed::<Json>(&KEYS[2]).unwrap();
 
         let timestamp =
             TimestampMetadataBuilder::from_snapshot(&snapshot, &[HashAlgorithm::Sha256])
@@ -862,10 +831,7 @@ mod test {
 
         tuf.update_timestamp(timestamp).unwrap();
 
-        let snapshot = SnapshotMetadataBuilder::new()
-            .version(1)
-            .signed::<Json>(&KEYS[1])
-            .unwrap();
+        let snapshot = SnapshotMetadataBuilder::new().version(1).signed::<Json>(&KEYS[1]).unwrap();
 
         assert!(tuf.update_snapshot(snapshot).is_err());
     }
@@ -880,9 +846,7 @@ mod test {
             .signed::<Json>(&KEYS[0])
             .unwrap();
 
-        let targets = TargetsMetadataBuilder::new()
-            .signed::<Json>(&KEYS[2])
-            .unwrap();
+        let targets = TargetsMetadataBuilder::new().signed::<Json>(&KEYS[2]).unwrap();
 
         let snapshot = SnapshotMetadataBuilder::new()
             .insert_metadata(&targets, &[HashAlgorithm::Sha256])
@@ -954,10 +918,7 @@ mod test {
 
         let mut tuf = Tuf::from_root(root).unwrap();
 
-        let targets = TargetsMetadataBuilder::new()
-            .version(2)
-            .signed::<Json>(&KEYS[2])
-            .unwrap();
+        let targets = TargetsMetadataBuilder::new().version(2).signed::<Json>(&KEYS[2]).unwrap();
 
         let snapshot = SnapshotMetadataBuilder::new()
             .insert_metadata(&targets, &[HashAlgorithm::Sha256])
@@ -974,10 +935,7 @@ mod test {
         tuf.update_timestamp(timestamp).unwrap();
         tuf.update_snapshot(snapshot).unwrap();
 
-        let targets = TargetsMetadataBuilder::new()
-            .version(1)
-            .signed::<Json>(&KEYS[2])
-            .unwrap();
+        let targets = TargetsMetadataBuilder::new().version(1).signed::<Json>(&KEYS[2]).unwrap();
 
         assert!(tuf.update_targets(targets).is_err());
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -131,152 +131,134 @@ mod test {
 
     #[test]
     fn valid_read() {
-        block_on(
-            async {
-                let bytes: &[u8] = &[0x00, 0x01, 0x02, 0x03];
-                let mut reader = SafeReader::new(bytes, bytes.len() as u64, 0, None).unwrap();
-                let mut buf = Vec::new();
-                assert!(await!(reader.read_to_end(&mut buf)).is_ok());
-                assert_eq!(buf, bytes);
-            },
-        )
+        block_on(async {
+            let bytes: &[u8] = &[0x00, 0x01, 0x02, 0x03];
+            let mut reader = SafeReader::new(bytes, bytes.len() as u64, 0, None).unwrap();
+            let mut buf = Vec::new();
+            assert!(await!(reader.read_to_end(&mut buf)).is_ok());
+            assert_eq!(buf, bytes);
+        })
     }
 
     #[test]
     fn valid_read_large_data() {
-        block_on(
-            async {
-                let bytes: &[u8] = &[0x00; 64 * 1024];
-                let mut reader = SafeReader::new(bytes, bytes.len() as u64, 0, None).unwrap();
-                let mut buf = Vec::new();
-                assert!(await!(reader.read_to_end(&mut buf)).is_ok());
-                assert_eq!(buf, bytes);
-            },
-        )
+        block_on(async {
+            let bytes: &[u8] = &[0x00; 64 * 1024];
+            let mut reader = SafeReader::new(bytes, bytes.len() as u64, 0, None).unwrap();
+            let mut buf = Vec::new();
+            assert!(await!(reader.read_to_end(&mut buf)).is_ok());
+            assert_eq!(buf, bytes);
+        })
     }
 
     #[test]
     fn valid_read_below_max_size() {
-        block_on(
-            async {
-                let bytes: &[u8] = &[0x00, 0x01, 0x02, 0x03];
-                let mut reader = SafeReader::new(bytes, (bytes.len() as u64) + 1, 0, None).unwrap();
-                let mut buf = Vec::new();
-                assert!(await!(reader.read_to_end(&mut buf)).is_ok());
-                assert_eq!(buf, bytes);
-            },
-        )
+        block_on(async {
+            let bytes: &[u8] = &[0x00, 0x01, 0x02, 0x03];
+            let mut reader = SafeReader::new(bytes, (bytes.len() as u64) + 1, 0, None).unwrap();
+            let mut buf = Vec::new();
+            assert!(await!(reader.read_to_end(&mut buf)).is_ok());
+            assert_eq!(buf, bytes);
+        })
     }
 
     #[test]
     fn invalid_read_above_max_size() {
-        block_on(
-            async {
-                let bytes: &[u8] = &[0x00, 0x01, 0x02, 0x03];
-                let mut reader = SafeReader::new(bytes, (bytes.len() as u64) - 1, 0, None).unwrap();
-                let mut buf = Vec::new();
-                assert!(await!(reader.read_to_end(&mut buf)).is_err());
-            },
-        )
+        block_on(async {
+            let bytes: &[u8] = &[0x00, 0x01, 0x02, 0x03];
+            let mut reader = SafeReader::new(bytes, (bytes.len() as u64) - 1, 0, None).unwrap();
+            let mut buf = Vec::new();
+            assert!(await!(reader.read_to_end(&mut buf)).is_err());
+        })
     }
 
     #[test]
     fn invalid_read_above_max_size_large_data() {
-        block_on(
-            async {
-                let bytes: &[u8] = &[0x00; 64 * 1024];
-                let mut reader = SafeReader::new(bytes, (bytes.len() as u64) - 1, 0, None).unwrap();
-                let mut buf = Vec::new();
-                assert!(await!(reader.read_to_end(&mut buf)).is_err());
-            },
-        )
+        block_on(async {
+            let bytes: &[u8] = &[0x00; 64 * 1024];
+            let mut reader = SafeReader::new(bytes, (bytes.len() as u64) - 1, 0, None).unwrap();
+            let mut buf = Vec::new();
+            assert!(await!(reader.read_to_end(&mut buf)).is_err());
+        })
     }
 
     #[test]
     fn valid_read_good_hash() {
-        block_on(
-            async {
-                let bytes: &[u8] = &[0x00, 0x01, 0x02, 0x03];
-                let mut context = digest::Context::new(&SHA256);
-                context.update(&bytes);
-                let hash_value = HashValue::new(context.finish().as_ref().to_vec());
-                let mut reader = SafeReader::new(
-                    bytes,
-                    bytes.len() as u64,
-                    0,
-                    Some((&HashAlgorithm::Sha256, hash_value)),
-                )
-                .unwrap();
-                let mut buf = Vec::new();
-                assert!(await!(reader.read_to_end(&mut buf)).is_ok());
-                assert_eq!(buf, bytes);
-            },
-        )
+        block_on(async {
+            let bytes: &[u8] = &[0x00, 0x01, 0x02, 0x03];
+            let mut context = digest::Context::new(&SHA256);
+            context.update(&bytes);
+            let hash_value = HashValue::new(context.finish().as_ref().to_vec());
+            let mut reader = SafeReader::new(
+                bytes,
+                bytes.len() as u64,
+                0,
+                Some((&HashAlgorithm::Sha256, hash_value)),
+            )
+            .unwrap();
+            let mut buf = Vec::new();
+            assert!(await!(reader.read_to_end(&mut buf)).is_ok());
+            assert_eq!(buf, bytes);
+        })
     }
 
     #[test]
     fn invalid_read_bad_hash() {
-        block_on(
-            async {
-                let bytes: &[u8] = &[0x00, 0x01, 0x02, 0x03];
-                let mut context = digest::Context::new(&SHA256);
-                context.update(&bytes);
-                context.update(&[0xFF]); // evil bytes
-                let hash_value = HashValue::new(context.finish().as_ref().to_vec());
-                let mut reader = SafeReader::new(
-                    bytes,
-                    bytes.len() as u64,
-                    0,
-                    Some((&HashAlgorithm::Sha256, hash_value)),
-                )
-                .unwrap();
-                let mut buf = Vec::new();
-                assert!(await!(reader.read_to_end(&mut buf)).is_err());
-            },
-        )
+        block_on(async {
+            let bytes: &[u8] = &[0x00, 0x01, 0x02, 0x03];
+            let mut context = digest::Context::new(&SHA256);
+            context.update(&bytes);
+            context.update(&[0xFF]); // evil bytes
+            let hash_value = HashValue::new(context.finish().as_ref().to_vec());
+            let mut reader = SafeReader::new(
+                bytes,
+                bytes.len() as u64,
+                0,
+                Some((&HashAlgorithm::Sha256, hash_value)),
+            )
+            .unwrap();
+            let mut buf = Vec::new();
+            assert!(await!(reader.read_to_end(&mut buf)).is_err());
+        })
     }
 
     #[test]
     fn valid_read_good_hash_large_data() {
-        block_on(
-            async {
-                let bytes: &[u8] = &[0x00; 64 * 1024];
-                let mut context = digest::Context::new(&SHA256);
-                context.update(&bytes);
-                let hash_value = HashValue::new(context.finish().as_ref().to_vec());
-                let mut reader = SafeReader::new(
-                    bytes,
-                    bytes.len() as u64,
-                    0,
-                    Some((&HashAlgorithm::Sha256, hash_value)),
-                )
-                .unwrap();
-                let mut buf = Vec::new();
-                assert!(await!(reader.read_to_end(&mut buf)).is_ok());
-                assert_eq!(buf, bytes);
-            },
-        )
+        block_on(async {
+            let bytes: &[u8] = &[0x00; 64 * 1024];
+            let mut context = digest::Context::new(&SHA256);
+            context.update(&bytes);
+            let hash_value = HashValue::new(context.finish().as_ref().to_vec());
+            let mut reader = SafeReader::new(
+                bytes,
+                bytes.len() as u64,
+                0,
+                Some((&HashAlgorithm::Sha256, hash_value)),
+            )
+            .unwrap();
+            let mut buf = Vec::new();
+            assert!(await!(reader.read_to_end(&mut buf)).is_ok());
+            assert_eq!(buf, bytes);
+        })
     }
 
     #[test]
     fn invalid_read_bad_hash_large_data() {
-        block_on(
-            async {
-                let bytes: &[u8] = &[0x00; 64 * 1024];
-                let mut context = digest::Context::new(&SHA256);
-                context.update(&bytes);
-                context.update(&[0xFF]); // evil bytes
-                let hash_value = HashValue::new(context.finish().as_ref().to_vec());
-                let mut reader = SafeReader::new(
-                    bytes,
-                    bytes.len() as u64,
-                    0,
-                    Some((&HashAlgorithm::Sha256, hash_value)),
-                )
-                .unwrap();
-                let mut buf = Vec::new();
-                assert!(await!(reader.read_to_end(&mut buf)).is_err());
-            },
-        )
+        block_on(async {
+            let bytes: &[u8] = &[0x00; 64 * 1024];
+            let mut context = digest::Context::new(&SHA256);
+            context.update(&bytes);
+            context.update(&[0xFF]); // evil bytes
+            let hash_value = HashValue::new(context.finish().as_ref().to_vec());
+            let mut reader = SafeReader::new(
+                bytes,
+                bytes.len() as u64,
+                0,
+                Some((&HashAlgorithm::Sha256, hash_value)),
+            )
+            .unwrap();
+            let mut buf = Vec::new();
+            assert!(await!(reader.read_to_end(&mut buf)).is_err());
+        })
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,10 +1,12 @@
 use chrono::offset::Utc;
 use chrono::DateTime;
 use futures::io::AsyncRead;
-use futures::task::Waker;
 use futures::{try_ready, Poll};
 use ring::digest::{self, SHA256, SHA512};
 use std::io::{self, ErrorKind};
+use std::marker::Unpin;
+use std::pin::Pin;
+use std::task::Context;
 
 use crate::crypto::{HashAlgorithm, HashValue};
 use crate::error::Error;
@@ -20,7 +22,7 @@ use crate::Result;
 ///
 /// It is **critical** that none of the bytes from this struct are used until it has been fully
 /// consumed as the data is untrusted.
-pub struct SafeReader<R: AsyncRead> {
+pub struct SafeReader<R> {
     inner: R,
     max_size: u64,
     min_bytes_per_second: u32,
@@ -70,9 +72,13 @@ impl<R: AsyncRead> SafeReader<R> {
     }
 }
 
-impl<R: AsyncRead> AsyncRead for SafeReader<R> {
-    fn poll_read(&mut self, waker: &Waker, buf: &mut [u8]) -> Poll<io::Result<usize>> {
-        let read_bytes = try_ready!(self.inner.poll_read(waker, buf));
+impl<R: AsyncRead + Unpin> AsyncRead for SafeReader<R> {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context,
+        buf: &mut [u8],
+    ) -> Poll<io::Result<usize>> {
+        let read_bytes = try_ready!(Pin::new(&mut self.inner).poll_read(cx, buf));
 
         if self.start_time.is_none() {
             self.start_time = Some(Utc::now())
@@ -105,7 +111,7 @@ impl<R: AsyncRead> AsyncRead for SafeReader<R> {
         let duration = Utc::now().signed_duration_since(self.start_time.unwrap());
         // 30 second grace period before we start checking the bitrate
         if duration.num_seconds() >= 30 {
-            if self.bytes_read as f32 / (duration.num_seconds() as f32)
+            if (self.bytes_read as f32) / (duration.num_seconds() as f32)
                 < self.min_bytes_per_second as f32
             {
                 return Poll::Ready(Err(io::Error::new(

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -63,14 +63,8 @@ fn simple_delegation() {
             MetadataPath::new("delegation".into()).unwrap(),
             false,
             1,
-            vec![delegation_key.key_id().clone()]
-                .iter()
-                .cloned()
-                .collect(),
-            vec![VirtualTargetPath::new("foo".into()).unwrap()]
-                .iter()
-                .cloned()
-                .collect(),
+            vec![delegation_key.key_id().clone()].iter().cloned().collect(),
+            vec![VirtualTargetPath::new("foo".into()).unwrap()].iter().cloned().collect(),
         )
         .unwrap()],
     )
@@ -94,12 +88,9 @@ fn simple_delegation() {
         .signed::<Json>(&delegation_key)
         .unwrap();
 
-    tuf.update_delegation(&MetadataPath::new("delegation".into()).unwrap(), delegation)
-        .unwrap();
+    tuf.update_delegation(&MetadataPath::new("delegation".into()).unwrap(), delegation).unwrap();
 
-    assert!(tuf
-        .target_description(&VirtualTargetPath::new("foo".into()).unwrap())
-        .is_ok());
+    assert!(tuf.target_description(&VirtualTargetPath::new("foo".into()).unwrap()).is_ok());
 }
 
 #[test]
@@ -157,14 +148,8 @@ fn nested_delegation() {
             MetadataPath::new("delegation-a".into()).unwrap(),
             false,
             1,
-            vec![delegation_a_key.key_id().clone()]
-                .iter()
-                .cloned()
-                .collect(),
-            vec![VirtualTargetPath::new("foo".into()).unwrap()]
-                .iter()
-                .cloned()
-                .collect(),
+            vec![delegation_a_key.key_id().clone()].iter().cloned().collect(),
+            vec![VirtualTargetPath::new("foo".into()).unwrap()].iter().cloned().collect(),
         )
         .unwrap()],
     )
@@ -184,14 +169,8 @@ fn nested_delegation() {
             MetadataPath::new("delegation-b".into()).unwrap(),
             false,
             1,
-            vec![delegation_b_key.key_id().clone()]
-                .iter()
-                .cloned()
-                .collect(),
-            vec![VirtualTargetPath::new("foo".into()).unwrap()]
-                .iter()
-                .cloned()
-                .collect(),
+            vec![delegation_b_key.key_id().clone()].iter().cloned().collect(),
+            vec![VirtualTargetPath::new("foo".into()).unwrap()].iter().cloned().collect(),
         )
         .unwrap()],
     )
@@ -202,11 +181,7 @@ fn nested_delegation() {
         .signed::<Json>(&delegation_a_key)
         .unwrap();
 
-    tuf.update_delegation(
-        &MetadataPath::new("delegation-a".into()).unwrap(),
-        delegation,
-    )
-    .unwrap();
+    tuf.update_delegation(&MetadataPath::new("delegation-a".into()).unwrap(), delegation).unwrap();
 
     //// build delegation B ////
 
@@ -222,13 +197,7 @@ fn nested_delegation() {
         .signed::<Json>(&delegation_b_key)
         .unwrap();
 
-    tuf.update_delegation(
-        &MetadataPath::new("delegation-b".into()).unwrap(),
-        delegation,
-    )
-    .unwrap();
+    tuf.update_delegation(&MetadataPath::new("delegation-b".into()).unwrap(), delegation).unwrap();
 
-    assert!(tuf
-        .target_description(&VirtualTargetPath::new("foo".into()).unwrap())
-        .is_ok());
+    assert!(tuf.target_description(&VirtualTargetPath::new("foo".into()).unwrap()).is_ok());
 }

--- a/tests/simple_example.rs
+++ b/tests/simple_example.rs
@@ -34,28 +34,21 @@ impl PathTranslator for MyPathTranslator {
 fn with_translator() {
     let mut remote = EphemeralRepository::<Json>::new();
     let config = Config::default();
-    block_on(
-        async {
-            let root_key_ids = await!(init_server(&mut remote, &config)).unwrap();
-            await!(init_client(&root_key_ids, remote, config)).unwrap();
-        },
-    )
+    block_on(async {
+        let root_key_ids = await!(init_server(&mut remote, &config)).unwrap();
+        await!(init_client(&root_key_ids, remote, config)).unwrap();
+    })
 }
 
 #[test]
 fn without_translator() {
     let mut remote = EphemeralRepository::<Json>::new();
-    let config = Config::build()
-        .path_translator(MyPathTranslator {})
-        .finish()
-        .unwrap();
+    let config = Config::build().path_translator(MyPathTranslator {}).finish().unwrap();
 
-    block_on(
-        async {
-            let root_key_ids = await!(init_server(&mut remote, &config)).unwrap();
-            await!(init_client(&root_key_ids, remote, config)).unwrap();
-        },
-    )
+    block_on(async {
+        let root_key_ids = await!(init_server(&mut remote, &config)).unwrap();
+        await!(init_client(&root_key_ids, remote, config)).unwrap();
+    })
 }
 
 async fn init_client<T: 'static>(
@@ -67,12 +60,7 @@ where
     T: PathTranslator,
 {
     let local = EphemeralRepository::<Json>::new();
-    let mut client = await!(Client::with_root_pinned(
-        &root_key_ids,
-        config,
-        local,
-        remote
-    ))?;
+    let mut client = await!(Client::with_root_pinned(&root_key_ids, config, local, remote))?;
     let _ = await!(client.update())?;
     let target_path = TargetPath::new("foo-bar".into())?;
     await!(client.fetch_target(&target_path))


### PR DESCRIPTION
This updates rust-tuf to futures-preview 0.3.0-alpha.15, which required adding a number of new constraints in a bunch of places due to a change in AsyncRead. In addition, futures-preview grew BoxFuture, which replaces the need for us to use TufFuture. Finally, this changes EphemeralRepository to not have to copy the target files when calling `.fetch_target`.