### PR TITLE
Add a json pretty printing interchange

### DIFF
--- a/src/interchange/cjson/mod.rs
+++ b/src/interchange/cjson/mod.rs
@@ -263,11 +263,24 @@ impl DataInterchange for Json {
     }
 
     /// ```
+    /// # use serde_json::json;
     /// # use tuf::interchange::{DataInterchange, Json};
-    /// let arr = vec![1, 2, 3];
+    /// let json = json!({
+    ///     "o": {
+    ///         "a": [1, 2, 3],
+    ///         "s": "string",
+    ///         "n": 123,
+    ///         "t": true,
+    ///         "f": false,
+    ///         "0": null,
+    ///     },
+    /// });
     /// let mut buf = Vec::new();
-    /// Json::to_writer(&mut buf, &arr).unwrap();
-    /// assert_eq!(&buf, b"[1,2,3]");
+    /// Json::to_writer(&mut buf, &json).unwrap();
+    /// assert_eq!(
+    ///     &String::from_utf8(buf).unwrap(),
+    ///     r#"{"o":{"0":null,"a":[1,2,3],"f":false,"n":123,"s":"string","t":true}}"#
+    /// );
     /// ```
     fn to_writer<W, T: Sized>(mut writer: W, value: &T) -> Result<()>
     where

--- a/src/interchange/cjson/mod.rs
+++ b/src/interchange/cjson/mod.rs
@@ -9,7 +9,10 @@ use crate::error::Error;
 use crate::interchange::DataInterchange;
 use crate::Result;
 
+pub(crate) mod pretty;
 pub(crate) mod shims;
+
+pub use pretty::JsonPretty;
 
 /// JSON data interchange.
 ///
@@ -301,76 +304,6 @@ impl DataInterchange for Json {
         T: DeserializeOwned,
     {
         Ok(serde_json::from_slice(slice)?)
-    }
-}
-
-/// Pretty JSON data interchange.
-///
-/// This is identical to [Json] in all manners except for the `to_writer` method. Instead of
-/// writing the metadata in the canonical format, it instead pretty prints the metadata.
-#[derive(Debug, Clone, PartialEq)]
-pub struct JsonPretty;
-
-impl DataInterchange for JsonPretty {
-    type RawData = serde_json::Value;
-
-    fn extension() -> &'static str {
-        Json::extension()
-    }
-
-    fn canonicalize(raw_data: &Self::RawData) -> Result<Vec<u8>> {
-        Json::canonicalize(raw_data)
-    }
-
-    fn deserialize<T>(raw_data: &Self::RawData) -> Result<T>
-    where
-        T: DeserializeOwned,
-    {
-        Json::deserialize(raw_data)
-    }
-
-    fn serialize<T>(data: &T) -> Result<Self::RawData>
-    where
-        T: Serialize,
-    {
-        Json::serialize(data)
-    }
-
-    /// ```
-    /// # use tuf::interchange::{DataInterchange, JsonPretty};
-    /// let arr = vec![1, 2, 3];
-    /// let mut buf = Vec::new();
-    /// JsonPretty::to_writer(&mut buf, &arr).unwrap();
-    /// assert_eq!(&String::from_utf8_lossy(&buf), "[
-    ///   1,
-    ///   2,
-    ///   3
-    /// ]");
-    /// ```
-    fn to_writer<W, T: Sized>(writer: W, value: &T) -> Result<()>
-    where
-        W: Write,
-        T: Serialize,
-    {
-        Ok(serde_json::to_writer_pretty(
-            writer,
-            &Self::serialize(value)?,
-        )?)
-    }
-
-    fn from_reader<R, T>(rdr: R) -> Result<T>
-    where
-        R: Read,
-        T: DeserializeOwned,
-    {
-        Json::from_reader(rdr)
-    }
-
-    fn from_slice<T>(slice: &[u8]) -> Result<T>
-    where
-        T: DeserializeOwned,
-    {
-        Json::from_slice(slice)
     }
 }
 

--- a/src/interchange/cjson/pretty.rs
+++ b/src/interchange/cjson/pretty.rs
@@ -1,0 +1,140 @@
+use serde::de::DeserializeOwned;
+use serde::ser::Serialize;
+use serde_json;
+use std::io::{Read, Write};
+
+use super::Json;
+use crate::interchange::DataInterchange;
+use crate::Result;
+
+/// Pretty JSON data interchange.
+///
+/// This is identical to [Json] in all manners except for the `to_writer` method. Instead of
+/// writing the metadata in the canonical format, it instead pretty prints the metadata.
+#[derive(Debug, Clone, PartialEq)]
+pub struct JsonPretty;
+
+impl DataInterchange for JsonPretty {
+    type RawData = serde_json::Value;
+
+    /// ```
+    /// # use tuf::interchange::{DataInterchange, JsonPretty};
+    /// assert_eq!(JsonPretty::extension(), "json");
+    /// ```
+    fn extension() -> &'static str {
+        Json::extension()
+    }
+
+    /// ```
+    /// # use tuf::interchange::{DataInterchange, JsonPretty};
+    /// # use std::collections::HashMap;
+    /// let jsn: &[u8] = br#"{"foo": "bar", "baz": "quux"}"#;
+    /// let raw = JsonPretty::from_reader(jsn).unwrap();
+    /// let out = JsonPretty::canonicalize(&raw).unwrap();
+    /// assert_eq!(out, br#"{"baz":"quux","foo":"bar"}"#);
+    /// ```
+    fn canonicalize(raw_data: &Self::RawData) -> Result<Vec<u8>> {
+        Json::canonicalize(raw_data)
+    }
+
+    /// ```
+    /// # use serde_derive::Deserialize;
+    /// # use serde_json::json;
+    /// # use std::collections::HashMap;
+    /// # use tuf::interchange::{DataInterchange, JsonPretty};
+    /// #
+    /// #[derive(Deserialize, Debug, PartialEq)]
+    /// struct Thing {
+    ///    foo: String,
+    ///    bar: String,
+    /// }
+    ///
+    /// # fn main() {
+    /// let jsn = json!({"foo": "wat", "bar": "lol"});
+    /// let thing = Thing { foo: "wat".into(), bar: "lol".into() };
+    /// let de: Thing = JsonPretty::deserialize(&jsn).unwrap();
+    /// assert_eq!(de, thing);
+    /// # }
+    /// ```
+    fn deserialize<T>(raw_data: &Self::RawData) -> Result<T>
+    where
+        T: DeserializeOwned,
+    {
+        Json::deserialize(raw_data)
+    }
+
+    /// ```
+    /// # use serde_derive::Serialize;
+    /// # use serde_json::json;
+    /// # use std::collections::HashMap;
+    /// # use tuf::interchange::{DataInterchange, JsonPretty};
+    /// #
+    /// #[derive(Serialize)]
+    /// struct Thing {
+    ///    foo: String,
+    ///    bar: String,
+    /// }
+    ///
+    /// # fn main() {
+    /// let jsn = json!({"foo": "wat", "bar": "lol"});
+    /// let thing = Thing { foo: "wat".into(), bar: "lol".into() };
+    /// let se: serde_json::Value = JsonPretty::serialize(&thing).unwrap();
+    /// assert_eq!(se, jsn);
+    /// # }
+    /// ```
+    fn serialize<T>(data: &T) -> Result<Self::RawData>
+    where
+        T: Serialize,
+    {
+        Json::serialize(data)
+    }
+
+    /// ```
+    /// # use tuf::interchange::{DataInterchange, JsonPretty};
+    /// let arr = vec![1, 2, 3];
+    /// let mut buf = Vec::new();
+    /// JsonPretty::to_writer(&mut buf, &arr).unwrap();
+    /// assert_eq!(&String::from_utf8_lossy(&buf), "[
+    ///   1,
+    ///   2,
+    ///   3
+    /// ]");
+    /// ```
+    fn to_writer<W, T: Sized>(writer: W, value: &T) -> Result<()>
+    where
+        W: Write,
+        T: Serialize,
+    {
+        Ok(serde_json::to_writer_pretty(
+            writer,
+            &Self::serialize(value)?,
+        )?)
+    }
+
+    /// ```
+    /// # use tuf::interchange::{DataInterchange, JsonPretty};
+    /// # use std::collections::HashMap;
+    /// let jsn: &[u8] = br#"{"foo": "bar", "baz": "quux"}"#;
+    /// let _: HashMap<String, String> = JsonPretty::from_reader(jsn).unwrap();
+    /// ```
+    fn from_reader<R, T>(rdr: R) -> Result<T>
+    where
+        R: Read,
+        T: DeserializeOwned,
+    {
+        Json::from_reader(rdr)
+    }
+
+    /// ```
+    /// # use tuf::interchange::{DataInterchange, JsonPretty};
+    /// # use std::collections::HashMap;
+    /// let jsn: &[u8] = br#"{"foo": "bar", "baz": "quux"}"#;
+    /// let _: HashMap<String, String> = JsonPretty::from_slice(&jsn).unwrap();
+    /// ```
+    fn from_slice<T>(slice: &[u8]) -> Result<T>
+    where
+        T: DeserializeOwned,
+    {
+        Json::from_slice(slice)
+    }
+}

--- a/src/interchange/cjson/pretty.rs
+++ b/src/interchange/cjson/pretty.rs
@@ -90,15 +90,34 @@ impl DataInterchange for JsonPretty {
     }
 
     /// ```
+    /// # use serde_json::json;
     /// # use tuf::interchange::{DataInterchange, JsonPretty};
-    /// let arr = vec![1, 2, 3];
+    /// let json = json!({
+    ///     "o": {
+    ///         "a": [1, 2, 3],
+    ///         "s": "string",
+    ///         "n": 123,
+    ///         "t": true,
+    ///         "f": false,
+    ///         "0": null,
+    ///     },
+    /// });
     /// let mut buf = Vec::new();
-    /// JsonPretty::to_writer(&mut buf, &arr).unwrap();
-    /// assert_eq!(&String::from_utf8_lossy(&buf), "[
-    ///   1,
-    ///   2,
-    ///   3
-    /// ]");
+    /// JsonPretty::to_writer(&mut buf, &json).unwrap();
+    /// assert_eq!(&String::from_utf8(buf).unwrap(), r#"{
+    ///   "o": {
+    ///     "0": null,
+    ///     "a": [
+    ///       1,
+    ///       2,
+    ///       3
+    ///     ],
+    ///     "f": false,
+    ///     "n": 123,
+    ///     "s": "string",
+    ///     "t": true
+    ///   }
+    /// }"#);
     /// ```
     fn to_writer<W, T: Sized>(writer: W, value: &T) -> Result<()>
     where

--- a/src/interchange/mod.rs
+++ b/src/interchange/mod.rs
@@ -1,7 +1,7 @@
 //! Structures and functions to aid in various TUF data interchange formats.
 
 pub(crate) mod cjson;
-pub use cjson::Json;
+pub use cjson::{Json, JsonPretty};
 
 use serde::de::DeserializeOwned;
 use serde::ser::Serialize;
@@ -32,9 +32,6 @@ pub trait DataInterchange: Debug + PartialEq + Clone {
         T: Serialize;
 
     /// Write a struct to a stream.
-    ///
-    /// Note: This *MUST* write the bytes canonically for hashes to line up correctly in other
-    /// areas of the library.
     fn to_writer<W, T: Sized>(writer: W, value: &T) -> Result<()>
     where
         W: Write,

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -929,7 +929,8 @@ impl TimestampMetadataBuilder {
         D: DataInterchange,
         M: Metadata,
     {
-        let bytes = D::canonicalize(&D::serialize(&snapshot)?)?;
+        let mut bytes = Vec::new();
+        D::to_writer(&mut bytes, &snapshot)?;
         let description = MetadataDescription::from_reader(&*bytes, snapshot.version(), hash_algs)?;
 
         Ok(Self::from_metadata_description(description))
@@ -1185,7 +1186,8 @@ impl SnapshotMetadataBuilder {
         M: Metadata,
         D: DataInterchange,
     {
-        let bytes = D::canonicalize(&D::serialize(metadata)?)?;
+        let mut bytes = Vec::new();
+        D::to_writer(&mut bytes, metadata)?;
         let description = MetadataDescription::from_reader(&*bytes, metadata.version(), hash_algs)?;
         let path = MetadataPath::new(path)?;
         Ok(self.insert_metadata_description(path, description))


### PR DESCRIPTION
This adds an interchange called `JsonPretty`, which makes it easier for humans to review metadata changes. It is identical to `tuf::interchange::Json`, except for the implementation of `to_writer`. Instead of writing out the canonical form, it writes out a pretty printed form of the data.

In addition, it changes `SnapshotMetadataBuilder::insert_metadata_with_path` and `TimestampMetadataBuilder::from_snapshot` to use `D::to_writer`. This makes sure that the hash of these metadata files are computed from the format written to disk, instead of the canonical format.

Closes: #238