### PR TITLE
Remove support for unknown KeyTypes and SignatureSchemes

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -41,6 +41,8 @@ pub enum Error {
     UnkonwnHashAlgorithm(String),
     /// There is no known or available key type.
     UnknownKeyType(String),
+    /// There is no known or available signature scheme.
+    UnknownSignatureScheme(String),
     /// The metadata or target failed to verify.
     VerificationFailure(String),
 }
@@ -60,6 +62,7 @@ impl ::std::error::Error for Error {
             Error::TargetUnavailable => "target unavailable",
             Error::UnkonwnHashAlgorithm(_) => "unknown hash algorithm",
             Error::UnknownKeyType(_) => "unknown key type",
+            Error::UnknownSignatureScheme(_) => "unknown signature scheme",
             Error::VerificationFailure(_) => "verification failure",
         }
     }


### PR DESCRIPTION
The only thing we do with unknown KeyType and SignatureSchemes is report and error if we attempt to use them. So instead, we should just not represent them in the crypto module.