### PR TITLE
Fix integration tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,41 @@
+version: '{build}'
+
+skip_branch_with_pr: true
+skip_tags: true
+
+max_jobs: 6
+
+matrix:
+  fast_finish: true
+
+environment:
+  matrix:
+    # Rust - Nightly
+    - TARGET: i686-pc-windows-gnu
+      RUST_VERSION: nightly
+      BITS: 32
+      MSYS2: 1
+    - TARGET: x86_64-pc-windows-msvc
+      RUST_VERSION: nightly
+      BITS: 64
+
+install:
+  - curl -sSf -o rustup-init.exe https://win.rustup.rs/
+  - rustup-init.exe -y --default-host %TARGET%
+  - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
+  - if defined MSYS2 set PATH=C:\msys64\mingw%BITS%\bin;%PATH%
+
+build: false
+
+test_script:
+  - rustup.exe default %RUST_VERSION%
+  - rustc -V
+  - cargo -V
+  - cargo build --verbose --target %TARGET%
+  - SET RUST_BACKTRACE=full
+  - cargo test --verbose --target %TARGET%
+
+# TODO on failure cat Cargo.lock
+
+cache:
+  - C:\Users\appveyor\.cargo\bin

--- a/tests/interop/fuchsia-go-tuf-5527fe/.gitattributes
+++ b/tests/interop/fuchsia-go-tuf-5527fe/.gitattributes
@@ -1,0 +1,2 @@
+# Never modify lines endings in our interop directories
+* -text

--- a/tests/interop/fuchsia-go-tuf-transition-M4/.gitattributes
+++ b/tests/interop/fuchsia-go-tuf-transition-M4/.gitattributes
@@ -1,0 +1,2 @@
+# Never modify lines endings in our interop directories
+* -text


### PR DESCRIPTION
This adds a .gitattribute to the interop metadata directories, to make sure that windows bots don't automatically convert line endings to CRLF.
    
In addition, it restores the appveyor.yml config as a stopgap until we disable the appveyor integration (see #235).
