### PR TITLE
delegation keys are a map of keyid to key; allow unknown key ids

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,4 +1,4 @@
-use maplit::hashset;
+use maplit::hashmap;
 use tuf::crypto::{HashAlgorithm, PrivateKey, SignatureScheme};
 use tuf::interchange::Json;
 use tuf::metadata::{
@@ -58,7 +58,7 @@ fn simple_delegation() {
 
     //// build the targets ////
     let delegations = Delegations::new(
-        &hashset![delegation_key.public().clone()],
+        hashmap! { delegation_key.public().key_id().clone() => delegation_key.public().clone() },
         vec![Delegation::new(
             MetadataPath::new("delegation".into()).unwrap(),
             false,
@@ -143,7 +143,9 @@ fn nested_delegation() {
     //// build the targets ////
 
     let delegations = Delegations::new(
-        &hashset![delegation_a_key.public().clone()],
+        hashmap! {
+            delegation_b_key.public().key_id().clone() => delegation_a_key.public().clone(),
+        },
         vec![Delegation::new(
             MetadataPath::new("delegation-a".into()).unwrap(),
             false,
@@ -164,7 +166,7 @@ fn nested_delegation() {
     //// build delegation A ////
 
     let delegations = Delegations::new(
-        &hashset![delegation_b_key.public().clone()],
+        hashmap! { delegation_b_key.public().key_id().clone() => delegation_b_key.public().clone() },
         vec![Delegation::new(
             MetadataPath::new("delegation-b".into()).unwrap(),
             false,


### PR DESCRIPTION
Like in #184, the [spec] in section 4.5, the `"keys"` object is a map
of key id to key. In addition, this changes Delegations::new to take
the keys as a HashMap instead of computing the keyid from the key.
This is to allow rust-tuf to ignore keys computed with alternative
algorithms. For example, python-tuf supports the ability to optionally
generate key ids with `hexdigest(sha512(cjson(public_key)))`. rust-tuf
should allow (and right now, ignore) those keys.

[spec]: https://github.com/theupdateframework/specification/blob/master/tuf-spec.md

Change-Id: Ifa9a2ab3e4342d70d730e432e38eee6cbca5f1dc