### PR TITLE
Allow MestadataPath::new to take &strs

### DIFF
--- a/src/interchange/cjson/shims.rs
+++ b/src/interchange/cjson/shims.rs
@@ -218,7 +218,7 @@ impl SnapshotMetadata {
                         )));
                     }
 
-                    let s = p.split_at(p.len() - ".json".len()).0.into();
+                    let s = p.split_at(p.len() - ".json".len()).0;
                     let p = metadata::MetadataPath::new(s)?;
 
                     Ok((p, d))

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -170,7 +170,7 @@ impl Role {
     /// assert!(Role::Timestamp.fuzzy_matches_path(&MetadataPath::from_role(&Role::Timestamp)));
     ///
     /// assert!(!Role::Root.fuzzy_matches_path(&MetadataPath::from_role(&Role::Snapshot)));
-    /// assert!(!Role::Root.fuzzy_matches_path(&MetadataPath::new("wat".into()).unwrap()));
+    /// assert!(!Role::Root.fuzzy_matches_path(&MetadataPath::new("wat").unwrap()));
     /// ```
     pub fn fuzzy_matches_path(&self, path: &MetadataPath) -> bool {
         match *self {
@@ -798,10 +798,10 @@ impl<'de> Deserialize<'de> for RoleDefinition {
 /// use tuf::metadata::MetadataPath;
 ///
 /// // right
-/// let _ = MetadataPath::new("root".into());
+/// let _ = MetadataPath::new("root");
 ///
 /// // wrong
-/// let _ = MetadataPath::new("root.json".into());
+/// let _ = MetadataPath::new("root.json");
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
 pub struct MetadataPath(String);
@@ -811,16 +811,17 @@ impl MetadataPath {
     ///
     /// ```
     /// # use tuf::metadata::MetadataPath;
-    /// assert!(MetadataPath::new("foo".into()).is_ok());
-    /// assert!(MetadataPath::new("/foo".into()).is_err());
-    /// assert!(MetadataPath::new("../foo".into()).is_err());
-    /// assert!(MetadataPath::new("foo/..".into()).is_err());
-    /// assert!(MetadataPath::new("foo/../bar".into()).is_err());
-    /// assert!(MetadataPath::new("..foo".into()).is_ok());
-    /// assert!(MetadataPath::new("foo/..bar".into()).is_ok());
-    /// assert!(MetadataPath::new("foo/bar..".into()).is_ok());
+    /// assert!(MetadataPath::new("foo").is_ok());
+    /// assert!(MetadataPath::new("/foo").is_err());
+    /// assert!(MetadataPath::new("../foo").is_err());
+    /// assert!(MetadataPath::new("foo/..").is_err());
+    /// assert!(MetadataPath::new("foo/../bar").is_err());
+    /// assert!(MetadataPath::new("..foo").is_ok());
+    /// assert!(MetadataPath::new("foo/..bar").is_ok());
+    /// assert!(MetadataPath::new("foo/bar..").is_ok());
     /// ```
-    pub fn new(path: String) -> Result<Self> {
+    pub fn new<P: Into<String>>(path: P) -> Result<Self> {
+        let path = path.into();
         safe_path(&path)?;
         Ok(MetadataPath(path))
     }
@@ -830,13 +831,13 @@ impl MetadataPath {
     /// ```
     /// # use tuf::metadata::{Role, MetadataPath};
     /// assert_eq!(MetadataPath::from_role(&Role::Root),
-    ///            MetadataPath::new("root".into()).unwrap());
+    ///            MetadataPath::new("root").unwrap());
     /// assert_eq!(MetadataPath::from_role(&Role::Snapshot),
-    ///            MetadataPath::new("snapshot".into()).unwrap());
+    ///            MetadataPath::new("snapshot").unwrap());
     /// assert_eq!(MetadataPath::from_role(&Role::Targets),
-    ///            MetadataPath::new("targets".into()).unwrap());
+    ///            MetadataPath::new("targets").unwrap());
     /// assert_eq!(MetadataPath::from_role(&Role::Timestamp),
-    ///            MetadataPath::new("timestamp".into()).unwrap());
+    ///            MetadataPath::new("timestamp").unwrap());
     /// ```
     pub fn from_role(role: &Role) -> Self {
         Self::new(format!("{}", role)).unwrap()
@@ -850,7 +851,7 @@ impl MetadataPath {
     /// # use tuf::interchange::Json;
     /// # use tuf::metadata::{MetadataPath, MetadataVersion};
     /// #
-    /// let path = MetadataPath::new("foo/bar".into()).unwrap();
+    /// let path = MetadataPath::new("foo/bar").unwrap();
     /// assert_eq!(path.components::<Json>(&MetadataVersion::None),
     ///            ["foo".to_string(), "bar.json".to_string()]);
     /// assert_eq!(path.components::<Json>(&MetadataVersion::Number(1)),
@@ -1139,7 +1140,7 @@ impl SnapshotMetadataBuilder {
     {
         let bytes = D::canonicalize(&D::serialize(metadata)?)?;
         let description = MetadataDescription::from_reader(&*bytes, metadata.version(), hash_algs)?;
-        let path = MetadataPath::new(path.into())?;
+        let path = MetadataPath::new(path)?;
         Ok(self.insert_metadata_description(path, description))
     }
 
@@ -2123,7 +2124,7 @@ mod test {
         let snapshot = SnapshotMetadataBuilder::new()
             .expires(Utc.ymd(2017, 1, 1).and_hms(0, 0, 0))
             .insert_metadata_description(
-                MetadataPath::new("targets".into()).unwrap(),
+                MetadataPath::new("targets").unwrap(),
                 MetadataDescription::new(
                     1,
                     100,
@@ -2235,7 +2236,7 @@ mod test {
         let delegations = Delegations::new(
             hashmap! { key.key_id().clone() => key.public().clone() },
             vec![Delegation::new(
-                MetadataPath::new("foo/bar".into()).unwrap(),
+                MetadataPath::new("foo/bar").unwrap(),
                 false,
                 1,
                 hashset!(key.key_id().clone()),
@@ -2291,7 +2292,7 @@ mod test {
         let snapshot = SnapshotMetadataBuilder::new()
             .expires(Utc.ymd(2017, 1, 1).and_hms(0, 0, 0))
             .insert_metadata_description(
-                MetadataPath::new("targets".into()).unwrap(),
+                MetadataPath::new("targets").unwrap(),
                 MetadataDescription::new(
                     1,
                     100,
@@ -2418,7 +2419,7 @@ mod test {
         let delegations = Delegations::new(
             hashmap! { key.key_id().clone() => key.clone() },
             vec![Delegation::new(
-                MetadataPath::new("foo".into()).unwrap(),
+                MetadataPath::new("foo").unwrap(),
                 false,
                 1,
                 hashset!(key.key_id().clone()),
@@ -2437,7 +2438,7 @@ mod test {
             .public()
             .clone();
         let delegation = Delegation::new(
-            MetadataPath::new("foo".into()).unwrap(),
+            MetadataPath::new("foo").unwrap(),
             false,
             1,
             hashset!(key.key_id().clone()),

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -38,11 +38,11 @@ fn simple_delegation() {
 
     let snapshot = SnapshotMetadataBuilder::new()
         .insert_metadata_description(
-            MetadataPath::new("targets".into()).unwrap(),
+            MetadataPath::new("targets").unwrap(),
             MetadataDescription::from_reader(&*vec![0u8], 1, &[HashAlgorithm::Sha256]).unwrap(),
         )
         .insert_metadata_description(
-            MetadataPath::new("delegation".into()).unwrap(),
+            MetadataPath::new("delegation").unwrap(),
             MetadataDescription::from_reader(&*vec![0u8], 1, &[HashAlgorithm::Sha256]).unwrap(),
         )
         .signed::<Json>(&snapshot_key)
@@ -60,7 +60,7 @@ fn simple_delegation() {
     let delegations = Delegations::new(
         hashmap! { delegation_key.public().key_id().clone() => delegation_key.public().clone() },
         vec![Delegation::new(
-            MetadataPath::new("delegation".into()).unwrap(),
+            MetadataPath::new("delegation").unwrap(),
             false,
             1,
             vec![delegation_key.key_id().clone()].iter().cloned().collect(),
@@ -88,7 +88,7 @@ fn simple_delegation() {
         .signed::<Json>(&delegation_key)
         .unwrap();
 
-    tuf.update_delegation(&MetadataPath::new("delegation".into()).unwrap(), delegation).unwrap();
+    tuf.update_delegation(&MetadataPath::new("delegation").unwrap(), delegation).unwrap();
 
     assert!(tuf.target_description(&VirtualTargetPath::new("foo".into()).unwrap()).is_ok());
 }
@@ -118,15 +118,15 @@ fn nested_delegation() {
 
     let snapshot = SnapshotMetadataBuilder::new()
         .insert_metadata_description(
-            MetadataPath::new("targets".into()).unwrap(),
+            MetadataPath::new("targets").unwrap(),
             MetadataDescription::from_reader(&*vec![0u8], 1, &[HashAlgorithm::Sha256]).unwrap(),
         )
         .insert_metadata_description(
-            MetadataPath::new("delegation-a".into()).unwrap(),
+            MetadataPath::new("delegation-a").unwrap(),
             MetadataDescription::from_reader(&*vec![0u8], 1, &[HashAlgorithm::Sha256]).unwrap(),
         )
         .insert_metadata_description(
-            MetadataPath::new("delegation-b".into()).unwrap(),
+            MetadataPath::new("delegation-b").unwrap(),
             MetadataDescription::from_reader(&*vec![0u8], 1, &[HashAlgorithm::Sha256]).unwrap(),
         )
         .signed::<Json>(&snapshot_key)
@@ -147,7 +147,7 @@ fn nested_delegation() {
             delegation_b_key.public().key_id().clone() => delegation_a_key.public().clone(),
         },
         vec![Delegation::new(
-            MetadataPath::new("delegation-a".into()).unwrap(),
+            MetadataPath::new("delegation-a").unwrap(),
             false,
             1,
             vec![delegation_a_key.key_id().clone()].iter().cloned().collect(),
@@ -168,7 +168,7 @@ fn nested_delegation() {
     let delegations = Delegations::new(
         hashmap! { delegation_b_key.public().key_id().clone() => delegation_b_key.public().clone() },
         vec![Delegation::new(
-            MetadataPath::new("delegation-b".into()).unwrap(),
+            MetadataPath::new("delegation-b").unwrap(),
             false,
             1,
             vec![delegation_b_key.key_id().clone()].iter().cloned().collect(),
@@ -183,7 +183,7 @@ fn nested_delegation() {
         .signed::<Json>(&delegation_a_key)
         .unwrap();
 
-    tuf.update_delegation(&MetadataPath::new("delegation-a".into()).unwrap(), delegation).unwrap();
+    tuf.update_delegation(&MetadataPath::new("delegation-a").unwrap(), delegation).unwrap();
 
     //// build delegation B ////
 
@@ -199,7 +199,7 @@ fn nested_delegation() {
         .signed::<Json>(&delegation_b_key)
         .unwrap();
 
-    tuf.update_delegation(&MetadataPath::new("delegation-b".into()).unwrap(), delegation).unwrap();
+    tuf.update_delegation(&MetadataPath::new("delegation-b").unwrap(), delegation).unwrap();
 
     assert!(tuf.target_description(&VirtualTargetPath::new("foo".into()).unwrap()).is_ok());
 }

--- a/tests/simple_example.rs
+++ b/tests/simple_example.rs
@@ -86,7 +86,7 @@ where
         .timestamp_key(timestamp_key.public().clone())
         .signed::<Json>(&root_key)?;
 
-    let root_path = MetadataPath::new("root".into())?;
+    let root_path = MetadataPath::new("root")?;
     remote.store_metadata(&root_path, &MetadataVersion::Number(1), &signed).await?;
     remote.store_metadata(&root_path, &MetadataVersion::None, &signed).await?;
 
@@ -105,7 +105,7 @@ where
         )?
         .signed::<Json>(&targets_key)?;
 
-    let targets_path = &MetadataPath::new("targets".into())?;
+    let targets_path = &MetadataPath::new("targets")?;
     remote.store_metadata(&targets_path, &MetadataVersion::Number(1), &targets).await?;
     remote.store_metadata(&targets_path, &MetadataVersion::None, &targets).await?;
 
@@ -115,7 +115,7 @@ where
         .insert_metadata(&targets, &[HashAlgorithm::Sha256])?
         .signed::<Json>(&snapshot_key)?;
 
-    let snapshot_path = MetadataPath::new("snapshot".into())?;
+    let snapshot_path = MetadataPath::new("snapshot")?;
     remote.store_metadata(&snapshot_path, &MetadataVersion::Number(1), &snapshot).await?;
     remote.store_metadata(&snapshot_path, &MetadataVersion::None, &snapshot).await?;
 
@@ -124,7 +124,7 @@ where
     let timestamp = TimestampMetadataBuilder::from_snapshot(&snapshot, &[HashAlgorithm::Sha256])?
         .signed::<Json>(&timestamp_key)?;
 
-    let timestamp_path = MetadataPath::new("timestamp".into())?;
+    let timestamp_path = MetadataPath::new("timestamp")?;
     remote.store_metadata(&timestamp_path, &MetadataVersion::Number(1), &timestamp).await?;
     remote.store_metadata(&timestamp_path, &MetadataVersion::None, &timestamp).await?;
 


### PR DESCRIPTION
This simplifies interacting with MetadataPaths when we have fixed strings.