### PR TITLE
Reformat with rustfmt 1.4.8-stable (afb1ee1c 2019-09-08)

### DIFF
--- a/src/repository.rs
+++ b/src/repository.rs
@@ -264,7 +264,7 @@ where
 
             Ok(())
         }
-        .boxed()
+            .boxed()
     }
 
     /// Fetch signed metadata.
@@ -296,7 +296,7 @@ where
 
             Ok(D::from_slice(&buf)?)
         }
-        .boxed()
+            .boxed()
     }
 
     fn store_target<'a, R>(
@@ -321,7 +321,7 @@ where
 
             Ok(())
         }
-        .boxed()
+            .boxed()
     }
 
     fn fetch_target<'a>(
@@ -348,7 +348,7 @@ where
 
             Ok(reader)
         }
-        .boxed()
+            .boxed()
     }
 }
 
@@ -537,7 +537,7 @@ where
                 "Http repo store metadata not implemented".to_string(),
             ))
         }
-        .boxed()
+            .boxed()
     }
 
     fn fetch_metadata<'a, M>(
@@ -573,7 +573,7 @@ where
 
             Ok(D::from_slice(&buf)?)
         }
-        .boxed()
+            .boxed()
     }
 
     /// This always returns `Err` as storing over HTTP is not yet supported.
@@ -608,7 +608,7 @@ where
 
             Ok(Box::new(reader) as Box<dyn AsyncRead + Send + Unpin>)
         }
-        .boxed()
+            .boxed()
     }
 }
 
@@ -669,7 +669,7 @@ where
                 .insert((meta_path.clone(), version.clone()), buf);
             Ok(())
         }
-        .boxed()
+            .boxed()
     }
 
     fn fetch_metadata<'a, M>(
@@ -708,7 +708,7 @@ where
 
             D::from_slice(&buf)
         }
-        .boxed()
+            .boxed()
     }
 
     fn store_target<'a, R>(
@@ -727,7 +727,7 @@ where
                 .insert(target_path.clone(), Arc::new(buf));
             Ok(())
         }
-        .boxed()
+            .boxed()
     }
 
     fn fetch_target<'a>(
@@ -762,7 +762,7 @@ where
 
             Ok(reader)
         }
-        .boxed()
+            .boxed()
     }
 }
 


### PR DESCRIPTION
Now that we can run on stable, I'm switching over to formatting with rustfmt stable, which should hopefully have less churn than using a random rustfmt nightly.