### PR TITLE
Signature's "value" field is "sig" in the spec

### DIFF
--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -683,6 +683,7 @@ impl Debug for PublicKeyValue {
 pub struct Signature {
     #[serde(rename = "keyid")]
     key_id: KeyId,
+    #[serde(rename = "sig")]
     value: SignatureValue,
 }
 
@@ -959,7 +960,7 @@ mod test {
         let encoded = serde_json::to_value(&sig).unwrap();
         let jsn = json!({
             "keyid": "qfrfBrkB4lBBSDEBlZgaTGS_SrE6UfmON9kP4i3dJFY=",
-            "value": "_k0Tsqc8Azod5_UQeyBfx7oOFWbLlbkjScrmqkU4lWATv-D3v5d8sHK7Z\
+            "sig": "_k0Tsqc8Azod5_UQeyBfx7oOFWbLlbkjScrmqkU4lWATv-D3v5d8sHK7Z\
                 eh4K18zoFc_54gWKZoBfKW6VZ45DA==",
             }
         );

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -2136,7 +2136,7 @@ mod test {
             "signatures": [
                 {
                     "keyid": "qfrfBrkB4lBBSDEBlZgaTGS_SrE6UfmON9kP4i3dJFY=",
-                    "value": "LpLKsO8-X6-u8KN2130IEWMr4lcp7nt-fEHErwdZlQQGFB0Vmz6MUDNlNZJxSBgBU9\
+                    "sig": "LpLKsO8-X6-u8KN2130IEWMr4lcp7nt-fEHErwdZlQQGFB0Vmz6MUDNlNZJxSBgBU9\
                         LZ2vyolgyfyRjGgDDIAw==",
                 }
             ],


### PR DESCRIPTION
According to the [spec] in section 4.2, the signature value field is called "sig".

[spec]: https://github.com/theupdateframework/specification/blob/master/tuf-spec.md