### PR TITLE
Update to latest rust nightly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,6 @@
     clippy::op_ref,
     clippy::too_many_arguments
 )]
-#![feature(async_await)]
 
 pub mod client;
 pub mod crypto;

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -512,7 +512,7 @@ where
 impl<C, D> Repository<D> for HttpRepository<C, D>
 where
     C: Connect + Sync + 'static,
-    D: DataInterchange + Sync,
+    D: DataInterchange + Send + Sync,
 {
     /// This always returns `Err` as storing over HTTP is not yet supported.
     fn store_metadata<'a, M>(

--- a/tests/simple_example.rs
+++ b/tests/simple_example.rs
@@ -1,5 +1,3 @@
-#![feature(async_await)]
-
 use futures::executor::block_on;
 use tuf::client::{Client, Config, PathTranslator};
 use tuf::crypto::{HashAlgorithm, KeyId, PrivateKey, SignatureScheme};


### PR DESCRIPTION
This fixes two errors on the latest nightly:

* async_await feature has stablized in nightly
* `HttpRepository`'s `D` generic parameter now needs to be `Send`.