### PR TITLE
change key id algorithm to hexdigit(sha256(cjson(public_key)))

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ url = "2"
 [dev-dependencies]
 lazy_static = "1"
 maplit = "1"
+pretty_assertions = "0.6"
 
 [features]
 default = ["hyper/default"]

--- a/src/client.rs
+++ b/src/client.rs
@@ -16,9 +16,9 @@
 //! # use tuf::repository::{Repository, FileSystemRepository, HttpRepositoryBuilder};
 //!
 //! static TRUSTED_ROOT_KEY_IDS: &'static [&str] = &[
-//!     "diNfThTFm0PI8R-Bq7NztUIvZbZiaC_weJBgcqaHlWw=",
-//!     "ar9AgoRsmeEcf6Ponta_1TZu1ds5uXbDemBig30O7ck=",
-//!     "T5vfRrM1iHpgzGwAHe7MbJH_7r4chkOAphV3OPCCv0I=",
+//!     "4750eaf6878740780d6f97b12dbad079fb012bec88c78de2c380add56d3f51db",
+//!     "01892c662c8cd79fab20edec21de1dcb8b75d9353103face7fe086ff5c0098e4",
+//!     "0823260c29956d0b64baa19a64c49c87922ba2bc532d09a6965aef044da490bd",
 //! ];
 //!
 //! # fn main() -> Result<()> {

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -110,67 +110,56 @@ pub fn calculate_hashes<R: Read>(
     Ok((size, hashes))
 }
 
-fn calculate_key_id(public_key: &[u8]) -> KeyId {
+fn shim_public_key(
+    key_type: &KeyType,
+    signature_scheme: &SignatureScheme,
+    public_key: &[u8],
+) -> ::std::result::Result<shims::PublicKey, derp::Error> {
+    let bytes = write_spki(public_key, &key_type)?;
+    let key = BASE64URL.encode(&bytes);
+
+    Ok(shims::PublicKey::new(key_type.clone(), signature_scheme.clone(), key))
+}
+
+
+fn calculate_key_id(
+    key_type: &KeyType,
+    signature_scheme: &SignatureScheme,
+    public_key: &[u8],
+) -> Result<KeyId> {
+    use crate::interchange::{DataInterchange, Json};
+
+    let public_key = shim_public_key(key_type, signature_scheme, public_key)?;
+    let public_key = Json::canonicalize(&Json::serialize(&public_key)?)?;
     let mut context = digest::Context::new(&SHA256);
     context.update(&public_key);
-    KeyId(context.finish().as_ref().to_vec())
+
+    let key_id = HEXLOWER.encode(context.finish().as_ref());
+
+    Ok(KeyId(key_id))
 }
 
 /// Wrapper type for public key's ID.
 ///
 /// # Calculating
-/// A `KeyId` is calculated as `sha256(spki(pub_key_bytes))` where `spki` is a function that takes
-/// any encoding for a public key an converts it into the `SubjectPublicKeyInfo` (SPKI) DER
-/// encoding as defined in [RFC 3280 Appendix A](https://www.ietf.org/rfc/rfc3280.txt).
-///
-/// Note: Historically the TUF spec says that a key's ID should be calculated with
-/// `sha256(cjson(encoded(pub_key_bytes)))`, but since there could be multiple supported data
-/// interchange formats, relying on an encoding that uses JSON does not make sense.
-///
-/// # ASN.1
-/// ```bash
-/// PublicKey ::= CHOICE {
-///     -- This field is checked for consistency against `subjectPublicKey`.
-///     -- The OID determines how we attempt to parse the `BIT STRING`.
-///     algorithm        AlgorithmIdentifier,
-///     -- Either:
-///     --   1. Encapsulates an `RsaPublicKey`
-///     --   2. Equals an `Ed25519PublicKey`
-///     subjectPublicKey BIT STRING
-/// }
-///
-/// AlgorithmIdentifier ::= SEQUENCE {
-///     -- Either:
-///     --   1. 1.2.840.113549.1.1.1 rsaEncryption(PKCS #1)
-///     --   2. 1.3.101.112 curveEd25519(EdDSA 25519 signature algorithm)
-///     algorithm  OBJECT IDENTIFIER,
-///     -- In our cases, this is always `NULL`.
-///     parameters ANY DEFINED BY algorithm OPTIONAL
-/// }
-///
-/// RsaPublicKey ::= SEQUENCE {
-///     modulus  INTEGER (1..MAX),
-///     exponent INTEGER (1..MAX)
-/// }
-///
-/// Ed25519PublicKey ::= BIT STRING
-/// ```
+/// A `KeyId` is calculated as the hex digest of the SHA-256 hash of the canonical form of the
+/// public key, or `hexdigest(sha256(cjson(public_key)))`.
 #[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct KeyId(Vec<u8>);
+pub struct KeyId(String);
 
 impl KeyId {
-    /// Parse a key ID from a base64url string.
+    /// Parse a key ID from a string.
     pub fn from_string(string: &str) -> Result<Self> {
-        if string.len() != 44 {
-            return Err(Error::IllegalArgument("Base64 key ID must be 44 characters long".into()));
+        if string.len() != 64 {
+            return Err(Error::IllegalArgument("key ID must be 64 characters long".into()));
         }
-        Ok(KeyId(BASE64URL.decode(string.as_bytes())?))
+        Ok(KeyId(string.to_owned()))
     }
 }
 
 impl Debug for KeyId {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "KeyId {{ \"{}\" }}", BASE64URL.encode(&self.0))
+        write!(f, "KeyId {{ \"{}\" }}", self.0)
     }
 }
 
@@ -179,7 +168,7 @@ impl Serialize for KeyId {
     where
         S: Serializer,
     {
-        BASE64URL.encode(&self.0).serialize(ser)
+        self.0.serialize(ser)
     }
 }
 
@@ -400,12 +389,11 @@ impl PrivateKey {
         let key = Ed25519KeyPair::from_pkcs8(der_key)
             .map_err(|_| Error::Encoding("Could not parse key as PKCS#8v2".into()))?;
 
-        let public = PublicKey {
-            typ: KeyType::Ed25519,
-            scheme: SignatureScheme::Ed25519,
-            key_id: calculate_key_id(&write_spki(key.public_key().as_ref(), &KeyType::Ed25519)?),
-            value: PublicKeyValue(key.public_key().as_ref().to_vec()),
-        };
+        let public = PublicKey::new(
+            KeyType::Ed25519,
+            SignatureScheme::Ed25519,
+            PublicKeyValue(key.public_key().as_ref().to_vec()),
+        )?;
         let private = PrivateKeyType::Ed25519(key);
 
         Ok(PrivateKey { private, public })
@@ -430,12 +418,7 @@ impl PrivateKey {
 
         let pub_key = extract_rsa_pub_from_pkcs8(der_key)?;
 
-        let public = PublicKey {
-            typ: KeyType::Rsa,
-            scheme,
-            key_id: calculate_key_id(&write_spki(&pub_key, &KeyType::Rsa)?),
-            value: PublicKeyValue(pub_key),
-        };
+        let public = PublicKey::new(KeyType::Rsa, scheme, PublicKeyValue(pub_key))?;
         let private = PrivateKeyType::Rsa(Arc::new(key));
 
         Ok(PrivateKey { private, public })
@@ -522,6 +505,11 @@ pub struct PublicKey {
 }
 
 impl PublicKey {
+    fn new(typ: KeyType, scheme: SignatureScheme, value: PublicKeyValue) -> Result<Self> {
+        let key_id = calculate_key_id(&typ, &scheme, &value.0)?;
+        Ok(PublicKey { typ, key_id, scheme, value })
+    }
+
     /// Parse DER bytes as an SPKI key.
     ///
     /// See the documentation on `KeyValue` for more information on SPKI.
@@ -545,8 +533,7 @@ impl PublicKey {
             })
         })?;
 
-        let key_id = calculate_key_id(der_bytes);
-        Ok(PublicKey { typ, key_id, scheme, value: PublicKeyValue(value) })
+        Self::new(typ, scheme, PublicKeyValue(value))
     }
 
     /// Write the public key as SPKI DER bytes.
@@ -620,13 +607,9 @@ impl Serialize for PublicKey {
     where
         S: Serializer,
     {
-        let bytes = self
-            .as_spki()
+        let key = shim_public_key(&self.typ, &self.scheme, &self.value.0)
             .map_err(|e| SerializeError::custom(format!("Couldn't write key as SPKI: {:?}", e)))?;
-
-        let key = BASE64URL.encode(&bytes);
-
-        shims::PublicKey::new(self.typ.clone(), self.scheme.clone(), key).serialize(ser)
+        key.serialize(ser)
     }
 }
 
@@ -871,7 +854,7 @@ mod test {
 
     #[test]
     fn serde_key_id() {
-        let s = "T5vfRrM1iHpgzGwAHe7MbJH_7r4chkOAphV3OPCCv0I=";
+        let s = "4750eaf6878740780d6f97b12dbad079fb012bec88c78de2c380add56d3f51db";
         let jsn = json!(s);
         let parsed: KeyId = serde_json::from_str(&format!("\"{}\"", s)).unwrap();
         assert_eq!(parsed, KeyId::from_string(s).unwrap());
@@ -930,12 +913,11 @@ mod test {
         let sig = key.sign(msg).unwrap();
         let encoded = serde_json::to_value(&sig).unwrap();
         let jsn = json!({
-            "keyid": "qfrfBrkB4lBBSDEBlZgaTGS_SrE6UfmON9kP4i3dJFY=",
+            "keyid": "218407c5b325798364fb331db730565604eeae7760fa09538584ad2290769731",
             "sig": "fe4d13b2a73c033a1de7f5107b205fc7ba0e1566cb95b92349cae6aa453\
                 8956013bfe0f7bf977cb072bb65e8782b5f33a0573fe78816299a017ca5ba55\
                 9e390c",
-            }
-        );
+        });
         assert_eq!(encoded, jsn);
 
         let decoded: Signature = serde_json::from_value(encoded).unwrap();

--- a/src/interchange/mod.rs
+++ b/src/interchange/mod.rs
@@ -66,7 +66,7 @@ pub trait DataInterchange: Debug + PartialEq + Clone {
 ///
 /// `EXPIRES` is an ISO-8601 date time in format `YYYY-MM-DD'T'hh:mm:ss'Z'`.
 ///
-/// `KEY_ID` is the base64url encoded value of `sha256(spki(pub_key))`.
+/// `KEY_ID` is the hex encoded value of `sha256(cjson(pub_key))`.
 ///
 /// `PUB_KEY` is the following:
 ///

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1746,6 +1746,7 @@ mod test {
     use crate::interchange::Json;
     use chrono::prelude::*;
     use maplit::{hashmap, hashset};
+    use pretty_assertions::assert_eq;
     use serde_json::json;
 
     const ED25519_1_PK8: &'static [u8] = include_bytes!("../tests/ed25519/ed25519-1.pk8.der");
@@ -1905,28 +1906,36 @@ mod test {
             "consistent_snapshot": false,
             "keys": {
                 "4hsyITLMQoWBg0ldCLKPlRZPIEf258cMg-xdAROsO6o=": {
-                    "type": "ed25519",
+                    "keytype": "ed25519",
                     "scheme": "ed25519",
-                    "public_key": "MCwwBwYDK2VwBQADIQAWY3bJCn9xfQJwVicvNhwlL7BQ\
-                        vtGgZ_8giaAwL7q3PQ==",
+                    "keyval": {
+                        "public": "MCwwBwYDK2VwBQADIQAWY3bJCn9xfQJwVicvNhwlL7BQ\
+                            vtGgZ_8giaAwL7q3PQ==",
+                    },
                 },
                 "5WvZhiiSSUung_OhJVbPshKwD_ZNkgeg80i4oy2KAVs=": {
-                    "type": "ed25519",
+                    "keytype": "ed25519",
                     "scheme": "ed25519",
-                    "public_key": "MCwwBwYDK2VwBQADIQBo2eyzhzcQBajrjmAQUwXDQ1ao\
-                        _NhZ1_7zzCKL8rKzsg==",
+                    "keyval": {
+                        "public": "MCwwBwYDK2VwBQADIQBo2eyzhzcQBajrjmAQUwXDQ1ao\
+                            _NhZ1_7zzCKL8rKzsg==",
+                    },
                 },
                 "C2hNB7qN99EAbHVGHPIJc5Hqa9RfEilnMqsCNJ5dGdw=": {
-                    "type": "ed25519",
+                    "keytype": "ed25519",
                     "scheme": "ed25519",
-                    "public_key": "MCwwBwYDK2VwBQADIQAUEK4wU6pwu_qYQoqHnWTTACo1\
-                        ePffquscsHZOhg9-Cw==",
+                    "keyval": {
+                        "public": "MCwwBwYDK2VwBQADIQAUEK4wU6pwu_qYQoqHnWTTACo1\
+                            ePffquscsHZOhg9-Cw==",
+                    },
                 },
                 "qfrfBrkB4lBBSDEBlZgaTGS_SrE6UfmON9kP4i3dJFY=": {
-                    "type": "ed25519",
+                    "keytype": "ed25519",
                     "scheme": "ed25519",
-                    "public_key": "MCwwBwYDK2VwBQADIQDrisJrXJ7wJ5474-giYqk7zhb-\
-                        WO5CJQDTjK9GHGWjtg==",
+                    "keyval": {
+                        "public": "MCwwBwYDK2VwBQADIQDrisJrXJ7wJ5474-giYqk7zhb-\
+                            WO5CJQDTjK9GHGWjtg==",
+                    },
                 }
             },
             "roles": {
@@ -2087,10 +2096,12 @@ mod test {
             "delegations": {
                 "keys": {
                     "qfrfBrkB4lBBSDEBlZgaTGS_SrE6UfmON9kP4i3dJFY=": {
-                        "type": "ed25519",
+                        "keytype": "ed25519",
                         "scheme": "ed25519",
-                        "public_key": "MCwwBwYDK2VwBQADIQDrisJrXJ7wJ5474-giYqk7zhb\
-                            -WO5CJQDTjK9GHGWjtg==",
+                        "keyval": {
+                            "public": "MCwwBwYDK2VwBQADIQDrisJrXJ7wJ5474-giYqk7zhb\
+                                -WO5CJQDTjK9GHGWjtg==",
+                        }
                     },
                 },
                 "roles": [

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1845,8 +1845,8 @@ mod test {
     #[test]
     fn serde_role_definition() {
         let hashes = hashset!(
-            "diNfThTFm0PI8R-Bq7NztUIvZbZiaC_weJBgcqaHlWw=",
-            "ar9AgoRsmeEcf6Ponta_1TZu1ds5uXbDemBig30O7ck=",
+            "01892c662c8cd79fab20edec21de1dcb8b75d9353103face7fe086ff5c0098e4",
+            "4750eaf6878740780d6f97b12dbad079fb012bec88c78de2c380add56d3f51db",
         )
         .iter()
         .map(|k| KeyId::from_string(*k).unwrap())
@@ -1856,8 +1856,8 @@ mod test {
             "threshold": 2,
             "keyids": [
                 // these need to be sorted for determinism
-                "ar9AgoRsmeEcf6Ponta_1TZu1ds5uXbDemBig30O7ck=",
-                "diNfThTFm0PI8R-Bq7NztUIvZbZiaC_weJBgcqaHlWw=",
+                "01892c662c8cd79fab20edec21de1dcb8b75d9353103face7fe086ff5c0098e4",
+                "4750eaf6878740780d6f97b12dbad079fb012bec88c78de2c380add56d3f51db",
             ],
         });
         let encoded = serde_json::to_value(&role_def).unwrap();
@@ -1868,7 +1868,8 @@ mod test {
         let jsn = json!({
             "threshold": 0,
             "keyids": [
-                "diNfThTFm0PI8R-Bq7NztUIvZbZiaC_weJBgcqaHlWw=",
+                "01892c662c8cd79fab20edec21de1dcb8b75d9353103face7fe086ff5c0098e4",
+                "4750eaf6878740780d6f97b12dbad079fb012bec88c78de2c380add56d3f51db",
             ],
         });
         assert!(serde_json::from_value::<RoleDefinition>(jsn).is_err());
@@ -1876,7 +1877,8 @@ mod test {
         let jsn = json!({
             "threshold": -1,
             "keyids": [
-                "diNfThTFm0PI8R-Bq7NztUIvZbZiaC_weJBgcqaHlWw=",
+                "01892c662c8cd79fab20edec21de1dcb8b75d9353103face7fe086ff5c0098e4",
+                "4750eaf6878740780d6f97b12dbad079fb012bec88c78de2c380add56d3f51db",
             ],
         });
         assert!(serde_json::from_value::<RoleDefinition>(jsn).is_err());
@@ -1905,55 +1907,51 @@ mod test {
             "expires": "2017-01-01T00:00:00Z",
             "consistent_snapshot": false,
             "keys": {
-                "4hsyITLMQoWBg0ldCLKPlRZPIEf258cMg-xdAROsO6o=": {
+                "218407c5b325798364fb331db730565604eeae7760fa09538584ad2290769731": {
                     "keytype": "ed25519",
                     "scheme": "ed25519",
                     "keyval": {
-                        "public": "MCwwBwYDK2VwBQADIQAWY3bJCn9xfQJwVicvNhwlL7BQ\
-                            vtGgZ_8giaAwL7q3PQ==",
+                        "public": "MCwwBwYDK2VwBQADIQDrisJrXJ7wJ5474-giYqk7zhb-WO5CJQDTjK9GHGWjtg==",
                     },
                 },
-                "5WvZhiiSSUung_OhJVbPshKwD_ZNkgeg80i4oy2KAVs=": {
+                "256e4ce533b211a249076d551b110cd13ae0b21474bddd14276da3d99cf87c18": {
                     "keytype": "ed25519",
                     "scheme": "ed25519",
                     "keyval": {
-                        "public": "MCwwBwYDK2VwBQADIQBo2eyzhzcQBajrjmAQUwXDQ1ao\
-                            _NhZ1_7zzCKL8rKzsg==",
+                        "public": "MCwwBwYDK2VwBQADIQAUEK4wU6pwu_qYQoqHnWTTACo1ePffquscsHZOhg9-Cw==",
                     },
                 },
-                "C2hNB7qN99EAbHVGHPIJc5Hqa9RfEilnMqsCNJ5dGdw=": {
+                "5d289e84203c7b42cb636ea1d0a8bd620bde9c21dfee3f2e5cf584d0fe97b368": {
                     "keytype": "ed25519",
                     "scheme": "ed25519",
                     "keyval": {
-                        "public": "MCwwBwYDK2VwBQADIQAUEK4wU6pwu_qYQoqHnWTTACo1\
-                            ePffquscsHZOhg9-Cw==",
+                        "public": "MCwwBwYDK2VwBQADIQBo2eyzhzcQBajrjmAQUwXDQ1ao_NhZ1_7zzCKL8rKzsg==",
                     },
                 },
-                "qfrfBrkB4lBBSDEBlZgaTGS_SrE6UfmON9kP4i3dJFY=": {
+                "d41ab60869f0ea8c605585cc1783678d27755458b630cf062cb2fa212f5a117d": {
                     "keytype": "ed25519",
                     "scheme": "ed25519",
                     "keyval": {
-                        "public": "MCwwBwYDK2VwBQADIQDrisJrXJ7wJ5474-giYqk7zhb-\
-                            WO5CJQDTjK9GHGWjtg==",
+                        "public": "MCwwBwYDK2VwBQADIQAWY3bJCn9xfQJwVicvNhwlL7BQvtGgZ_8giaAwL7q3PQ==",
                     },
                 }
             },
             "roles": {
                 "root": {
                     "threshold": 1,
-                    "keyids": ["qfrfBrkB4lBBSDEBlZgaTGS_SrE6UfmON9kP4i3dJFY="],
+                    "keyids": ["218407c5b325798364fb331db730565604eeae7760fa09538584ad2290769731"],
                 },
                 "snapshot": {
                     "threshold": 1,
-                    "keyids": ["5WvZhiiSSUung_OhJVbPshKwD_ZNkgeg80i4oy2KAVs="],
+                    "keyids": ["5d289e84203c7b42cb636ea1d0a8bd620bde9c21dfee3f2e5cf584d0fe97b368"],
                 },
                 "targets": {
                     "threshold": 1,
-                    "keyids": ["4hsyITLMQoWBg0ldCLKPlRZPIEf258cMg-xdAROsO6o="],
+                    "keyids": ["d41ab60869f0ea8c605585cc1783678d27755458b630cf062cb2fa212f5a117d"],
                 },
                 "timestamp": {
                     "threshold": 1,
-                    "keyids": ["C2hNB7qN99EAbHVGHPIJc5Hqa9RfEilnMqsCNJ5dGdw="],
+                    "keyids": ["256e4ce533b211a249076d551b110cd13ae0b21474bddd14276da3d99cf87c18"],
                 },
             },
         });
@@ -2095,7 +2093,7 @@ mod test {
             "targets": {},
             "delegations": {
                 "keys": {
-                    "qfrfBrkB4lBBSDEBlZgaTGS_SrE6UfmON9kP4i3dJFY=": {
+                    "218407c5b325798364fb331db730565604eeae7760fa09538584ad2290769731": {
                         "keytype": "ed25519",
                         "scheme": "ed25519",
                         "keyval": {
@@ -2109,7 +2107,7 @@ mod test {
                         "role": "foo/bar",
                         "terminating": false,
                         "threshold": 1,
-                        "keyids": ["qfrfBrkB4lBBSDEBlZgaTGS_SrE6UfmON9kP4i3dJFY="],
+                        "keyids": ["218407c5b325798364fb331db730565604eeae7760fa09538584ad2290769731"],
                         "paths": ["baz/quux"],
                     },
                 ],
@@ -2145,10 +2143,10 @@ mod test {
         let jsn = json!({
             "signatures": [
                 {
-                    "keyid": "qfrfBrkB4lBBSDEBlZgaTGS_SrE6UfmON9kP4i3dJFY=",
-                    "sig": "2e92cab0ef3e5fafaef0a376d77d0811632be25729ee7b7e7c\
-                        41c4af0759950406141d159b3e8c50336535927148180153d2d9da\
-                        fca8960c9fc918c68030c803",
+                    "keyid": "218407c5b325798364fb331db730565604eeae7760fa09538584ad2290769731",
+                    "sig": "2e92cab0ef3e5fafaef0a376d77d0811632be25729ee7b7e7c4\
+                        1c4af0759950406141d159b3e8c50336535927148180153d2d9dafc\
+                        a8960c9fc918c68030c803",
                 }
             ],
             "signed": {

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -1,6 +1,5 @@
 use chrono::offset::Utc;
 use chrono::prelude::*;
-use data_encoding::BASE64URL;
 use serde_derive::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashSet};
 
@@ -227,32 +226,36 @@ impl TargetsMetadata {
 
 #[derive(Serialize, Deserialize)]
 pub struct PublicKey {
-    #[serde(rename = "type")]
-    typ: crypto::KeyType,
+    keytype: crypto::KeyType,
     scheme: crypto::SignatureScheme,
-    public_key: String,
+    keyval: PublicKeyValue,
 }
 
 impl PublicKey {
     pub fn new(
-        typ: crypto::KeyType,
+        keytype: crypto::KeyType,
         scheme: crypto::SignatureScheme,
-        public_key_bytes: &[u8],
+        public_key: String,
     ) -> Self {
-        PublicKey { typ, scheme, public_key: BASE64URL.encode(public_key_bytes) }
+        PublicKey { keytype, scheme, keyval: PublicKeyValue { public: public_key } }
     }
 
-    pub fn public_key(&self) -> &String {
-        &self.public_key
+    pub fn public_key(&self) -> &str {
+        &self.keyval.public
     }
 
     pub fn scheme(&self) -> &crypto::SignatureScheme {
         &self.scheme
     }
 
-    pub fn typ(&self) -> &crypto::KeyType {
-        &self.typ
+    pub fn keytype(&self) -> &crypto::KeyType {
+        &self.keytype
     }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct PublicKeyValue {
+    public: String,
 }
 
 #[derive(Serialize, Deserialize)]


### PR DESCRIPTION
The [spec] in section 4.2 defines that key ids are calculated using `hexdigit(sha256(cjson(public_key)))`.

Note this PR is layered on top of #200 to simplify landing multiple patches.

Closes #150

[spec]: https://github.com/theupdateframework/specification/blob/master/tuf-spec.md#4-document-formats