### PR TITLE
Fetch targets by HASH.FILENAME.EXT

### DIFF
--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1435,6 +1435,18 @@ impl TargetPath {
     pub fn value(&self) -> &str {
         &self.0
     }
+
+    /// Prefix the target path with a hash value to support TUF spec 5.5.2.
+    pub fn with_hash_prefix(&self, hash: &HashValue) -> Result<TargetPath> {
+        let mut components = self.components();
+
+        // The unwrap here is safe because we checked in `safe_path` that the path is not empty.
+        let file_name = components.pop().unwrap();
+
+        components.push(format!("{}.{}", hash, file_name));
+
+        TargetPath::new(components.join("/"))
+    }
 }
 
 /// Description of a target, used in verification.


### PR DESCRIPTION
In section 5.5.2 of the [TUF Spec], it states that if consistent snapshots is enabled, targets are downloaded by fetching HASH.FILENAME.EXT.

Note that this is layered on top of https://github.com/heartsucker/rust-tuf/pull/231, so I recommend reviewing that first, then reviewing the second commit. 
    
Closes #225
    
[TUF Spec]: https://github.com/theupdateframework/specification/blob/master/tuf-spec.md#5-detailed-workflows