### PR TITLE
re-enable building on stable rust, switch to futures 0.3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ dist: trusty
 language: rust
 cache: cargo
 rust:
+  - stable
+  - beta
   - nightly
 
 env:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,8 @@ path = "./src/lib.rs"
 chrono = { version = "0.4", features = [ "serde" ] }
 data-encoding = "2.0.0-rc.2"
 derp = "0.0.13"
-futures-preview = { version = "=0.3.0-alpha.19", features = [ "compat" ] }
+futures-io = "0.3.1"
+futures-util = { version = "0.3.1", features = [ "compat", "io" ] }
 http = "0.1"
 hyper = { version = "0.12", default-features = false }
 itoa = "0.4"
@@ -40,6 +41,7 @@ untrusted = "0.7"
 url = "2"
 
 [dev-dependencies]
+futures-executor = "0.3.1"
 lazy_static = "1"
 maplit = "1"
 matches = "0.1.8"

--- a/src/client.rs
+++ b/src/client.rs
@@ -3,8 +3,7 @@
 //! # Example
 //!
 //! ```no_run
-//! #![feature(async_await, futures_api)]
-//! # use futures::executor::block_on;
+//! # use futures_executor::block_on;
 //! # use hyper::client::Client as HttpClient;
 //! # use std::path::PathBuf;
 //! # use std::str::FromStr;
@@ -51,9 +50,10 @@
 //! ```
 
 use chrono::offset::Utc;
-use futures::future::Future;
-use futures::io::{AsyncRead, AsyncReadExt, AsyncWrite};
+use futures_io::{AsyncRead, AsyncWrite};
+use futures_util::io::copy;
 use log::{error, warn};
+use std::future::Future;
 use std::pin::Pin;
 
 use crate::crypto::{self, KeyId};
@@ -440,7 +440,7 @@ where
         W: AsyncWrite + Send + Unpin,
     {
         let read = self._fetch_target(&target).await?;
-        read.copy_into(&mut write).await?;
+        copy(read, &mut write).await?;
         Ok(())
     }
 
@@ -774,7 +774,7 @@ mod test {
     };
     use crate::repository::EphemeralRepository;
     use chrono::prelude::*;
-    use futures::executor::block_on;
+    use futures_executor::block_on;
     use lazy_static::lazy_static;
 
     lazy_static! {

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,12 +1,12 @@
 use chrono::offset::Utc;
 use chrono::DateTime;
-use futures::io::AsyncRead;
-use futures::{ready, Poll};
+use futures_io::AsyncRead;
+use futures_util::ready;
 use ring::digest::{self, SHA256, SHA512};
 use std::io::{self, ErrorKind};
 use std::marker::Unpin;
 use std::pin::Pin;
-use std::task::Context;
+use std::task::{Context, Poll};
 
 use crate::crypto::{HashAlgorithm, HashValue};
 use crate::error::Error;
@@ -132,8 +132,8 @@ impl<R: AsyncRead + Unpin> AsyncRead for SafeReader<R> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use futures::executor::block_on;
-    use futures::io::AsyncReadExt;
+    use futures_executor::block_on;
+    use futures_util::io::AsyncReadExt;
 
     #[test]
     fn valid_read() {

--- a/tests/simple_example.rs
+++ b/tests/simple_example.rs
@@ -1,4 +1,4 @@
-use futures::executor::block_on;
+use futures_executor::block_on;
 use tuf::client::{Client, Config, PathTranslator};
 use tuf::crypto::{HashAlgorithm, KeyId, PrivateKey, SignatureScheme};
 use tuf::interchange::Json;


### PR DESCRIPTION
With the Rust 1.39.0 release, async-await is now stablized so we can start testing on stable rust again. This also switches over to futures-0.3.0, which should be semver compatible with all 0.3.x changes.

Finally, it switches away from depending on the `futures` crate, and instead depends on `futures-io` and `futures-util` (and `futures-executor` in tests) to reduce crate download size.