### PR TITLE
public key type field is "keytype", and value is a "keyval" object

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ url = "2"
 [dev-dependencies]
 lazy_static = "1"
 maplit = "1"
+pretty_assertions = "0.6"
 
 [features]
 default = ["hyper/default"]

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1746,6 +1746,7 @@ mod test {
     use crate::interchange::Json;
     use chrono::prelude::*;
     use maplit::{hashmap, hashset};
+    use pretty_assertions::assert_eq;
     use serde_json::json;
 
     const ED25519_1_PK8: &'static [u8] = include_bytes!("../tests/ed25519/ed25519-1.pk8.der");
@@ -1905,28 +1906,36 @@ mod test {
             "consistent_snapshot": false,
             "keys": {
                 "4hsyITLMQoWBg0ldCLKPlRZPIEf258cMg-xdAROsO6o=": {
-                    "type": "ed25519",
+                    "keytype": "ed25519",
                     "scheme": "ed25519",
-                    "public_key": "MCwwBwYDK2VwBQADIQAWY3bJCn9xfQJwVicvNhwlL7BQ\
-                        vtGgZ_8giaAwL7q3PQ==",
+                    "keyval": {
+                        "public": "MCwwBwYDK2VwBQADIQAWY3bJCn9xfQJwVicvNhwlL7BQ\
+                            vtGgZ_8giaAwL7q3PQ==",
+                    },
                 },
                 "5WvZhiiSSUung_OhJVbPshKwD_ZNkgeg80i4oy2KAVs=": {
-                    "type": "ed25519",
+                    "keytype": "ed25519",
                     "scheme": "ed25519",
-                    "public_key": "MCwwBwYDK2VwBQADIQBo2eyzhzcQBajrjmAQUwXDQ1ao\
-                        _NhZ1_7zzCKL8rKzsg==",
+                    "keyval": {
+                        "public": "MCwwBwYDK2VwBQADIQBo2eyzhzcQBajrjmAQUwXDQ1ao\
+                            _NhZ1_7zzCKL8rKzsg==",
+                    },
                 },
                 "C2hNB7qN99EAbHVGHPIJc5Hqa9RfEilnMqsCNJ5dGdw=": {
-                    "type": "ed25519",
+                    "keytype": "ed25519",
                     "scheme": "ed25519",
-                    "public_key": "MCwwBwYDK2VwBQADIQAUEK4wU6pwu_qYQoqHnWTTACo1\
-                        ePffquscsHZOhg9-Cw==",
+                    "keyval": {
+                        "public": "MCwwBwYDK2VwBQADIQAUEK4wU6pwu_qYQoqHnWTTACo1\
+                            ePffquscsHZOhg9-Cw==",
+                    },
                 },
                 "qfrfBrkB4lBBSDEBlZgaTGS_SrE6UfmON9kP4i3dJFY=": {
-                    "type": "ed25519",
+                    "keytype": "ed25519",
                     "scheme": "ed25519",
-                    "public_key": "MCwwBwYDK2VwBQADIQDrisJrXJ7wJ5474-giYqk7zhb-\
-                        WO5CJQDTjK9GHGWjtg==",
+                    "keyval": {
+                        "public": "MCwwBwYDK2VwBQADIQDrisJrXJ7wJ5474-giYqk7zhb-\
+                            WO5CJQDTjK9GHGWjtg==",
+                    },
                 }
             },
             "roles": {
@@ -2087,10 +2096,12 @@ mod test {
             "delegations": {
                 "keys": {
                     "qfrfBrkB4lBBSDEBlZgaTGS_SrE6UfmON9kP4i3dJFY=": {
-                        "type": "ed25519",
+                        "keytype": "ed25519",
                         "scheme": "ed25519",
-                        "public_key": "MCwwBwYDK2VwBQADIQDrisJrXJ7wJ5474-giYqk7zhb\
-                            -WO5CJQDTjK9GHGWjtg==",
+                        "keyval": {
+                            "public": "MCwwBwYDK2VwBQADIQDrisJrXJ7wJ5474-giYqk7zhb\
+                                -WO5CJQDTjK9GHGWjtg==",
+                        }
                     },
                 },
                 "roles": [

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -1,6 +1,5 @@
 use chrono::offset::Utc;
 use chrono::prelude::*;
-use data_encoding::BASE64URL;
 use serde_derive::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashSet};
 
@@ -227,32 +226,36 @@ impl TargetsMetadata {
 
 #[derive(Serialize, Deserialize)]
 pub struct PublicKey {
-    #[serde(rename = "type")]
-    typ: crypto::KeyType,
+    keytype: crypto::KeyType,
     scheme: crypto::SignatureScheme,
-    public_key: String,
+    keyval: PublicKeyValue,
 }
 
 impl PublicKey {
     pub fn new(
-        typ: crypto::KeyType,
+        keytype: crypto::KeyType,
         scheme: crypto::SignatureScheme,
-        public_key_bytes: &[u8],
+        public_key: String,
     ) -> Self {
-        PublicKey { typ, scheme, public_key: BASE64URL.encode(public_key_bytes) }
+        PublicKey { keytype, scheme, keyval: PublicKeyValue { public: public_key } }
     }
 
-    pub fn public_key(&self) -> &String {
-        &self.public_key
+    pub fn public_key(&self) -> &str {
+        &self.keyval.public
     }
 
     pub fn scheme(&self) -> &crypto::SignatureScheme {
         &self.scheme
     }
 
-    pub fn typ(&self) -> &crypto::KeyType {
-        &self.typ
+    pub fn keytype(&self) -> &crypto::KeyType {
+        &self.keytype
     }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct PublicKeyValue {
+    public: String,
 }
 
 #[derive(Serialize, Deserialize)]


### PR DESCRIPTION
In the [spec] in section 4.2, keys store their type in a field "keytype", and the value in "keyval": {"public": <key>} object.

Note this adds the "pretty_assertions" dev dependency, which highlights differences between comparisons.

Closes #198

[spec]: https://github.com/theupdateframework/specification/blob/master/tuf-spec.md