### PR TITLE
Bump dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ hyper = { version = "0.12", default-features = false }
 itoa = "0.4"
 log = "0.4"
 ring = { version = "0.16" }
-parking_lot = "0.7.1"
+parking_lot = "0.9"
 serde = "1"
 serde_derive = "1"
 serde_json = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ path = "./src/lib.rs"
 [dependencies]
 chrono = { version = "0.4", features = [ "serde" ] }
 data-encoding = "2.0.0-rc.2"
-derp = "0.0.11"
+derp = "0.0.13"
 futures-preview = { version = "=0.3.0-alpha.17", features = [ "compat" ] }
 http = "0.1"
 hyper = { version = "0.12", default-features = false }
@@ -36,7 +36,7 @@ serde = "1"
 serde_derive = "1"
 serde_json = "1"
 tempfile = "3"
-untrusted = "0.6"
+untrusted = "0.7"
 url = "2"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ http = "0.1"
 hyper = { version = "0.12", default-features = false }
 itoa = "0.4"
 log = "0.4"
-ring = { version = "0.14" }
+ring = { version = "0.16" }
 parking_lot = "0.7.1"
 serde = "1"
 serde_derive = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ serde_derive = "1"
 serde_json = "1"
 tempfile = "3"
 untrusted = "0.6"
-url = "1"
+url = "2"
 
 [dev-dependencies]
 lazy_static = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ path = "./src/lib.rs"
 chrono = { version = "0.4", features = [ "serde" ] }
 data-encoding = "2.0.0-rc.2"
 derp = "0.0.11"
-futures-preview = { version = "=0.3.0-alpha.15", features = [ "compat" ] }
+futures-preview = { version = "=0.3.0-alpha.17", features = [ "compat" ] }
 http = "0.1"
 hyper = { version = "0.12", default-features = false }
 itoa = "0.4"

--- a/src/client.rs
+++ b/src/client.rs
@@ -3,7 +3,7 @@
 //! # Example
 //!
 //! ```no_run
-//! #![feature(async_await, await_macro, futures_api)]
+//! #![feature(async_await, futures_api)]
 //! # use futures::executor::block_on;
 //! # use hyper::client::Client as HttpClient;
 //! # use std::path::PathBuf;
@@ -36,14 +36,14 @@
 //! .user_agent("rustup/1.4.0")
 //! .build();
 //!
-//! let mut client = await!(Client::with_root_pinned(
+//! let mut client = Client::with_root_pinned(
 //!     &key_ids,
 //!     Config::default(),
 //!     local,
 //!     remote,
-//! ))?;
+//! ).await?;
 //!
-//! let _ = await!(client.update())?;
+//! let _ = client.update().await?;
 //! # Ok(())
 //! # })
 //! # }
@@ -142,7 +142,7 @@ where
         let root_version = MetadataVersion::Number(1);
 
         let root =
-            await!(local.fetch_metadata(&root_path, &root_version, &config.max_root_length, None))?;
+            local.fetch_metadata(&root_path, &root_version, &config.max_root_length, None).await?;
 
         let tuf = Tuf::from_root(root)?;
 
@@ -162,23 +162,23 @@ where
         let root_path = MetadataPath::from_role(&Role::Root);
         let root_version = MetadataVersion::Number(1);
 
-        let root = match await!(local.fetch_metadata(
+        let root = match local.fetch_metadata(
             &root_path,
             &root_version,
             &config.max_root_length,
             None,
-        )) {
+        ).await {
             Ok(root) => root,
             Err(_) => {
                 // FIXME: should we be fetching the latest version instead of version 1?
-                let root = await!(remote.fetch_metadata(
+                let root = remote.fetch_metadata(
                     &root_path,
                     &root_version,
                     &config.max_root_length,
                     None,
-                ))?;
+                ).await?;
 
-                await!(local.store_metadata(&root_path, &MetadataVersion::Number(1), &root))?;
+                local.store_metadata(&root_path, &MetadataVersion::Number(1), &root).await?;
 
                 // FIXME: should we also the root as `MetadataVersion::None`?
 
@@ -195,10 +195,10 @@ where
     ///
     /// Returns `true` if an update occurred and `false` otherwise.
     pub async fn update(&mut self) -> Result<bool> {
-        let r = await!(self.update_root())?;
-        let ts = await!(self.update_timestamp())?;
-        let sn = await!(self.update_snapshot())?;
-        let ta = await!(self.update_targets())?;
+        let r = self.update_root().await?;
+        let ts = self.update_timestamp().await?;
+        let sn = self.update_snapshot().await?;
+        let ta = self.update_targets().await?;
 
         Ok(r || ts || sn || ta)
     }
@@ -213,7 +213,7 @@ where
     ) where
         M: Metadata + Sync + 'static,
     {
-        match await!(self.local.store_metadata(path, version, metadata)) {
+        match self.local.store_metadata(path, version, metadata).await {
             Ok(()) => {}
             Err(err) => {
                 warn!(
@@ -231,12 +231,12 @@ where
     async fn update_root(&mut self) -> Result<bool> {
         let root_path = MetadataPath::from_role(&Role::Root);
 
-        let latest_root = await!(self.remote.fetch_metadata(
+        let latest_root = self.remote.fetch_metadata(
             &root_path,
             &MetadataVersion::None,
             &self.config.max_root_length,
             None,
-        ))?;
+        ).await?;
         let latest_version = latest_root.version();
 
         if latest_version < self.tuf.root().version() {
@@ -255,19 +255,19 @@ where
         for i in (self.tuf.root().version() + 1)..latest_version {
             let version = MetadataVersion::Number(i);
 
-            let signed_root = await!(self.remote.fetch_metadata(
+            let signed_root = self.remote.fetch_metadata(
                 &root_path,
                 &version,
                 &self.config.max_root_length,
                 None,
-            ))?;
+            ).await?;
 
             if !self.tuf.update_root(signed_root.clone())? {
                 error!("{}", err_msg);
                 return Err(Error::Programming(err_msg.into()));
             }
 
-            await!(self.store_metadata(&root_path, &version, &signed_root));
+            self.store_metadata(&root_path, &version, &signed_root).await;
         }
 
         if !self.tuf.update_root(latest_root.clone())? {
@@ -277,8 +277,8 @@ where
 
         let latest_version = MetadataVersion::Number(latest_version);
 
-        await!(self.store_metadata(&root_path, &latest_version, &latest_root,));
-        await!(self.store_metadata(&root_path, &MetadataVersion::None, &latest_root));
+        self.store_metadata(&root_path, &latest_version, &latest_root,).await;
+        self.store_metadata(&root_path, &MetadataVersion::None, &latest_root).await;
 
         if self.tuf.root().expires() <= &Utc::now() {
             error!("Root metadata expired, potential freeze attack");
@@ -292,18 +292,18 @@ where
     async fn update_timestamp(&mut self) -> Result<bool> {
         let timestamp_path = MetadataPath::from_role(&Role::Timestamp);
 
-        let signed_timestamp = await!(self.remote.fetch_metadata(
+        let signed_timestamp = self.remote.fetch_metadata(
             &timestamp_path,
             &MetadataVersion::None,
             &self.config.max_timestamp_length,
             None,
-        ))?;
+        ).await?;
 
         if self.tuf.update_timestamp(signed_timestamp.clone())? {
             let latest_version = signed_timestamp.version();
             let latest_version = MetadataVersion::Number(latest_version);
 
-            await!(self.store_metadata(&timestamp_path, &latest_version, &signed_timestamp,));
+            self.store_metadata(&timestamp_path, &latest_version, &signed_timestamp,).await;
 
             Ok(true)
         } else {
@@ -337,15 +337,15 @@ where
         let snapshot_path = MetadataPath::from_role(&Role::Snapshot);
         let snapshot_length = Some(snapshot_description.length());
 
-        let signed_snapshot = await!(self.remote.fetch_metadata(
+        let signed_snapshot = self.remote.fetch_metadata(
             &snapshot_path,
             &version,
             &snapshot_length,
             Some((alg, value.clone())),
-        ))?;
+        ).await?;
 
         if self.tuf.update_snapshot(signed_snapshot.clone())? {
-            await!(self.store_metadata(&snapshot_path, &version, &signed_snapshot));
+            self.store_metadata(&snapshot_path, &version, &signed_snapshot).await;
 
             Ok(true)
         } else {
@@ -383,15 +383,15 @@ where
         let targets_path = MetadataPath::from_role(&Role::Targets);
         let targets_length = Some(targets_description.length());
 
-        let signed_targets = await!(self.remote.fetch_metadata(
+        let signed_targets = self.remote.fetch_metadata(
             &targets_path,
             &version,
             &targets_length,
             Some((alg, value.clone())),
-        ))?;
+        ).await?;
 
         if self.tuf.update_targets(signed_targets.clone())? {
-            await!(self.store_metadata(&targets_path, &version, &signed_targets));
+            self.store_metadata(&targets_path, &version, &signed_targets).await;
 
             Ok(true)
         } else {
@@ -401,8 +401,8 @@ where
 
     /// Fetch a target from the remote repo and write it to the local repo.
     pub async fn fetch_target<'a>(&'a mut self, target: &'a TargetPath) -> Result<()> {
-        let read = await!(self._fetch_target(target))?;
-        await!(self.local.store_target(read, target))
+        let read = self._fetch_target(target).await?;
+        self.local.store_target(read, target).await
     }
 
     /// Fetch a target from the remote repo and write it to the provided writer.
@@ -414,8 +414,8 @@ where
     where
         W: AsyncWrite + Send + Unpin,
     {
-        let read = await!(self._fetch_target(&target))?;
-        await!(read.copy_into(&mut write))?;
+        let read = self._fetch_target(&target).await?;
+        read.copy_into(&mut write).await?;
         Ok(())
     }
 
@@ -429,10 +429,10 @@ where
         let snapshot =
             self.tuf.snapshot().ok_or_else(|| Error::MissingMetadata(Role::Snapshot))?.clone();
         let (_, target_description) =
-            await!(self.lookup_target_description(false, 0, &virt, &snapshot, None));
+            self.lookup_target_description(false, 0, &virt, &snapshot, None).await;
         let target_description = target_description?;
 
-        await!(self.remote.fetch_target(target, &target_description))
+        self.remote.fetch_target(target, &target_description).await
     }
 
     async fn lookup_target_description<'a>(
@@ -499,22 +499,22 @@ where
             };
 
             let role_length = Some(role_meta.length());
-            let signed_meta = await!(self.local.fetch_metadata::<TargetsMetadata>(
+            let signed_meta = self.local.fetch_metadata::<TargetsMetadata>(
                 delegation.role(),
                 &MetadataVersion::None,
                 &role_length,
                 Some((alg, value.clone())),
-            ));
+            ).await;
 
             let signed_meta = match signed_meta {
                 Ok(signed_meta) => signed_meta,
                 Err(_) => {
-                    match await!(self.remote.fetch_metadata::<TargetsMetadata>(
+                    match self.remote.fetch_metadata::<TargetsMetadata>(
                         delegation.role(),
                         &version,
                         &role_length,
                         Some((alg, value.clone())),
-                    )) {
+                    ).await {
                         Ok(m) => m,
                         Err(ref e) if !delegation.terminating() => {
                             warn!("Failed to fetch metadata {:?}: {:?}", delegation.role(), e);
@@ -530,11 +530,11 @@ where
 
             match self.tuf.update_delegation(delegation.role(), signed_meta.clone()) {
                 Ok(_) => {
-                    match await!(self.local.store_metadata(
+                    match self.local.store_metadata(
                         delegation.role(),
                         &MetadataVersion::None,
                         &signed_meta,
-                    )) {
+                    ).await {
                         Ok(_) => (),
                         Err(e) => {
                             warn!("Error storing metadata {:?} locally: {:?}", delegation.role(), e)
@@ -550,7 +550,7 @@ where
                             snapshot,
                             Some(meta.as_ref()),
                         ));
-                    let (term, res) = await!(f);
+                    let (term, res) = f.await;
 
                     if term && res.is_err() {
                         return (true, res);

--- a/src/client.rs
+++ b/src/client.rs
@@ -414,7 +414,7 @@ where
     where
         W: AsyncWrite + Send + Unpin,
     {
-        let mut read = await!(self._fetch_target(&target))?;
+        let read = await!(self._fetch_target(&target))?;
         await!(read.copy_into(&mut write))?;
         Ok(())
     }
@@ -542,13 +542,14 @@ where
                     }
 
                     let meta = self.tuf.delegations().get(delegation.role()).unwrap().clone();
-                    let f: Pin<Box<Future<Output = _>>> = Box::pin(self.lookup_target_description(
-                        delegation.terminating(),
-                        current_depth + 1,
-                        target,
-                        snapshot,
-                        Some(meta.as_ref()),
-                    ));
+                    let f: Pin<Box<dyn Future<Output = _>>> =
+                        Box::pin(self.lookup_target_description(
+                            delegation.terminating(),
+                            current_depth + 1,
+                            target,
+                            snapshot,
+                            Some(meta.as_ref()),
+                        ));
                     let (term, res) = await!(f);
 
                     if term && res.is_err() {

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -591,7 +591,7 @@ impl PublicKey {
 
     /// Use this key to verify a message with a signature.
     pub fn verify(&self, msg: &[u8], sig: &Signature) -> Result<()> {
-        let alg: &ring::signature::VerificationAlgorithm = match self.scheme {
+        let alg: &dyn ring::signature::VerificationAlgorithm = match self.scheme {
             SignatureScheme::Ed25519 => &ED25519,
             SignatureScheme::RsaSsaPssSha256 => &RSA_PSS_2048_8192_SHA256,
             SignatureScheme::RsaSsaPssSha512 => &RSA_PSS_2048_8192_SHA512,

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -415,7 +415,7 @@ impl PrivateKey {
     }
 
     fn ed25519_from_pkcs8(der_key: &[u8]) -> Result<Self> {
-        let key = Ed25519KeyPair::from_pkcs8(Input::from(der_key))
+        let key = Ed25519KeyPair::from_pkcs8(der_key)
             .map_err(|_| Error::Encoding("Could not parse key as PKCS#8v2".into()))?;
 
         let public = PublicKey {
@@ -436,7 +436,7 @@ impl PrivateKey {
             ));
         }
 
-        let key = RsaKeyPair::from_pkcs8(Input::from(der_key))
+        let key = RsaKeyPair::from_pkcs8(der_key)
             .map_err(|_| Error::Encoding("Could not parse key as PKCS#8v2".into()))?;
 
         if key.public_modulus_len() < 256 {
@@ -600,13 +600,8 @@ impl PublicKey {
             }
         };
 
-        ring::signature::verify(
-            alg,
-            Input::from(&self.value.0),
-            Input::from(msg),
-            Input::from(&sig.value.0),
-        )
-        .map_err(|_| Error::BadSignature)
+        let key = ring::signature::UnparsedPublicKey::new(alg, &self.value.0);
+        key.verify(msg, &sig.value.0).map_err(|_| Error::BadSignature)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,7 @@
     clippy::op_ref,
     clippy::too_many_arguments
 )]
-#![feature(async_await, await_macro)]
+#![feature(async_await)]
 
 pub mod client;
 pub mod crypto;

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -181,7 +181,7 @@ where
 
     fn store_target<'a, R>(
         &'a self,
-        mut read: R,
+        read: R,
         target_path: &'a TargetPath,
     ) -> BoxFuture<'a, Result<()>>
     where
@@ -617,7 +617,6 @@ mod test {
     use super::*;
     use crate::interchange::Json;
     use futures::executor::block_on;
-    use futures::io::AsyncReadExt;
     use tempfile;
 
     #[test]

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -172,7 +172,7 @@ where
             )?;
 
             let mut buf = Vec::with_capacity(max_length.unwrap_or(0));
-            await!(reader.read_to_end(&mut buf))?;
+            reader.read_to_end(&mut buf).await?;
 
             Ok(D::from_slice(&buf)?)
         }
@@ -196,7 +196,7 @@ where
             }
 
             let mut temp_file = AllowStdIo::new(create_temp_file(&path)?);
-            await!(read.copy_into(&mut temp_file))?;
+            read.copy_into(&mut temp_file).await?;
             temp_file.into_inner().persist(&path)?;
 
             Ok(())
@@ -365,7 +365,7 @@ where
             .header("User-Agent", &*self.user_agent)
             .body(Body::default())?;
 
-        let resp = await!(self.client.request(req).compat())?;
+        let resp = self.client.request(req).compat().await?;
         let status = resp.status();
 
         if !status.is_success() {
@@ -412,7 +412,7 @@ where
             Self::check::<M>(meta_path)?;
 
             let components = meta_path.components::<D>(&version);
-            let resp = await!(self.get(&self.metadata_prefix, &components))?;
+            let resp = self.get(&self.metadata_prefix, &components).await?;
 
             let stream =
                 resp.into_body().compat().map_err(|err| io::Error::new(io::ErrorKind::Other, err));
@@ -425,7 +425,7 @@ where
             )?;
 
             let mut buf = Vec::new();
-            await!(reader.read_to_end(&mut buf))?;
+            reader.read_to_end(&mut buf).await?;
 
             Ok(D::from_slice(&buf)?)
         }
@@ -448,7 +448,7 @@ where
         async move {
             let (alg, value) = crypto::hash_preference(target_description.hashes())?;
             let components = target_path.components();
-            let resp = await!(self.get(&None, &components))?;
+            let resp = self.get(&None, &components).await?;
 
             let stream =
                 resp.into_body().compat().map_err(|err| io::Error::new(io::ErrorKind::Other, err));
@@ -552,7 +552,7 @@ where
             )?;
 
             let mut buf = Vec::with_capacity(max_length.unwrap_or(0));
-            await!(reader.read_to_end(&mut buf))?;
+            reader.read_to_end(&mut buf).await?;
 
             D::from_slice(&buf)
         }
@@ -569,7 +569,7 @@ where
     {
         async move {
             let mut buf = Vec::new();
-            await!(read.read_to_end(&mut buf))?;
+            read.read_to_end(&mut buf).await?;
             self.targets.write().insert(target_path.clone(), Arc::new(buf));
             Ok(())
         }
@@ -628,17 +628,17 @@ mod test {
             let target_description =
                 TargetDescription::from_reader(data, &[HashAlgorithm::Sha256]).unwrap();
             let path = TargetPath::new("batty".into()).unwrap();
-            await!(repo.store_target(data, &path)).unwrap();
+            repo.store_target(data, &path).await.unwrap();
 
-            let mut read = await!(repo.fetch_target(&path, &target_description)).unwrap();
+            let mut read = repo.fetch_target(&path, &target_description).await.unwrap();
             let mut buf = Vec::new();
-            await!(read.read_to_end(&mut buf)).unwrap();
+            read.read_to_end(&mut buf).await.unwrap();
             assert_eq!(buf.as_slice(), data);
 
             let bad_data: &[u8] = b"you're in a desert";
-            await!(repo.store_target(bad_data, &path)).unwrap();
-            let mut read = await!(repo.fetch_target(&path, &target_description)).unwrap();
-            assert!(await!(read.read_to_end(&mut buf)).is_err());
+            repo.store_target(bad_data, &path).await.unwrap();
+            let mut read = repo.fetch_target(&path, &target_description).await.unwrap();
+            assert!(read.read_to_end(&mut buf).await.is_err());
         })
     }
 
@@ -657,7 +657,7 @@ mod test {
             let target_description =
                 TargetDescription::from_reader(data, &[HashAlgorithm::Sha256]).unwrap();
             let path = TargetPath::new("foo/bar/baz".into()).unwrap();
-            await!(repo.store_target(data, &path)).unwrap();
+            repo.store_target(data, &path).await.unwrap();
             assert!(temp_dir.path().join("targets").join("foo").join("bar").join("baz").exists());
 
             let mut buf = Vec::new();
@@ -666,15 +666,15 @@ mod test {
             // This is needed for `tempfile` on Windows, which doesn't open the
             // files in a mode that allows the file to be opened multiple times.
             {
-                let mut read = await!(repo.fetch_target(&path, &target_description)).unwrap();
-                await!(read.read_to_end(&mut buf)).unwrap();
+                let mut read = repo.fetch_target(&path, &target_description).await.unwrap();
+                read.read_to_end(&mut buf).await.unwrap();
                 assert_eq!(buf.as_slice(), data);
             }
 
             let bad_data: &[u8] = b"you're in a desert";
-            await!(repo.store_target(bad_data, &path)).unwrap();
-            let mut read = await!(repo.fetch_target(&path, &target_description)).unwrap();
-            assert!(await!(read.read_to_end(&mut buf)).is_err());
+            repo.store_target(bad_data, &path).await.unwrap();
+            let mut read = repo.fetch_target(&path, &target_description).await.unwrap();
+            assert!(read.read_to_end(&mut buf).await.is_err());
         })
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,7 +1,7 @@
 use chrono::offset::Utc;
 use chrono::DateTime;
 use futures::io::AsyncRead;
-use futures::{try_ready, Poll};
+use futures::{ready, Poll};
 use ring::digest::{self, SHA256, SHA512};
 use std::io::{self, ErrorKind};
 use std::marker::Unpin;
@@ -78,7 +78,7 @@ impl<R: AsyncRead + Unpin> AsyncRead for SafeReader<R> {
         cx: &mut Context,
         buf: &mut [u8],
     ) -> Poll<io::Result<usize>> {
-        let read_bytes = try_ready!(Pin::new(&mut self.inner).poll_read(cx, buf));
+        let read_bytes = ready!(Pin::new(&mut self.inner).poll_read(cx, buf))?;
 
         if self.start_time.is_none() {
             self.start_time = Some(Utc::now())

--- a/src/util.rs
+++ b/src/util.rs
@@ -141,7 +141,7 @@ mod test {
             let bytes: &[u8] = &[0x00, 0x01, 0x02, 0x03];
             let mut reader = SafeReader::new(bytes, bytes.len() as u64, 0, None).unwrap();
             let mut buf = Vec::new();
-            assert!(await!(reader.read_to_end(&mut buf)).is_ok());
+            assert!(reader.read_to_end(&mut buf).await.is_ok());
             assert_eq!(buf, bytes);
         })
     }
@@ -152,7 +152,7 @@ mod test {
             let bytes: &[u8] = &[0x00; 64 * 1024];
             let mut reader = SafeReader::new(bytes, bytes.len() as u64, 0, None).unwrap();
             let mut buf = Vec::new();
-            assert!(await!(reader.read_to_end(&mut buf)).is_ok());
+            assert!(reader.read_to_end(&mut buf).await.is_ok());
             assert_eq!(buf, bytes);
         })
     }
@@ -163,7 +163,7 @@ mod test {
             let bytes: &[u8] = &[0x00, 0x01, 0x02, 0x03];
             let mut reader = SafeReader::new(bytes, (bytes.len() as u64) + 1, 0, None).unwrap();
             let mut buf = Vec::new();
-            assert!(await!(reader.read_to_end(&mut buf)).is_ok());
+            assert!(reader.read_to_end(&mut buf).await.is_ok());
             assert_eq!(buf, bytes);
         })
     }
@@ -174,7 +174,7 @@ mod test {
             let bytes: &[u8] = &[0x00, 0x01, 0x02, 0x03];
             let mut reader = SafeReader::new(bytes, (bytes.len() as u64) - 1, 0, None).unwrap();
             let mut buf = Vec::new();
-            assert!(await!(reader.read_to_end(&mut buf)).is_err());
+            assert!(reader.read_to_end(&mut buf).await.is_err());
         })
     }
 
@@ -184,7 +184,7 @@ mod test {
             let bytes: &[u8] = &[0x00; 64 * 1024];
             let mut reader = SafeReader::new(bytes, (bytes.len() as u64) - 1, 0, None).unwrap();
             let mut buf = Vec::new();
-            assert!(await!(reader.read_to_end(&mut buf)).is_err());
+            assert!(reader.read_to_end(&mut buf).await.is_err());
         })
     }
 
@@ -203,7 +203,7 @@ mod test {
             )
             .unwrap();
             let mut buf = Vec::new();
-            assert!(await!(reader.read_to_end(&mut buf)).is_ok());
+            assert!(reader.read_to_end(&mut buf).await.is_ok());
             assert_eq!(buf, bytes);
         })
     }
@@ -224,7 +224,7 @@ mod test {
             )
             .unwrap();
             let mut buf = Vec::new();
-            assert!(await!(reader.read_to_end(&mut buf)).is_err());
+            assert!(reader.read_to_end(&mut buf).await.is_err());
         })
     }
 
@@ -243,7 +243,7 @@ mod test {
             )
             .unwrap();
             let mut buf = Vec::new();
-            assert!(await!(reader.read_to_end(&mut buf)).is_ok());
+            assert!(reader.read_to_end(&mut buf).await.is_ok());
             assert_eq!(buf, bytes);
         })
     }
@@ -264,7 +264,7 @@ mod test {
             )
             .unwrap();
             let mut buf = Vec::new();
-            assert!(await!(reader.read_to_end(&mut buf)).is_err());
+            assert!(reader.read_to_end(&mut buf).await.is_err());
         })
     }
 }

--- a/tests/simple_example.rs
+++ b/tests/simple_example.rs
@@ -1,4 +1,4 @@
-#![feature(async_await, await_macro, futures_api)]
+#![feature(async_await, await_macro)]
 
 use futures::executor::block_on;
 use tuf::client::{Client, Config, PathTranslator};

--- a/tests/simple_example.rs
+++ b/tests/simple_example.rs
@@ -1,4 +1,4 @@
-#![feature(async_await, await_macro)]
+#![feature(async_await)]
 
 use futures::executor::block_on;
 use tuf::client::{Client, Config, PathTranslator};
@@ -35,8 +35,8 @@ fn with_translator() {
     let mut remote = EphemeralRepository::<Json>::new();
     let config = Config::default();
     block_on(async {
-        let root_key_ids = await!(init_server(&mut remote, &config)).unwrap();
-        await!(init_client(&root_key_ids, remote, config)).unwrap();
+        let root_key_ids = init_server(&mut remote, &config).await.unwrap();
+        init_client(&root_key_ids, remote, config).await.unwrap();
     })
 }
 
@@ -46,8 +46,8 @@ fn without_translator() {
     let config = Config::build().path_translator(MyPathTranslator {}).finish().unwrap();
 
     block_on(async {
-        let root_key_ids = await!(init_server(&mut remote, &config)).unwrap();
-        await!(init_client(&root_key_ids, remote, config)).unwrap();
+        let root_key_ids = init_server(&mut remote, &config).await.unwrap();
+        init_client(&root_key_ids, remote, config).await.unwrap();
     })
 }
 
@@ -60,10 +60,10 @@ where
     T: PathTranslator,
 {
     let local = EphemeralRepository::<Json>::new();
-    let mut client = await!(Client::with_root_pinned(&root_key_ids, config, local, remote))?;
-    let _ = await!(client.update())?;
+    let mut client = Client::with_root_pinned(&root_key_ids, config, local, remote).await?;
+    let _ = client.update().await?;
     let target_path = TargetPath::new("foo-bar".into())?;
-    await!(client.fetch_target(&target_path))
+    client.fetch_target(&target_path).await
 }
 
 async fn init_server<'a, T>(
@@ -89,15 +89,15 @@ where
         .signed::<Json>(&root_key)?;
 
     let root_path = MetadataPath::new("root".into())?;
-    await!(remote.store_metadata(&root_path, &MetadataVersion::Number(1), &signed,))?;
-    await!(remote.store_metadata(&root_path, &MetadataVersion::None, &signed,))?;
+    remote.store_metadata(&root_path, &MetadataVersion::Number(1), &signed,).await?;
+    remote.store_metadata(&root_path, &MetadataVersion::None, &signed,).await?;
 
     //// build the targets ////
 
     let target_file: &[u8] = b"things fade, alternatives exclude";
 
     let target_path = TargetPath::new("foo-bar".into())?;
-    let _ = await!(remote.store_target(target_file, &target_path));
+    let _ = remote.store_target(target_file, &target_path).await;
 
     let targets = TargetsMetadataBuilder::new()
         .insert_target_from_reader(
@@ -108,8 +108,8 @@ where
         .signed::<Json>(&targets_key)?;
 
     let targets_path = &MetadataPath::new("targets".into())?;
-    await!(remote.store_metadata(&targets_path, &MetadataVersion::Number(1), &targets,))?;
-    await!(remote.store_metadata(&targets_path, &MetadataVersion::None, &targets,))?;
+    remote.store_metadata(&targets_path, &MetadataVersion::Number(1), &targets,).await?;
+    remote.store_metadata(&targets_path, &MetadataVersion::None, &targets,).await?;
 
     //// build the snapshot ////
 
@@ -118,8 +118,8 @@ where
         .signed::<Json>(&snapshot_key)?;
 
     let snapshot_path = MetadataPath::new("snapshot".into())?;
-    await!(remote.store_metadata(&snapshot_path, &MetadataVersion::Number(1), &snapshot,))?;
-    await!(remote.store_metadata(&snapshot_path, &MetadataVersion::None, &snapshot,))?;
+    remote.store_metadata(&snapshot_path, &MetadataVersion::Number(1), &snapshot,).await?;
+    remote.store_metadata(&snapshot_path, &MetadataVersion::None, &snapshot,).await?;
 
     //// build the timestamp ////
 
@@ -127,8 +127,8 @@ where
         .signed::<Json>(&timestamp_key)?;
 
     let timestamp_path = MetadataPath::new("timestamp".into())?;
-    await!(remote.store_metadata(&timestamp_path, &MetadataVersion::Number(1), &timestamp,))?;
-    await!(remote.store_metadata(&timestamp_path, &MetadataVersion::None, &timestamp,))?;
+    remote.store_metadata(&timestamp_path, &MetadataVersion::Number(1), &timestamp,).await?;
+    remote.store_metadata(&timestamp_path, &MetadataVersion::None, &timestamp,).await?;
 
     Ok(vec![root_key.key_id().clone()])
 }


### PR DESCRIPTION
This bumps the following dependencies:

* futures-preview to 0.3.0-alpha.17
* ring to 0.16.4
* url to 2.0.0
* parking_lot to 0.9.0

The one outstanding dependency is derp, which is waiting on https://github.com/heartsucker/derp/pull/5.