### PR TITLE
add support for versioned trusted root keys

### DIFF
--- a/tests/simple_example.rs
+++ b/tests/simple_example.rs
@@ -61,7 +61,7 @@ where
     T: PathTranslator,
 {
     let local = EphemeralRepository::<Json>::new();
-    let mut client = Client::with_root_pinned(&root_key_ids, config, local, remote).await?;
+    let mut client = Client::with_root_pinned(&root_key_ids, config, local, remote, 1).await?;
     let _ = client.update().await?;
     let target_path = TargetPath::new("foo-bar".into())?;
     client.fetch_target(&target_path).await


### PR DESCRIPTION
rust-tuf currently assumes that the trusted_root_keys given when initializing the client are associated with version 1 of the root metadata. This patch changes Client::root_with_pinned to take a version input for the root metadata and start walking the root metadata chain from that possibly later version.