### PR TITLE
Make git ignore .* files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target
 Cargo.lock
 *.rs.bk
+.*


### PR DESCRIPTION
The reason is that vim (my text editor) uses files starting with '.' for autosave and recovery, these files are hidden by default by 'ls' and most other Linux applications.