### PR TITLE
Identity test with checked in metadata

### DIFF
--- a/tests/interop/main.rs
+++ b/tests/interop/main.rs
@@ -90,7 +90,7 @@ fn fuchsia_go_tuf_transition_m4_consistent_snapshot_true() {
 
 // Tests to catch changes to the way we generate metadata.
 #[test]
-fn fuchsia_rust_tuf_identity_consistent_snapshot_false() {
+fn rust_tuf_identity_consistent_snapshot_false() {
     test_key_rotation(
         Path::new("tests")
             .join("metadata")
@@ -100,7 +100,7 @@ fn fuchsia_rust_tuf_identity_consistent_snapshot_false() {
 
 #[test]
 #[ignore] // FIXME: Blocked on #225
-fn fuchsia_rust_tuf_identity_consistent_snapshot_true() {
+fn rust_tuf_identity_consistent_snapshot_true() {
     test_key_rotation(
         Path::new("tests")
             .join("metadata")

--- a/tests/interop/main.rs
+++ b/tests/interop/main.rs
@@ -85,7 +85,27 @@ fn fuchsia_go_tuf_transition_m4_consistent_snapshot_true() {
             .join("interop")
             .join("fuchsia-go-tuf-transition-M4")
             .join("consistent-snapshot-true"),
-    )
+    );
+}
+
+// Tests to catch changes to the way we generate metadata.
+#[test]
+fn fuchsia_rust_tuf_identity_consistent_snapshot_false() {
+    test_key_rotation(
+        Path::new("tests")
+            .join("metadata")
+            .join("consistent-snapshot-false"),
+    );
+}
+
+#[test]
+#[ignore] // FIXME: Blocked on #225
+fn fuchsia_rust_tuf_identity_consistent_snapshot_true() {
+    test_key_rotation(
+        Path::new("tests")
+            .join("metadata")
+            .join("consistent-snapshot-true"),
+    );
 }
 
 fn test_key_rotation(dir: PathBuf) {

--- a/tests/metadata/consistent-snapshot-false/1/repository/1.root.json
+++ b/tests/metadata/consistent-snapshot-false/1/repository/1.root.json
@@ -1,1 +1,87 @@
-../../0/repository/1.root.json
+{
+  "signatures": [
+    {
+      "keyid": "ce72db3f938914205461a415c9b7b91267a2079df991fd6283aa8461988c1add",
+      "sig": "afab8b34f93c99e200505cc6f0d6a9c4e757a7229f96bd31ab618f8bc4c3abe491b372bfec9d231136de46c1e183df194d372360ee9d32652f8c04d7574e2608"
+    }
+  ],
+  "signed": {
+    "_type": "root",
+    "consistent_snapshot": false,
+    "expires": "2100-01-01T00:00:00Z",
+    "keys": {
+      "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "d482fa4805a50870aa1356ace6b764f7ab47ed4dc38f49b1a189afa25f179e94"
+        },
+        "scheme": "ed25519"
+      },
+      "808aa256a8172bb0cb961767c6768e55ccf732c99afccc6145752d7a328b7937": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "62f71f99c788f16bcdc8bb252455e3a690350e4ddea5a6aab1f9a3aaabcf369a"
+        },
+        "scheme": "ed25519"
+      },
+      "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "8656ad20568cd3534c405e4d9a84b0c6e6163f7f66434df77416502835b9b160"
+        },
+        "scheme": "ed25519"
+      },
+      "ce72db3f938914205461a415c9b7b91267a2079df991fd6283aa8461988c1add": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "bca152214dbfd3e7a1b7a7b3e2cc179fb00520fd7212c8a60ba99f14dfc0e1ca"
+        },
+        "scheme": "ed25519"
+      }
+    },
+    "roles": {
+      "root": {
+        "keyids": [
+          "ce72db3f938914205461a415c9b7b91267a2079df991fd6283aa8461988c1add"
+        ],
+        "threshold": 1
+      },
+      "snapshot": {
+        "keyids": [
+          "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45"
+        ],
+        "threshold": 1
+      },
+      "targets": {
+        "keyids": [
+          "808aa256a8172bb0cb961767c6768e55ccf732c99afccc6145752d7a328b7937"
+        ],
+        "threshold": 1
+      },
+      "timestamp": {
+        "keyids": [
+          "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8"
+        ],
+        "threshold": 1
+      }
+    },
+    "spec_version": "1.0",
+    "version": 1
+  }
+}

--- a/tests/metadata/consistent-snapshot-false/1/repository/2.root.json
+++ b/tests/metadata/consistent-snapshot-false/1/repository/2.root.json
@@ -2,7 +2,11 @@
   "signatures": [
     {
       "keyid": "ce72db3f938914205461a415c9b7b91267a2079df991fd6283aa8461988c1add",
-      "sig": "a38848508d2ce8697c5eec5de2a65f845ba1e6a25ae0e0d4be06cd0e3ca0f196a8bb3d16154e558a12281f234f73fdab175cfbb4bab2f94bc40b4c710fafb203"
+      "sig": "65f63745aa8bd39132f827c427ea6d87f620ec805d9f376b6a8400dc3db7eb964e5423d31ed08867916d039661a70d6bf255bca552248021a4e78b5d357c2b0f"
+    },
+    {
+      "keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
+      "sig": "20e91b55c995989b270091b714347b15169285cb636ef05d68d49ed7b7a96ebfda13898e0d9ef928c382873b9dba90dca492dbf705d56a4b293adaaed574340f"
     }
   ],
   "signed": {
@@ -82,6 +86,6 @@
       }
     },
     "spec_version": "1.0",
-    "version": 1
+    "version": 2
   }
 }

--- a/tests/metadata/consistent-snapshot-false/1/repository/root.json
+++ b/tests/metadata/consistent-snapshot-false/1/repository/root.json
@@ -2,7 +2,11 @@
   "signatures": [
     {
       "keyid": "ce72db3f938914205461a415c9b7b91267a2079df991fd6283aa8461988c1add",
-      "sig": "a38848508d2ce8697c5eec5de2a65f845ba1e6a25ae0e0d4be06cd0e3ca0f196a8bb3d16154e558a12281f234f73fdab175cfbb4bab2f94bc40b4c710fafb203"
+      "sig": "65f63745aa8bd39132f827c427ea6d87f620ec805d9f376b6a8400dc3db7eb964e5423d31ed08867916d039661a70d6bf255bca552248021a4e78b5d357c2b0f"
+    },
+    {
+      "keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
+      "sig": "20e91b55c995989b270091b714347b15169285cb636ef05d68d49ed7b7a96ebfda13898e0d9ef928c382873b9dba90dca492dbf705d56a4b293adaaed574340f"
     }
   ],
   "signed": {
@@ -82,6 +86,6 @@
       }
     },
     "spec_version": "1.0",
-    "version": 1
+    "version": 2
   }
 }

--- a/tests/metadata/consistent-snapshot-false/1/repository/snapshot.json
+++ b/tests/metadata/consistent-snapshot-false/1/repository/snapshot.json
@@ -2,7 +2,7 @@
   "signatures": [
     {
       "keyid": "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45",
-      "sig": "a6cb00a2106e095857edb20d9e59c6d722af93c1a58f15c4d4384a46efa98a1d0e39f745717662603f47e048966fff6e9d0d2f366cdb33e774ce1bf70da1a404"
+      "sig": "c3eaa4ff63e189db79bac83d03ba6ac4fce89202535a3634ff9ec1df8a77537b01ada21cfd7f7426a918047e86145f60cafbd451142f382a4618c0f27b19d207"
     }
   ],
   "signed": {
@@ -11,13 +11,13 @@
     "meta": {
       "targets.json": {
         "hashes": {
-          "sha256": "b94550c5ca58966c848a41a3b8c2c81f247fe42309f44591ce785824b175691d"
+          "sha256": "5975a125ea2a25f4ef671597937c0ed2aee4a3d403c3b4f28c3b265d3acae79f"
         },
         "length": 733,
-        "version": 1
+        "version": 2
       }
     },
     "spec_version": "1.0",
-    "version": 1
+    "version": 2
   }
 }

--- a/tests/metadata/consistent-snapshot-false/1/repository/targets.json
+++ b/tests/metadata/consistent-snapshot-false/1/repository/targets.json
@@ -2,7 +2,7 @@
   "signatures": [
     {
       "keyid": "808aa256a8172bb0cb961767c6768e55ccf732c99afccc6145752d7a328b7937",
-      "sig": "66bddbea0156eb594981fc24ac769cf325c8fed350e83827c375870d51daebdc9e695454eb4a01e8573da21c426440344f8de9ba2f1ef77c989eeb64df9f810d"
+      "sig": "286234d725c777e3b7361af91d92e509f83d9c9e53feb7daad291f34e49557af418716bc7bf88901fd1beb0d580848516cb7c1a2623d526b8d0c68d67624e80f"
     }
   ],
   "signed": {
@@ -23,6 +23,6 @@
         "length": 1
       }
     },
-    "version": 1
+    "version": 2
   }
 }

--- a/tests/metadata/consistent-snapshot-false/1/repository/targets/0
+++ b/tests/metadata/consistent-snapshot-false/1/repository/targets/0
@@ -1,1 +1,1 @@
-../../../0/repository/targets/0
+0

--- a/tests/metadata/consistent-snapshot-false/1/repository/timestamp.json
+++ b/tests/metadata/consistent-snapshot-false/1/repository/timestamp.json
@@ -2,7 +2,7 @@
   "signatures": [
     {
       "keyid": "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8",
-      "sig": "f0dbea901a89a58b1e1500c7470a5d791f74850b8dfb317701ad9558f8f1d57737a2364ac776fef71e35eab48d232b16f3215e99ff469387699b890430e6640a"
+      "sig": "9a83f1f85472bd01726739d63bbc95b2ac5bb7146cfe73debfb6379e2aca2a30158b1420436c2f82f080d10e4b27bcbfdfcb1c93501416edc3ae73d6ad5c760d"
     }
   ],
   "signed": {
@@ -11,13 +11,13 @@
     "meta": {
       "snapshot.json": {
         "hashes": {
-          "sha256": "80e5b2e94e657b4ff468965369ee9981e67c973d6576e9a970ea4d7ca07fd87e"
+          "sha256": "57a4211414ea2fd5304683ad93b7187ef4145c98df54293389b8d978d98e5cce"
         },
         "length": 606,
-        "version": 1
+        "version": 2
       }
     },
     "spec_version": "1.0",
-    "version": 1
+    "version": 2
   }
 }

--- a/tests/metadata/consistent-snapshot-false/2/repository/1.root.json
+++ b/tests/metadata/consistent-snapshot-false/2/repository/1.root.json
@@ -1,1 +1,87 @@
-../../1/repository/1.root.json
+{
+  "signatures": [
+    {
+      "keyid": "ce72db3f938914205461a415c9b7b91267a2079df991fd6283aa8461988c1add",
+      "sig": "afab8b34f93c99e200505cc6f0d6a9c4e757a7229f96bd31ab618f8bc4c3abe491b372bfec9d231136de46c1e183df194d372360ee9d32652f8c04d7574e2608"
+    }
+  ],
+  "signed": {
+    "_type": "root",
+    "consistent_snapshot": false,
+    "expires": "2100-01-01T00:00:00Z",
+    "keys": {
+      "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "d482fa4805a50870aa1356ace6b764f7ab47ed4dc38f49b1a189afa25f179e94"
+        },
+        "scheme": "ed25519"
+      },
+      "808aa256a8172bb0cb961767c6768e55ccf732c99afccc6145752d7a328b7937": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "62f71f99c788f16bcdc8bb252455e3a690350e4ddea5a6aab1f9a3aaabcf369a"
+        },
+        "scheme": "ed25519"
+      },
+      "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "8656ad20568cd3534c405e4d9a84b0c6e6163f7f66434df77416502835b9b160"
+        },
+        "scheme": "ed25519"
+      },
+      "ce72db3f938914205461a415c9b7b91267a2079df991fd6283aa8461988c1add": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "bca152214dbfd3e7a1b7a7b3e2cc179fb00520fd7212c8a60ba99f14dfc0e1ca"
+        },
+        "scheme": "ed25519"
+      }
+    },
+    "roles": {
+      "root": {
+        "keyids": [
+          "ce72db3f938914205461a415c9b7b91267a2079df991fd6283aa8461988c1add"
+        ],
+        "threshold": 1
+      },
+      "snapshot": {
+        "keyids": [
+          "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45"
+        ],
+        "threshold": 1
+      },
+      "targets": {
+        "keyids": [
+          "808aa256a8172bb0cb961767c6768e55ccf732c99afccc6145752d7a328b7937"
+        ],
+        "threshold": 1
+      },
+      "timestamp": {
+        "keyids": [
+          "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8"
+        ],
+        "threshold": 1
+      }
+    },
+    "spec_version": "1.0",
+    "version": 1
+  }
+}

--- a/tests/metadata/consistent-snapshot-false/2/repository/2.root.json
+++ b/tests/metadata/consistent-snapshot-false/2/repository/2.root.json
@@ -1,1 +1,91 @@
-../../1/repository/2.root.json
+{
+  "signatures": [
+    {
+      "keyid": "ce72db3f938914205461a415c9b7b91267a2079df991fd6283aa8461988c1add",
+      "sig": "65f63745aa8bd39132f827c427ea6d87f620ec805d9f376b6a8400dc3db7eb964e5423d31ed08867916d039661a70d6bf255bca552248021a4e78b5d357c2b0f"
+    },
+    {
+      "keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
+      "sig": "20e91b55c995989b270091b714347b15169285cb636ef05d68d49ed7b7a96ebfda13898e0d9ef928c382873b9dba90dca492dbf705d56a4b293adaaed574340f"
+    }
+  ],
+  "signed": {
+    "_type": "root",
+    "consistent_snapshot": false,
+    "expires": "2100-01-01T00:00:00Z",
+    "keys": {
+      "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "d482fa4805a50870aa1356ace6b764f7ab47ed4dc38f49b1a189afa25f179e94"
+        },
+        "scheme": "ed25519"
+      },
+      "808aa256a8172bb0cb961767c6768e55ccf732c99afccc6145752d7a328b7937": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "62f71f99c788f16bcdc8bb252455e3a690350e4ddea5a6aab1f9a3aaabcf369a"
+        },
+        "scheme": "ed25519"
+      },
+      "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "8656ad20568cd3534c405e4d9a84b0c6e6163f7f66434df77416502835b9b160"
+        },
+        "scheme": "ed25519"
+      },
+      "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "153986a7370e002f377dd68797e7466c421180c1571e233de2f8ab41c8af4f54"
+        },
+        "scheme": "ed25519"
+      }
+    },
+    "roles": {
+      "root": {
+        "keyids": [
+          "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f"
+        ],
+        "threshold": 1
+      },
+      "snapshot": {
+        "keyids": [
+          "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45"
+        ],
+        "threshold": 1
+      },
+      "targets": {
+        "keyids": [
+          "808aa256a8172bb0cb961767c6768e55ccf732c99afccc6145752d7a328b7937"
+        ],
+        "threshold": 1
+      },
+      "timestamp": {
+        "keyids": [
+          "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8"
+        ],
+        "threshold": 1
+      }
+    },
+    "spec_version": "1.0",
+    "version": 2
+  }
+}

--- a/tests/metadata/consistent-snapshot-false/2/repository/3.root.json
+++ b/tests/metadata/consistent-snapshot-false/2/repository/3.root.json
@@ -2,7 +2,7 @@
   "signatures": [
     {
       "keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
-      "sig": "d1650d9b57eb9af129bb590fa176528e3bc9e0bc16c7d9fa766b0ca98442fd78c5c106985cd13245084ff17f3856244f4a5831949617eacad7025637db647b0c"
+      "sig": "cfe8b0919d1707ca6c23501909b77c8b94d1ede2b85a3081ab7146244cc6fe436b06ad58163919276f2e37ddbcc13a0dde4851301053dcea2a9bcabc5e1cd004"
     }
   ],
   "signed": {
@@ -82,6 +82,6 @@
       }
     },
     "spec_version": "1.0",
-    "version": 1
+    "version": 3
   }
 }

--- a/tests/metadata/consistent-snapshot-false/2/repository/root.json
+++ b/tests/metadata/consistent-snapshot-false/2/repository/root.json
@@ -2,7 +2,7 @@
   "signatures": [
     {
       "keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
-      "sig": "d1650d9b57eb9af129bb590fa176528e3bc9e0bc16c7d9fa766b0ca98442fd78c5c106985cd13245084ff17f3856244f4a5831949617eacad7025637db647b0c"
+      "sig": "cfe8b0919d1707ca6c23501909b77c8b94d1ede2b85a3081ab7146244cc6fe436b06ad58163919276f2e37ddbcc13a0dde4851301053dcea2a9bcabc5e1cd004"
     }
   ],
   "signed": {
@@ -82,6 +82,6 @@
       }
     },
     "spec_version": "1.0",
-    "version": 1
+    "version": 3
   }
 }

--- a/tests/metadata/consistent-snapshot-false/2/repository/snapshot.json
+++ b/tests/metadata/consistent-snapshot-false/2/repository/snapshot.json
@@ -2,7 +2,7 @@
   "signatures": [
     {
       "keyid": "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45",
-      "sig": "5be4664c0ada239accc1a52f005aaeafd84ef7836586b62122802c9b0566707dab0323e3e7a132614d3451c565e9406abf9fa56bbdd7889de9573922e1b66609"
+      "sig": "88450c663d32ed78e937ba759c106349bf94c1c44307ef07191cb595a7e4328abcea952134533f2ef5d7ce56d0ca68899636d3037e497d2f034b5e4ba27b3c00"
     }
   ],
   "signed": {
@@ -11,13 +11,13 @@
     "meta": {
       "targets.json": {
         "hashes": {
-          "sha256": "862027382b8c6b9300e04ca83246abc68e7210af75b5df70aa984c0c1ed9fc2f"
+          "sha256": "d9b3218dc3c3527b24f851212f352aa3d4ca07c40552a130b7ca45105ca96fa7"
         },
         "length": 893,
-        "version": 1
+        "version": 3
       }
     },
     "spec_version": "1.0",
-    "version": 1
+    "version": 3
   }
 }

--- a/tests/metadata/consistent-snapshot-false/2/repository/targets.json
+++ b/tests/metadata/consistent-snapshot-false/2/repository/targets.json
@@ -2,7 +2,7 @@
   "signatures": [
     {
       "keyid": "bc8f087663855564b358ddf314d5932ab920af17bd1df2f58b397afd82d76dc1",
-      "sig": "d45d0a32ad2b1f71589b5586a457aa7d27a4e8d64747edbd6e18b6d8499c37032eac36d68b05ecbe839058f1c78b5d26d8ad1cb83947594186e8500db21e8008"
+      "sig": "e19dc8a26f209a8422b21b71d1f0c2ffd5e2eea9d0f8848ca8395c496735860bafd28b62deb8f439a3b2e957494f751eca28399e406e062a0591e1549ab86508"
     }
   ],
   "signed": {
@@ -29,6 +29,6 @@
         "length": 1
       }
     },
-    "version": 1
+    "version": 3
   }
 }

--- a/tests/metadata/consistent-snapshot-false/2/repository/targets/0
+++ b/tests/metadata/consistent-snapshot-false/2/repository/targets/0
@@ -1,1 +1,1 @@
-../../../1/repository/targets/0
+0

--- a/tests/metadata/consistent-snapshot-false/2/repository/targets/1
+++ b/tests/metadata/consistent-snapshot-false/2/repository/targets/1
@@ -1,1 +1,1 @@
-../../../1/repository/targets/1
+1

--- a/tests/metadata/consistent-snapshot-false/2/repository/timestamp.json
+++ b/tests/metadata/consistent-snapshot-false/2/repository/timestamp.json
@@ -2,7 +2,7 @@
   "signatures": [
     {
       "keyid": "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8",
-      "sig": "774139b1204af52960e5375cf775ffb6e0a5f6863d003b8eeeb9a333c92910a0518ddc98b958c75520e95dcbc944c42a49134370a8a5c3723794ae2c10c0f00d"
+      "sig": "6090861afdf2b0dc5b899291d4ff3af9ab731b84660351a929c649b6cd5e0db6c63f480ffdbd70d9d22fd09f7144fae54df5c8db8a37757a3d0b83fce6acda09"
     }
   ],
   "signed": {
@@ -11,13 +11,13 @@
     "meta": {
       "snapshot.json": {
         "hashes": {
-          "sha256": "117d2ed64ce4baa4fdb0f097d3442d2558655ba5ee273a2eda7f8412e0cf9b12"
+          "sha256": "94fc023ccf37a06e6264117a3908f678f348b0a200faed236e68c1457b1faec3"
         },
         "length": 606,
-        "version": 1
+        "version": 3
       }
     },
     "spec_version": "1.0",
-    "version": 1
+    "version": 3
   }
 }

--- a/tests/metadata/consistent-snapshot-false/3/repository/1.root.json
+++ b/tests/metadata/consistent-snapshot-false/3/repository/1.root.json
@@ -1,1 +1,87 @@
-../../2/repository/1.root.json
+{
+  "signatures": [
+    {
+      "keyid": "ce72db3f938914205461a415c9b7b91267a2079df991fd6283aa8461988c1add",
+      "sig": "afab8b34f93c99e200505cc6f0d6a9c4e757a7229f96bd31ab618f8bc4c3abe491b372bfec9d231136de46c1e183df194d372360ee9d32652f8c04d7574e2608"
+    }
+  ],
+  "signed": {
+    "_type": "root",
+    "consistent_snapshot": false,
+    "expires": "2100-01-01T00:00:00Z",
+    "keys": {
+      "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "d482fa4805a50870aa1356ace6b764f7ab47ed4dc38f49b1a189afa25f179e94"
+        },
+        "scheme": "ed25519"
+      },
+      "808aa256a8172bb0cb961767c6768e55ccf732c99afccc6145752d7a328b7937": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "62f71f99c788f16bcdc8bb252455e3a690350e4ddea5a6aab1f9a3aaabcf369a"
+        },
+        "scheme": "ed25519"
+      },
+      "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "8656ad20568cd3534c405e4d9a84b0c6e6163f7f66434df77416502835b9b160"
+        },
+        "scheme": "ed25519"
+      },
+      "ce72db3f938914205461a415c9b7b91267a2079df991fd6283aa8461988c1add": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "bca152214dbfd3e7a1b7a7b3e2cc179fb00520fd7212c8a60ba99f14dfc0e1ca"
+        },
+        "scheme": "ed25519"
+      }
+    },
+    "roles": {
+      "root": {
+        "keyids": [
+          "ce72db3f938914205461a415c9b7b91267a2079df991fd6283aa8461988c1add"
+        ],
+        "threshold": 1
+      },
+      "snapshot": {
+        "keyids": [
+          "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45"
+        ],
+        "threshold": 1
+      },
+      "targets": {
+        "keyids": [
+          "808aa256a8172bb0cb961767c6768e55ccf732c99afccc6145752d7a328b7937"
+        ],
+        "threshold": 1
+      },
+      "timestamp": {
+        "keyids": [
+          "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8"
+        ],
+        "threshold": 1
+      }
+    },
+    "spec_version": "1.0",
+    "version": 1
+  }
+}

--- a/tests/metadata/consistent-snapshot-false/3/repository/2.root.json
+++ b/tests/metadata/consistent-snapshot-false/3/repository/2.root.json
@@ -1,1 +1,91 @@
-../../2/repository/2.root.json
+{
+  "signatures": [
+    {
+      "keyid": "ce72db3f938914205461a415c9b7b91267a2079df991fd6283aa8461988c1add",
+      "sig": "65f63745aa8bd39132f827c427ea6d87f620ec805d9f376b6a8400dc3db7eb964e5423d31ed08867916d039661a70d6bf255bca552248021a4e78b5d357c2b0f"
+    },
+    {
+      "keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
+      "sig": "20e91b55c995989b270091b714347b15169285cb636ef05d68d49ed7b7a96ebfda13898e0d9ef928c382873b9dba90dca492dbf705d56a4b293adaaed574340f"
+    }
+  ],
+  "signed": {
+    "_type": "root",
+    "consistent_snapshot": false,
+    "expires": "2100-01-01T00:00:00Z",
+    "keys": {
+      "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "d482fa4805a50870aa1356ace6b764f7ab47ed4dc38f49b1a189afa25f179e94"
+        },
+        "scheme": "ed25519"
+      },
+      "808aa256a8172bb0cb961767c6768e55ccf732c99afccc6145752d7a328b7937": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "62f71f99c788f16bcdc8bb252455e3a690350e4ddea5a6aab1f9a3aaabcf369a"
+        },
+        "scheme": "ed25519"
+      },
+      "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "8656ad20568cd3534c405e4d9a84b0c6e6163f7f66434df77416502835b9b160"
+        },
+        "scheme": "ed25519"
+      },
+      "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "153986a7370e002f377dd68797e7466c421180c1571e233de2f8ab41c8af4f54"
+        },
+        "scheme": "ed25519"
+      }
+    },
+    "roles": {
+      "root": {
+        "keyids": [
+          "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f"
+        ],
+        "threshold": 1
+      },
+      "snapshot": {
+        "keyids": [
+          "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45"
+        ],
+        "threshold": 1
+      },
+      "targets": {
+        "keyids": [
+          "808aa256a8172bb0cb961767c6768e55ccf732c99afccc6145752d7a328b7937"
+        ],
+        "threshold": 1
+      },
+      "timestamp": {
+        "keyids": [
+          "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8"
+        ],
+        "threshold": 1
+      }
+    },
+    "spec_version": "1.0",
+    "version": 2
+  }
+}

--- a/tests/metadata/consistent-snapshot-false/3/repository/3.root.json
+++ b/tests/metadata/consistent-snapshot-false/3/repository/3.root.json
@@ -1,1 +1,87 @@
-../../2/repository/3.root.json
+{
+  "signatures": [
+    {
+      "keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
+      "sig": "cfe8b0919d1707ca6c23501909b77c8b94d1ede2b85a3081ab7146244cc6fe436b06ad58163919276f2e37ddbcc13a0dde4851301053dcea2a9bcabc5e1cd004"
+    }
+  ],
+  "signed": {
+    "_type": "root",
+    "consistent_snapshot": false,
+    "expires": "2100-01-01T00:00:00Z",
+    "keys": {
+      "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "d482fa4805a50870aa1356ace6b764f7ab47ed4dc38f49b1a189afa25f179e94"
+        },
+        "scheme": "ed25519"
+      },
+      "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "8656ad20568cd3534c405e4d9a84b0c6e6163f7f66434df77416502835b9b160"
+        },
+        "scheme": "ed25519"
+      },
+      "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "153986a7370e002f377dd68797e7466c421180c1571e233de2f8ab41c8af4f54"
+        },
+        "scheme": "ed25519"
+      },
+      "bc8f087663855564b358ddf314d5932ab920af17bd1df2f58b397afd82d76dc1": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "aee574e56780ea1709a8b56e02d4ffdd9a3a1deaed61e2eb0701f376a4422e42"
+        },
+        "scheme": "ed25519"
+      }
+    },
+    "roles": {
+      "root": {
+        "keyids": [
+          "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f"
+        ],
+        "threshold": 1
+      },
+      "snapshot": {
+        "keyids": [
+          "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45"
+        ],
+        "threshold": 1
+      },
+      "targets": {
+        "keyids": [
+          "bc8f087663855564b358ddf314d5932ab920af17bd1df2f58b397afd82d76dc1"
+        ],
+        "threshold": 1
+      },
+      "timestamp": {
+        "keyids": [
+          "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8"
+        ],
+        "threshold": 1
+      }
+    },
+    "spec_version": "1.0",
+    "version": 3
+  }
+}

--- a/tests/metadata/consistent-snapshot-false/3/repository/4.root.json
+++ b/tests/metadata/consistent-snapshot-false/3/repository/4.root.json
@@ -2,7 +2,7 @@
   "signatures": [
     {
       "keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
-      "sig": "f7d77c0fa229d3590c6f2d3966e5498c9dda562098698aa85c87bb2d2cfe7534dc24d3fd38fd985f2ef527aa85b3c07617ed357e6ca89a16f030d4b410238702"
+      "sig": "3004c4b60645c6cca18e33835837a1639eead05355aa549f1d1304a22304e7058a50fb6188fc3617a47248eb7481de7a625f036cc69b53daf04a103b12768401"
     }
   ],
   "signed": {
@@ -82,6 +82,6 @@
       }
     },
     "spec_version": "1.0",
-    "version": 1
+    "version": 4
   }
 }

--- a/tests/metadata/consistent-snapshot-false/3/repository/root.json
+++ b/tests/metadata/consistent-snapshot-false/3/repository/root.json
@@ -2,7 +2,7 @@
   "signatures": [
     {
       "keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
-      "sig": "f7d77c0fa229d3590c6f2d3966e5498c9dda562098698aa85c87bb2d2cfe7534dc24d3fd38fd985f2ef527aa85b3c07617ed357e6ca89a16f030d4b410238702"
+      "sig": "3004c4b60645c6cca18e33835837a1639eead05355aa549f1d1304a22304e7058a50fb6188fc3617a47248eb7481de7a625f036cc69b53daf04a103b12768401"
     }
   ],
   "signed": {
@@ -82,6 +82,6 @@
       }
     },
     "spec_version": "1.0",
-    "version": 1
+    "version": 4
   }
 }

--- a/tests/metadata/consistent-snapshot-false/3/repository/snapshot.json
+++ b/tests/metadata/consistent-snapshot-false/3/repository/snapshot.json
@@ -2,7 +2,7 @@
   "signatures": [
     {
       "keyid": "b096bc2d67080cec22e6c0bbaa69cfd9d714b9e9ad847d255f950b2728855fef",
-      "sig": "de676dd15bf3535afc7f95fb81384a14d81454cbb980cfef623332d7f7df9e5837f748afbef04004cc5d8a03bef05394990757850767cd71e63264a8e5c4d709"
+      "sig": "46ec63e7984f022a3338eacb86e385f5dc464ec72ec876735b3522d5857ceef8a7f44264e3bc326233e54717c488e7ae37c72226ca62f1c75ab9000436ffff0f"
     }
   ],
   "signed": {
@@ -11,13 +11,13 @@
     "meta": {
       "targets.json": {
         "hashes": {
-          "sha256": "7b64a146874838bfa0c88d81914a1216f0c721eb9b2d53037a41231066c208f6"
+          "sha256": "618ad46b2eb62ce9842ebd490b4e6f38d34c1c9318b43bd87dc2fe963a2acbfc"
         },
         "length": 1053,
-        "version": 1
+        "version": 4
       }
     },
     "spec_version": "1.0",
-    "version": 1
+    "version": 4
   }
 }

--- a/tests/metadata/consistent-snapshot-false/3/repository/targets.json
+++ b/tests/metadata/consistent-snapshot-false/3/repository/targets.json
@@ -2,7 +2,7 @@
   "signatures": [
     {
       "keyid": "bc8f087663855564b358ddf314d5932ab920af17bd1df2f58b397afd82d76dc1",
-      "sig": "c809aed78c8475ac1e87e9c9fe6ba5c1bc69acc70777d81821d6727a7718004ce8ada721fe1c59b7dfe452c787dc5e36b6c506555782bdb5ae0ff9d1baaff60f"
+      "sig": "44c8222aedd3e8e5818f12cf6373ebe025487212db45eeb479330f69f14de163e212541bd1d0aa1c294da901be866241209182033e3874416e023d4963d78905"
     }
   ],
   "signed": {
@@ -35,6 +35,6 @@
         "length": 1
       }
     },
-    "version": 1
+    "version": 4
   }
 }

--- a/tests/metadata/consistent-snapshot-false/3/repository/targets/0
+++ b/tests/metadata/consistent-snapshot-false/3/repository/targets/0
@@ -1,1 +1,1 @@
-../../../2/repository/targets/0
+0

--- a/tests/metadata/consistent-snapshot-false/3/repository/targets/1
+++ b/tests/metadata/consistent-snapshot-false/3/repository/targets/1
@@ -1,1 +1,1 @@
-../../../2/repository/targets/1
+1

--- a/tests/metadata/consistent-snapshot-false/3/repository/targets/2
+++ b/tests/metadata/consistent-snapshot-false/3/repository/targets/2
@@ -1,1 +1,1 @@
-../../../2/repository/targets/2
+2

--- a/tests/metadata/consistent-snapshot-false/3/repository/timestamp.json
+++ b/tests/metadata/consistent-snapshot-false/3/repository/timestamp.json
@@ -2,7 +2,7 @@
   "signatures": [
     {
       "keyid": "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8",
-      "sig": "f622bda68466c12c267848cd75880b57fb95b3728c691bd81f0d3d593179dcd7a35976bc35e4b5a715509b85647589dc1dc9410c3c4a974f9de06dbcc3f88d04"
+      "sig": "92f5824f6ec91a018362ec9da77f0f44b5894ae1d1cdc4aa21149c652842e9056208e2f7b6aa579a93169bf7ee32ae0933f4494ed6a4dbeb294eac6ad548510f"
     }
   ],
   "signed": {
@@ -11,13 +11,13 @@
     "meta": {
       "snapshot.json": {
         "hashes": {
-          "sha256": "d89d289cdf4473c9a0fa6eab7a4c40289f44cf5c68de0ac23bef02b31d5798f9"
+          "sha256": "4071731205e7ab717878f787ce16709bf4fe7794c1f16a2ee275d8dafe435f4f"
         },
         "length": 607,
-        "version": 1
+        "version": 4
       }
     },
     "spec_version": "1.0",
-    "version": 1
+    "version": 4
   }
 }

--- a/tests/metadata/consistent-snapshot-false/4/repository/1.root.json
+++ b/tests/metadata/consistent-snapshot-false/4/repository/1.root.json
@@ -1,1 +1,87 @@
-../../3/repository/1.root.json
+{
+  "signatures": [
+    {
+      "keyid": "ce72db3f938914205461a415c9b7b91267a2079df991fd6283aa8461988c1add",
+      "sig": "afab8b34f93c99e200505cc6f0d6a9c4e757a7229f96bd31ab618f8bc4c3abe491b372bfec9d231136de46c1e183df194d372360ee9d32652f8c04d7574e2608"
+    }
+  ],
+  "signed": {
+    "_type": "root",
+    "consistent_snapshot": false,
+    "expires": "2100-01-01T00:00:00Z",
+    "keys": {
+      "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "d482fa4805a50870aa1356ace6b764f7ab47ed4dc38f49b1a189afa25f179e94"
+        },
+        "scheme": "ed25519"
+      },
+      "808aa256a8172bb0cb961767c6768e55ccf732c99afccc6145752d7a328b7937": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "62f71f99c788f16bcdc8bb252455e3a690350e4ddea5a6aab1f9a3aaabcf369a"
+        },
+        "scheme": "ed25519"
+      },
+      "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "8656ad20568cd3534c405e4d9a84b0c6e6163f7f66434df77416502835b9b160"
+        },
+        "scheme": "ed25519"
+      },
+      "ce72db3f938914205461a415c9b7b91267a2079df991fd6283aa8461988c1add": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "bca152214dbfd3e7a1b7a7b3e2cc179fb00520fd7212c8a60ba99f14dfc0e1ca"
+        },
+        "scheme": "ed25519"
+      }
+    },
+    "roles": {
+      "root": {
+        "keyids": [
+          "ce72db3f938914205461a415c9b7b91267a2079df991fd6283aa8461988c1add"
+        ],
+        "threshold": 1
+      },
+      "snapshot": {
+        "keyids": [
+          "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45"
+        ],
+        "threshold": 1
+      },
+      "targets": {
+        "keyids": [
+          "808aa256a8172bb0cb961767c6768e55ccf732c99afccc6145752d7a328b7937"
+        ],
+        "threshold": 1
+      },
+      "timestamp": {
+        "keyids": [
+          "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8"
+        ],
+        "threshold": 1
+      }
+    },
+    "spec_version": "1.0",
+    "version": 1
+  }
+}

--- a/tests/metadata/consistent-snapshot-false/4/repository/2.root.json
+++ b/tests/metadata/consistent-snapshot-false/4/repository/2.root.json
@@ -1,1 +1,91 @@
-../../3/repository/2.root.json
+{
+  "signatures": [
+    {
+      "keyid": "ce72db3f938914205461a415c9b7b91267a2079df991fd6283aa8461988c1add",
+      "sig": "65f63745aa8bd39132f827c427ea6d87f620ec805d9f376b6a8400dc3db7eb964e5423d31ed08867916d039661a70d6bf255bca552248021a4e78b5d357c2b0f"
+    },
+    {
+      "keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
+      "sig": "20e91b55c995989b270091b714347b15169285cb636ef05d68d49ed7b7a96ebfda13898e0d9ef928c382873b9dba90dca492dbf705d56a4b293adaaed574340f"
+    }
+  ],
+  "signed": {
+    "_type": "root",
+    "consistent_snapshot": false,
+    "expires": "2100-01-01T00:00:00Z",
+    "keys": {
+      "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "d482fa4805a50870aa1356ace6b764f7ab47ed4dc38f49b1a189afa25f179e94"
+        },
+        "scheme": "ed25519"
+      },
+      "808aa256a8172bb0cb961767c6768e55ccf732c99afccc6145752d7a328b7937": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "62f71f99c788f16bcdc8bb252455e3a690350e4ddea5a6aab1f9a3aaabcf369a"
+        },
+        "scheme": "ed25519"
+      },
+      "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "8656ad20568cd3534c405e4d9a84b0c6e6163f7f66434df77416502835b9b160"
+        },
+        "scheme": "ed25519"
+      },
+      "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "153986a7370e002f377dd68797e7466c421180c1571e233de2f8ab41c8af4f54"
+        },
+        "scheme": "ed25519"
+      }
+    },
+    "roles": {
+      "root": {
+        "keyids": [
+          "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f"
+        ],
+        "threshold": 1
+      },
+      "snapshot": {
+        "keyids": [
+          "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45"
+        ],
+        "threshold": 1
+      },
+      "targets": {
+        "keyids": [
+          "808aa256a8172bb0cb961767c6768e55ccf732c99afccc6145752d7a328b7937"
+        ],
+        "threshold": 1
+      },
+      "timestamp": {
+        "keyids": [
+          "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8"
+        ],
+        "threshold": 1
+      }
+    },
+    "spec_version": "1.0",
+    "version": 2
+  }
+}

--- a/tests/metadata/consistent-snapshot-false/4/repository/3.root.json
+++ b/tests/metadata/consistent-snapshot-false/4/repository/3.root.json
@@ -1,1 +1,87 @@
-../../3/repository/3.root.json
+{
+  "signatures": [
+    {
+      "keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
+      "sig": "cfe8b0919d1707ca6c23501909b77c8b94d1ede2b85a3081ab7146244cc6fe436b06ad58163919276f2e37ddbcc13a0dde4851301053dcea2a9bcabc5e1cd004"
+    }
+  ],
+  "signed": {
+    "_type": "root",
+    "consistent_snapshot": false,
+    "expires": "2100-01-01T00:00:00Z",
+    "keys": {
+      "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "d482fa4805a50870aa1356ace6b764f7ab47ed4dc38f49b1a189afa25f179e94"
+        },
+        "scheme": "ed25519"
+      },
+      "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "8656ad20568cd3534c405e4d9a84b0c6e6163f7f66434df77416502835b9b160"
+        },
+        "scheme": "ed25519"
+      },
+      "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "153986a7370e002f377dd68797e7466c421180c1571e233de2f8ab41c8af4f54"
+        },
+        "scheme": "ed25519"
+      },
+      "bc8f087663855564b358ddf314d5932ab920af17bd1df2f58b397afd82d76dc1": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "aee574e56780ea1709a8b56e02d4ffdd9a3a1deaed61e2eb0701f376a4422e42"
+        },
+        "scheme": "ed25519"
+      }
+    },
+    "roles": {
+      "root": {
+        "keyids": [
+          "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f"
+        ],
+        "threshold": 1
+      },
+      "snapshot": {
+        "keyids": [
+          "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45"
+        ],
+        "threshold": 1
+      },
+      "targets": {
+        "keyids": [
+          "bc8f087663855564b358ddf314d5932ab920af17bd1df2f58b397afd82d76dc1"
+        ],
+        "threshold": 1
+      },
+      "timestamp": {
+        "keyids": [
+          "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8"
+        ],
+        "threshold": 1
+      }
+    },
+    "spec_version": "1.0",
+    "version": 3
+  }
+}

--- a/tests/metadata/consistent-snapshot-false/4/repository/4.root.json
+++ b/tests/metadata/consistent-snapshot-false/4/repository/4.root.json
@@ -1,1 +1,87 @@
-../../3/repository/4.root.json
+{
+  "signatures": [
+    {
+      "keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
+      "sig": "3004c4b60645c6cca18e33835837a1639eead05355aa549f1d1304a22304e7058a50fb6188fc3617a47248eb7481de7a625f036cc69b53daf04a103b12768401"
+    }
+  ],
+  "signed": {
+    "_type": "root",
+    "consistent_snapshot": false,
+    "expires": "2100-01-01T00:00:00Z",
+    "keys": {
+      "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "8656ad20568cd3534c405e4d9a84b0c6e6163f7f66434df77416502835b9b160"
+        },
+        "scheme": "ed25519"
+      },
+      "b096bc2d67080cec22e6c0bbaa69cfd9d714b9e9ad847d255f950b2728855fef": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "722dbc861813bb5b568524d62083e875c08e66fed1694d9161d253fa163dd86f"
+        },
+        "scheme": "ed25519"
+      },
+      "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "153986a7370e002f377dd68797e7466c421180c1571e233de2f8ab41c8af4f54"
+        },
+        "scheme": "ed25519"
+      },
+      "bc8f087663855564b358ddf314d5932ab920af17bd1df2f58b397afd82d76dc1": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "aee574e56780ea1709a8b56e02d4ffdd9a3a1deaed61e2eb0701f376a4422e42"
+        },
+        "scheme": "ed25519"
+      }
+    },
+    "roles": {
+      "root": {
+        "keyids": [
+          "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f"
+        ],
+        "threshold": 1
+      },
+      "snapshot": {
+        "keyids": [
+          "b096bc2d67080cec22e6c0bbaa69cfd9d714b9e9ad847d255f950b2728855fef"
+        ],
+        "threshold": 1
+      },
+      "targets": {
+        "keyids": [
+          "bc8f087663855564b358ddf314d5932ab920af17bd1df2f58b397afd82d76dc1"
+        ],
+        "threshold": 1
+      },
+      "timestamp": {
+        "keyids": [
+          "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8"
+        ],
+        "threshold": 1
+      }
+    },
+    "spec_version": "1.0",
+    "version": 4
+  }
+}

--- a/tests/metadata/consistent-snapshot-false/4/repository/5.root.json
+++ b/tests/metadata/consistent-snapshot-false/4/repository/5.root.json
@@ -2,7 +2,7 @@
   "signatures": [
     {
       "keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
-      "sig": "5c459d1c8628d9a6049f02567e22d4cebf53fe9fc28e7b86a24efefa2a6d8186352a79d453e68244ef10bd7f44e767ebd934ba989fc6c336fcb0dd3699179e08"
+      "sig": "bd2edde6ba4f5cb3a0cc28dca272e2fc0be691575082479f86b82cea4e541a686a0c132c3a7eca231a5782e52e629df92f8f3f89a5b1f57e8b5368986bddfa0e"
     }
   ],
   "signed": {
@@ -82,6 +82,6 @@
       }
     },
     "spec_version": "1.0",
-    "version": 1
+    "version": 5
   }
 }

--- a/tests/metadata/consistent-snapshot-false/4/repository/root.json
+++ b/tests/metadata/consistent-snapshot-false/4/repository/root.json
@@ -2,7 +2,7 @@
   "signatures": [
     {
       "keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
-      "sig": "5c459d1c8628d9a6049f02567e22d4cebf53fe9fc28e7b86a24efefa2a6d8186352a79d453e68244ef10bd7f44e767ebd934ba989fc6c336fcb0dd3699179e08"
+      "sig": "bd2edde6ba4f5cb3a0cc28dca272e2fc0be691575082479f86b82cea4e541a686a0c132c3a7eca231a5782e52e629df92f8f3f89a5b1f57e8b5368986bddfa0e"
     }
   ],
   "signed": {
@@ -82,6 +82,6 @@
       }
     },
     "spec_version": "1.0",
-    "version": 1
+    "version": 5
   }
 }

--- a/tests/metadata/consistent-snapshot-false/4/repository/snapshot.json
+++ b/tests/metadata/consistent-snapshot-false/4/repository/snapshot.json
@@ -2,7 +2,7 @@
   "signatures": [
     {
       "keyid": "b096bc2d67080cec22e6c0bbaa69cfd9d714b9e9ad847d255f950b2728855fef",
-      "sig": "941fe32e73659117ace6990ae8e0c160975142514df09bb60c07b7ca9b2884ed290f8857555b2914800cb09205e58a1e3ee8f5907c1716836734bfb639146400"
+      "sig": "e909ae39d5724cb05788dac7b81f7c91bb2f1a9badebeb09a485b58665f6d471090df92c5bf76a92fd36e5af0655b144cfc2cd8a1d11de3fc43f739145c5fa02"
     }
   ],
   "signed": {
@@ -11,13 +11,13 @@
     "meta": {
       "targets.json": {
         "hashes": {
-          "sha256": "0b5b663a36df0f3821756bac1d028c1eaeeacc2f783ac0cd328969ea5e5ea0b1"
+          "sha256": "e981f082145fd093e0469ad7f88f6cc2b9ccc8058e6b081b4f85eea0178e72ad"
         },
         "length": 1213,
-        "version": 1
+        "version": 5
       }
     },
     "spec_version": "1.0",
-    "version": 1
+    "version": 5
   }
 }

--- a/tests/metadata/consistent-snapshot-false/4/repository/targets.json
+++ b/tests/metadata/consistent-snapshot-false/4/repository/targets.json
@@ -2,7 +2,7 @@
   "signatures": [
     {
       "keyid": "bc8f087663855564b358ddf314d5932ab920af17bd1df2f58b397afd82d76dc1",
-      "sig": "9a75e06f5fdd92bc91d2921ddefd22aa5cfdd83bf79dadc1954d044259478a8392d41494611845d67ef9d8e747fe99cc2d322f35666cd6eba37ef845fb7e1f05"
+      "sig": "c88a8309f966fb794f41acf864c2b204ecb32ada9c4f4844657fa67f174735f75bdd799dfe6850ea8a775b8d2acba5bf82def8b909d3633a0f289eb246cd9f05"
     }
   ],
   "signed": {
@@ -41,6 +41,6 @@
         "length": 1
       }
     },
-    "version": 1
+    "version": 5
   }
 }

--- a/tests/metadata/consistent-snapshot-false/4/repository/targets/0
+++ b/tests/metadata/consistent-snapshot-false/4/repository/targets/0
@@ -1,1 +1,1 @@
-../../../3/repository/targets/0
+0

--- a/tests/metadata/consistent-snapshot-false/4/repository/targets/1
+++ b/tests/metadata/consistent-snapshot-false/4/repository/targets/1
@@ -1,1 +1,1 @@
-../../../3/repository/targets/1
+1

--- a/tests/metadata/consistent-snapshot-false/4/repository/targets/2
+++ b/tests/metadata/consistent-snapshot-false/4/repository/targets/2
@@ -1,1 +1,1 @@
-../../../3/repository/targets/2
+2

--- a/tests/metadata/consistent-snapshot-false/4/repository/targets/3
+++ b/tests/metadata/consistent-snapshot-false/4/repository/targets/3
@@ -1,1 +1,1 @@
-../../../3/repository/targets/3
+3

--- a/tests/metadata/consistent-snapshot-false/4/repository/timestamp.json
+++ b/tests/metadata/consistent-snapshot-false/4/repository/timestamp.json
@@ -2,7 +2,7 @@
   "signatures": [
     {
       "keyid": "a8eaf6de5aecfd0a72b60295b1e1cd12f349079ebcbbb63dbe7072f162e85315",
-      "sig": "9ebda34a99eaf35c066c126efc5af3d6eb94cbb70310c54eaef45623f29a9de11cabb964982f25c7983f374d51fb850424a8348fcd1425147cb8e5e447a67a04"
+      "sig": "8388bf58e18024922f5c24f091cf372d3991f3aa7fbe85ce68d81cb12c894bd422d542f1e9d9d1f83ab5957db50692f974476a2dcc9ee8c7f0ad5b16e4a05801"
     }
   ],
   "signed": {
@@ -11,13 +11,13 @@
     "meta": {
       "snapshot.json": {
         "hashes": {
-          "sha256": "7d68a04ca089190ebdcb79e5430bd033d40378ccf98c67af33779658f294763c"
+          "sha256": "fce145d30b6375b4eba810a95f143cf8e6209b37f696ce10fe084f0e0ca09bd5"
         },
         "length": 607,
-        "version": 1
+        "version": 5
       }
     },
     "spec_version": "1.0",
-    "version": 1
+    "version": 5
   }
 }

--- a/tests/metadata/consistent-snapshot-false/5/repository/1.root.json
+++ b/tests/metadata/consistent-snapshot-false/5/repository/1.root.json
@@ -1,1 +1,87 @@
-../../4/repository/1.root.json
+{
+  "signatures": [
+    {
+      "keyid": "ce72db3f938914205461a415c9b7b91267a2079df991fd6283aa8461988c1add",
+      "sig": "afab8b34f93c99e200505cc6f0d6a9c4e757a7229f96bd31ab618f8bc4c3abe491b372bfec9d231136de46c1e183df194d372360ee9d32652f8c04d7574e2608"
+    }
+  ],
+  "signed": {
+    "_type": "root",
+    "consistent_snapshot": false,
+    "expires": "2100-01-01T00:00:00Z",
+    "keys": {
+      "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "d482fa4805a50870aa1356ace6b764f7ab47ed4dc38f49b1a189afa25f179e94"
+        },
+        "scheme": "ed25519"
+      },
+      "808aa256a8172bb0cb961767c6768e55ccf732c99afccc6145752d7a328b7937": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "62f71f99c788f16bcdc8bb252455e3a690350e4ddea5a6aab1f9a3aaabcf369a"
+        },
+        "scheme": "ed25519"
+      },
+      "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "8656ad20568cd3534c405e4d9a84b0c6e6163f7f66434df77416502835b9b160"
+        },
+        "scheme": "ed25519"
+      },
+      "ce72db3f938914205461a415c9b7b91267a2079df991fd6283aa8461988c1add": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "bca152214dbfd3e7a1b7a7b3e2cc179fb00520fd7212c8a60ba99f14dfc0e1ca"
+        },
+        "scheme": "ed25519"
+      }
+    },
+    "roles": {
+      "root": {
+        "keyids": [
+          "ce72db3f938914205461a415c9b7b91267a2079df991fd6283aa8461988c1add"
+        ],
+        "threshold": 1
+      },
+      "snapshot": {
+        "keyids": [
+          "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45"
+        ],
+        "threshold": 1
+      },
+      "targets": {
+        "keyids": [
+          "808aa256a8172bb0cb961767c6768e55ccf732c99afccc6145752d7a328b7937"
+        ],
+        "threshold": 1
+      },
+      "timestamp": {
+        "keyids": [
+          "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8"
+        ],
+        "threshold": 1
+      }
+    },
+    "spec_version": "1.0",
+    "version": 1
+  }
+}

--- a/tests/metadata/consistent-snapshot-false/5/repository/2.root.json
+++ b/tests/metadata/consistent-snapshot-false/5/repository/2.root.json
@@ -1,1 +1,91 @@
-../../4/repository/2.root.json
+{
+  "signatures": [
+    {
+      "keyid": "ce72db3f938914205461a415c9b7b91267a2079df991fd6283aa8461988c1add",
+      "sig": "65f63745aa8bd39132f827c427ea6d87f620ec805d9f376b6a8400dc3db7eb964e5423d31ed08867916d039661a70d6bf255bca552248021a4e78b5d357c2b0f"
+    },
+    {
+      "keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
+      "sig": "20e91b55c995989b270091b714347b15169285cb636ef05d68d49ed7b7a96ebfda13898e0d9ef928c382873b9dba90dca492dbf705d56a4b293adaaed574340f"
+    }
+  ],
+  "signed": {
+    "_type": "root",
+    "consistent_snapshot": false,
+    "expires": "2100-01-01T00:00:00Z",
+    "keys": {
+      "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "d482fa4805a50870aa1356ace6b764f7ab47ed4dc38f49b1a189afa25f179e94"
+        },
+        "scheme": "ed25519"
+      },
+      "808aa256a8172bb0cb961767c6768e55ccf732c99afccc6145752d7a328b7937": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "62f71f99c788f16bcdc8bb252455e3a690350e4ddea5a6aab1f9a3aaabcf369a"
+        },
+        "scheme": "ed25519"
+      },
+      "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "8656ad20568cd3534c405e4d9a84b0c6e6163f7f66434df77416502835b9b160"
+        },
+        "scheme": "ed25519"
+      },
+      "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "153986a7370e002f377dd68797e7466c421180c1571e233de2f8ab41c8af4f54"
+        },
+        "scheme": "ed25519"
+      }
+    },
+    "roles": {
+      "root": {
+        "keyids": [
+          "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f"
+        ],
+        "threshold": 1
+      },
+      "snapshot": {
+        "keyids": [
+          "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45"
+        ],
+        "threshold": 1
+      },
+      "targets": {
+        "keyids": [
+          "808aa256a8172bb0cb961767c6768e55ccf732c99afccc6145752d7a328b7937"
+        ],
+        "threshold": 1
+      },
+      "timestamp": {
+        "keyids": [
+          "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8"
+        ],
+        "threshold": 1
+      }
+    },
+    "spec_version": "1.0",
+    "version": 2
+  }
+}

--- a/tests/metadata/consistent-snapshot-false/5/repository/3.root.json
+++ b/tests/metadata/consistent-snapshot-false/5/repository/3.root.json
@@ -1,1 +1,87 @@
-../../4/repository/3.root.json
+{
+  "signatures": [
+    {
+      "keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
+      "sig": "cfe8b0919d1707ca6c23501909b77c8b94d1ede2b85a3081ab7146244cc6fe436b06ad58163919276f2e37ddbcc13a0dde4851301053dcea2a9bcabc5e1cd004"
+    }
+  ],
+  "signed": {
+    "_type": "root",
+    "consistent_snapshot": false,
+    "expires": "2100-01-01T00:00:00Z",
+    "keys": {
+      "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "d482fa4805a50870aa1356ace6b764f7ab47ed4dc38f49b1a189afa25f179e94"
+        },
+        "scheme": "ed25519"
+      },
+      "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "8656ad20568cd3534c405e4d9a84b0c6e6163f7f66434df77416502835b9b160"
+        },
+        "scheme": "ed25519"
+      },
+      "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "153986a7370e002f377dd68797e7466c421180c1571e233de2f8ab41c8af4f54"
+        },
+        "scheme": "ed25519"
+      },
+      "bc8f087663855564b358ddf314d5932ab920af17bd1df2f58b397afd82d76dc1": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "aee574e56780ea1709a8b56e02d4ffdd9a3a1deaed61e2eb0701f376a4422e42"
+        },
+        "scheme": "ed25519"
+      }
+    },
+    "roles": {
+      "root": {
+        "keyids": [
+          "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f"
+        ],
+        "threshold": 1
+      },
+      "snapshot": {
+        "keyids": [
+          "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45"
+        ],
+        "threshold": 1
+      },
+      "targets": {
+        "keyids": [
+          "bc8f087663855564b358ddf314d5932ab920af17bd1df2f58b397afd82d76dc1"
+        ],
+        "threshold": 1
+      },
+      "timestamp": {
+        "keyids": [
+          "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8"
+        ],
+        "threshold": 1
+      }
+    },
+    "spec_version": "1.0",
+    "version": 3
+  }
+}

--- a/tests/metadata/consistent-snapshot-false/5/repository/4.root.json
+++ b/tests/metadata/consistent-snapshot-false/5/repository/4.root.json
@@ -1,1 +1,87 @@
-../../4/repository/4.root.json
+{
+  "signatures": [
+    {
+      "keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
+      "sig": "3004c4b60645c6cca18e33835837a1639eead05355aa549f1d1304a22304e7058a50fb6188fc3617a47248eb7481de7a625f036cc69b53daf04a103b12768401"
+    }
+  ],
+  "signed": {
+    "_type": "root",
+    "consistent_snapshot": false,
+    "expires": "2100-01-01T00:00:00Z",
+    "keys": {
+      "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "8656ad20568cd3534c405e4d9a84b0c6e6163f7f66434df77416502835b9b160"
+        },
+        "scheme": "ed25519"
+      },
+      "b096bc2d67080cec22e6c0bbaa69cfd9d714b9e9ad847d255f950b2728855fef": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "722dbc861813bb5b568524d62083e875c08e66fed1694d9161d253fa163dd86f"
+        },
+        "scheme": "ed25519"
+      },
+      "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "153986a7370e002f377dd68797e7466c421180c1571e233de2f8ab41c8af4f54"
+        },
+        "scheme": "ed25519"
+      },
+      "bc8f087663855564b358ddf314d5932ab920af17bd1df2f58b397afd82d76dc1": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "aee574e56780ea1709a8b56e02d4ffdd9a3a1deaed61e2eb0701f376a4422e42"
+        },
+        "scheme": "ed25519"
+      }
+    },
+    "roles": {
+      "root": {
+        "keyids": [
+          "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f"
+        ],
+        "threshold": 1
+      },
+      "snapshot": {
+        "keyids": [
+          "b096bc2d67080cec22e6c0bbaa69cfd9d714b9e9ad847d255f950b2728855fef"
+        ],
+        "threshold": 1
+      },
+      "targets": {
+        "keyids": [
+          "bc8f087663855564b358ddf314d5932ab920af17bd1df2f58b397afd82d76dc1"
+        ],
+        "threshold": 1
+      },
+      "timestamp": {
+        "keyids": [
+          "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8"
+        ],
+        "threshold": 1
+      }
+    },
+    "spec_version": "1.0",
+    "version": 4
+  }
+}

--- a/tests/metadata/consistent-snapshot-false/5/repository/5.root.json
+++ b/tests/metadata/consistent-snapshot-false/5/repository/5.root.json
@@ -1,1 +1,87 @@
-../../4/repository/5.root.json
+{
+  "signatures": [
+    {
+      "keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
+      "sig": "bd2edde6ba4f5cb3a0cc28dca272e2fc0be691575082479f86b82cea4e541a686a0c132c3a7eca231a5782e52e629df92f8f3f89a5b1f57e8b5368986bddfa0e"
+    }
+  ],
+  "signed": {
+    "_type": "root",
+    "consistent_snapshot": false,
+    "expires": "2100-01-01T00:00:00Z",
+    "keys": {
+      "a8eaf6de5aecfd0a72b60295b1e1cd12f349079ebcbbb63dbe7072f162e85315": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "3ab34b0c2d4eadccaa0f0cf22ced07b552394063a9de2806993d022360dffc76"
+        },
+        "scheme": "ed25519"
+      },
+      "b096bc2d67080cec22e6c0bbaa69cfd9d714b9e9ad847d255f950b2728855fef": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "722dbc861813bb5b568524d62083e875c08e66fed1694d9161d253fa163dd86f"
+        },
+        "scheme": "ed25519"
+      },
+      "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "153986a7370e002f377dd68797e7466c421180c1571e233de2f8ab41c8af4f54"
+        },
+        "scheme": "ed25519"
+      },
+      "bc8f087663855564b358ddf314d5932ab920af17bd1df2f58b397afd82d76dc1": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "aee574e56780ea1709a8b56e02d4ffdd9a3a1deaed61e2eb0701f376a4422e42"
+        },
+        "scheme": "ed25519"
+      }
+    },
+    "roles": {
+      "root": {
+        "keyids": [
+          "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f"
+        ],
+        "threshold": 1
+      },
+      "snapshot": {
+        "keyids": [
+          "b096bc2d67080cec22e6c0bbaa69cfd9d714b9e9ad847d255f950b2728855fef"
+        ],
+        "threshold": 1
+      },
+      "targets": {
+        "keyids": [
+          "bc8f087663855564b358ddf314d5932ab920af17bd1df2f58b397afd82d76dc1"
+        ],
+        "threshold": 1
+      },
+      "timestamp": {
+        "keyids": [
+          "a8eaf6de5aecfd0a72b60295b1e1cd12f349079ebcbbb63dbe7072f162e85315"
+        ],
+        "threshold": 1
+      }
+    },
+    "spec_version": "1.0",
+    "version": 5
+  }
+}

--- a/tests/metadata/consistent-snapshot-false/5/repository/6.root.json
+++ b/tests/metadata/consistent-snapshot-false/5/repository/6.root.json
@@ -2,7 +2,7 @@
   "signatures": [
     {
       "keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
-      "sig": "5c459d1c8628d9a6049f02567e22d4cebf53fe9fc28e7b86a24efefa2a6d8186352a79d453e68244ef10bd7f44e767ebd934ba989fc6c336fcb0dd3699179e08"
+      "sig": "136ed9c67addd8e587212b808a9a78c06e2f2ffbe359125db6b871070713a79b17ec31b5b535b19e6bb0a7093e55ceec20a01617e57b18efe84eb1c85ec3390a"
     }
   ],
   "signed": {
@@ -82,6 +82,6 @@
       }
     },
     "spec_version": "1.0",
-    "version": 1
+    "version": 6
   }
 }

--- a/tests/metadata/consistent-snapshot-false/5/repository/root.json
+++ b/tests/metadata/consistent-snapshot-false/5/repository/root.json
@@ -1,1 +1,87 @@
-../../4/repository/root.json
+{
+  "signatures": [
+    {
+      "keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
+      "sig": "136ed9c67addd8e587212b808a9a78c06e2f2ffbe359125db6b871070713a79b17ec31b5b535b19e6bb0a7093e55ceec20a01617e57b18efe84eb1c85ec3390a"
+    }
+  ],
+  "signed": {
+    "_type": "root",
+    "consistent_snapshot": false,
+    "expires": "2100-01-01T00:00:00Z",
+    "keys": {
+      "a8eaf6de5aecfd0a72b60295b1e1cd12f349079ebcbbb63dbe7072f162e85315": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "3ab34b0c2d4eadccaa0f0cf22ced07b552394063a9de2806993d022360dffc76"
+        },
+        "scheme": "ed25519"
+      },
+      "b096bc2d67080cec22e6c0bbaa69cfd9d714b9e9ad847d255f950b2728855fef": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "722dbc861813bb5b568524d62083e875c08e66fed1694d9161d253fa163dd86f"
+        },
+        "scheme": "ed25519"
+      },
+      "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "153986a7370e002f377dd68797e7466c421180c1571e233de2f8ab41c8af4f54"
+        },
+        "scheme": "ed25519"
+      },
+      "bc8f087663855564b358ddf314d5932ab920af17bd1df2f58b397afd82d76dc1": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "aee574e56780ea1709a8b56e02d4ffdd9a3a1deaed61e2eb0701f376a4422e42"
+        },
+        "scheme": "ed25519"
+      }
+    },
+    "roles": {
+      "root": {
+        "keyids": [
+          "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f"
+        ],
+        "threshold": 1
+      },
+      "snapshot": {
+        "keyids": [
+          "b096bc2d67080cec22e6c0bbaa69cfd9d714b9e9ad847d255f950b2728855fef"
+        ],
+        "threshold": 1
+      },
+      "targets": {
+        "keyids": [
+          "bc8f087663855564b358ddf314d5932ab920af17bd1df2f58b397afd82d76dc1"
+        ],
+        "threshold": 1
+      },
+      "timestamp": {
+        "keyids": [
+          "a8eaf6de5aecfd0a72b60295b1e1cd12f349079ebcbbb63dbe7072f162e85315"
+        ],
+        "threshold": 1
+      }
+    },
+    "spec_version": "1.0",
+    "version": 6
+  }
+}

--- a/tests/metadata/consistent-snapshot-false/5/repository/snapshot.json
+++ b/tests/metadata/consistent-snapshot-false/5/repository/snapshot.json
@@ -2,7 +2,7 @@
   "signatures": [
     {
       "keyid": "b096bc2d67080cec22e6c0bbaa69cfd9d714b9e9ad847d255f950b2728855fef",
-      "sig": "98de73b5a6b84c678acc887e8d79af8a5d210344f301433a8b67488fc84bee0f9953229749c94fe0a15e26eb7f3441b6546019aa3f9b79eca07ec371d565d103"
+      "sig": "f3944db41af91bf423e6615d58ab53946266190a74a791fb0bd0dc54b2a355666c116616ee377322161d49d6c34560f1a845fd375deaa4e3489ccbcdfccca604"
     }
   ],
   "signed": {
@@ -11,13 +11,13 @@
     "meta": {
       "targets.json": {
         "hashes": {
-          "sha256": "ec57b871bed358e266a3a6c3d84b53a534901b411ba1dcb2be7f99331e39e16a"
+          "sha256": "c9d177e880cb5e0f9d3c03c5e6e3afff18633dbf8299d6fd30e21d56f4b7a7cd"
         },
         "length": 1373,
-        "version": 1
+        "version": 6
       }
     },
     "spec_version": "1.0",
-    "version": 1
+    "version": 6
   }
 }

--- a/tests/metadata/consistent-snapshot-false/5/repository/targets.json
+++ b/tests/metadata/consistent-snapshot-false/5/repository/targets.json
@@ -2,7 +2,7 @@
   "signatures": [
     {
       "keyid": "bc8f087663855564b358ddf314d5932ab920af17bd1df2f58b397afd82d76dc1",
-      "sig": "eb6cf42a042e2e5e78a896158670cdb5a10f59bed5f521dccd2456a6f8a6bdcfcb5ae43ad88281aa9c84a38a806db20fc66130f009cb1f78d272c6d0dd7e2a02"
+      "sig": "5a69e9de1f932e72dc54d3df21fbe4b601203fe1a1b9d84cf9ac5f964639ff996718432a1fe6f90e44275423b0acea173ba0a5706db14b217864ca8639f99c03"
     }
   ],
   "signed": {
@@ -47,6 +47,6 @@
         "length": 1
       }
     },
-    "version": 1
+    "version": 6
   }
 }

--- a/tests/metadata/consistent-snapshot-false/5/repository/targets/0
+++ b/tests/metadata/consistent-snapshot-false/5/repository/targets/0
@@ -1,1 +1,1 @@
-../../../4/repository/targets/0
+0

--- a/tests/metadata/consistent-snapshot-false/5/repository/targets/1
+++ b/tests/metadata/consistent-snapshot-false/5/repository/targets/1
@@ -1,1 +1,1 @@
-../../../4/repository/targets/1
+1

--- a/tests/metadata/consistent-snapshot-false/5/repository/targets/2
+++ b/tests/metadata/consistent-snapshot-false/5/repository/targets/2
@@ -1,1 +1,1 @@
-../../../4/repository/targets/2
+2

--- a/tests/metadata/consistent-snapshot-false/5/repository/targets/3
+++ b/tests/metadata/consistent-snapshot-false/5/repository/targets/3
@@ -1,1 +1,1 @@
-../../../4/repository/targets/3
+3

--- a/tests/metadata/consistent-snapshot-false/5/repository/targets/4
+++ b/tests/metadata/consistent-snapshot-false/5/repository/targets/4
@@ -1,1 +1,1 @@
-../../../4/repository/targets/4
+4

--- a/tests/metadata/consistent-snapshot-false/5/repository/timestamp.json
+++ b/tests/metadata/consistent-snapshot-false/5/repository/timestamp.json
@@ -2,7 +2,7 @@
   "signatures": [
     {
       "keyid": "a8eaf6de5aecfd0a72b60295b1e1cd12f349079ebcbbb63dbe7072f162e85315",
-      "sig": "358e037beae1485097a86c6bcde2a4494985eddb81a8f910a226cb78e61b1994c7a6e701906b0a1f2431a344a12e3559d923e5fc22ff740c07605e573e21880b"
+      "sig": "95ff2508f9913723413ab07e61c21932080af120a162a28b02c5a07eaebe1a9211b30889c44f30dbfa194f7718b059db47046e5e3aea08b5dbbed4b29757140d"
     }
   ],
   "signed": {
@@ -11,13 +11,13 @@
     "meta": {
       "snapshot.json": {
         "hashes": {
-          "sha256": "d2fde7e9b8ec33b3da54a4ae590bad682c57280d95ea57be85b5c245df587c6d"
+          "sha256": "c36eec1e1c876d3cd3be47ecd7f962a1e50dae30be7ab09943c2160b8c28ca8c"
         },
         "length": 607,
-        "version": 1
+        "version": 6
       }
     },
     "spec_version": "1.0",
-    "version": 1
+    "version": 6
   }
 }

--- a/tests/metadata/consistent-snapshot-true/1/repository/1.root.json
+++ b/tests/metadata/consistent-snapshot-true/1/repository/1.root.json
@@ -1,1 +1,87 @@
-../../0/repository/1.root.json
+{
+  "signatures": [
+    {
+      "keyid": "ce72db3f938914205461a415c9b7b91267a2079df991fd6283aa8461988c1add",
+      "sig": "104eb78cba674adfc7ade1d4396c99466a7d4480e50aab89df53117faffd3d4d4ea87833fe6f83b8dc7f6e1e4a62c0329244c6e5f910627772df3c4d61a8900f"
+    }
+  ],
+  "signed": {
+    "_type": "root",
+    "consistent_snapshot": true,
+    "expires": "2100-01-01T00:00:00Z",
+    "keys": {
+      "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "d482fa4805a50870aa1356ace6b764f7ab47ed4dc38f49b1a189afa25f179e94"
+        },
+        "scheme": "ed25519"
+      },
+      "808aa256a8172bb0cb961767c6768e55ccf732c99afccc6145752d7a328b7937": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "62f71f99c788f16bcdc8bb252455e3a690350e4ddea5a6aab1f9a3aaabcf369a"
+        },
+        "scheme": "ed25519"
+      },
+      "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "8656ad20568cd3534c405e4d9a84b0c6e6163f7f66434df77416502835b9b160"
+        },
+        "scheme": "ed25519"
+      },
+      "ce72db3f938914205461a415c9b7b91267a2079df991fd6283aa8461988c1add": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "bca152214dbfd3e7a1b7a7b3e2cc179fb00520fd7212c8a60ba99f14dfc0e1ca"
+        },
+        "scheme": "ed25519"
+      }
+    },
+    "roles": {
+      "root": {
+        "keyids": [
+          "ce72db3f938914205461a415c9b7b91267a2079df991fd6283aa8461988c1add"
+        ],
+        "threshold": 1
+      },
+      "snapshot": {
+        "keyids": [
+          "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45"
+        ],
+        "threshold": 1
+      },
+      "targets": {
+        "keyids": [
+          "808aa256a8172bb0cb961767c6768e55ccf732c99afccc6145752d7a328b7937"
+        ],
+        "threshold": 1
+      },
+      "timestamp": {
+        "keyids": [
+          "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8"
+        ],
+        "threshold": 1
+      }
+    },
+    "spec_version": "1.0",
+    "version": 1
+  }
+}

--- a/tests/metadata/consistent-snapshot-true/1/repository/1.snapshot.json
+++ b/tests/metadata/consistent-snapshot-true/1/repository/1.snapshot.json
@@ -1,1 +1,23 @@
-../../0/repository/1.snapshot.json
+{
+  "signatures": [
+    {
+      "keyid": "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45",
+      "sig": "4b1d5d95b627df2724ac1cfaac5c724b1ff30417e79806b3b4bbf6b2bc82d503a550b67cf61c6d6ba75c946c83f01d37e5b91a7e523347f031a6e5c911ec9b0e"
+    }
+  ],
+  "signed": {
+    "_type": "snapshot",
+    "expires": "2100-01-01T00:00:00Z",
+    "meta": {
+      "targets.json": {
+        "hashes": {
+          "sha256": "6f3dfc94b76f43571cb0ae35a2624059fc423c920c983d4d4be65a48e5b1e0f4"
+        },
+        "length": 573,
+        "version": 1
+      }
+    },
+    "spec_version": "1.0",
+    "version": 1
+  }
+}

--- a/tests/metadata/consistent-snapshot-true/1/repository/1.targets.json
+++ b/tests/metadata/consistent-snapshot-true/1/repository/1.targets.json
@@ -1,1 +1,22 @@
-../../0/repository/1.targets.json
+{
+  "signatures": [
+    {
+      "keyid": "808aa256a8172bb0cb961767c6768e55ccf732c99afccc6145752d7a328b7937",
+      "sig": "4c52ea661f1d5177a0c8d2b2f1187fbdc41e3bf2e25d134a89c7955317c783f36de6c224121f643916115a46061769f527465b23a481dd14c26eec4b58342607"
+    }
+  ],
+  "signed": {
+    "_type": "targets",
+    "expires": "2100-01-01T00:00:00Z",
+    "spec_version": "1.0",
+    "targets": {
+      "0": {
+        "hashes": {
+          "sha256": "5feceb66ffc86f38d952786c6d696c79c2dbc239dd4e91b46729d73a27fb57e9"
+        },
+        "length": 1
+      }
+    },
+    "version": 1
+  }
+}

--- a/tests/metadata/consistent-snapshot-true/1/repository/2.root.json
+++ b/tests/metadata/consistent-snapshot-true/1/repository/2.root.json
@@ -2,7 +2,11 @@
   "signatures": [
     {
       "keyid": "ce72db3f938914205461a415c9b7b91267a2079df991fd6283aa8461988c1add",
-      "sig": "6658129fea318671119384ba07d53121ad14981730f1e6761c18358140fc1aa2ff8cfec9a50ce46642aa55d55369ce0ccec0aa7d3dea224ead3971747e58670a"
+      "sig": "e560f386c0c270bb44cedda965ad21526e65162b41a2c30d84fb3a80f58913432e8dc74e5e7b0635ccdf51a2b951dae3b0ba28b4aac4088641a2b2cd2933dd04"
+    },
+    {
+      "keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
+      "sig": "7ac71619b21fe3a076fbbf3e17f92177c5374f005c32f1818e7c92eee107e3c726ccf906e800878035a9caf7679610147d72cb515cd76164b08b5c8bf93c0f0e"
     }
   ],
   "signed": {
@@ -82,6 +86,6 @@
       }
     },
     "spec_version": "1.0",
-    "version": 1
+    "version": 2
   }
 }

--- a/tests/metadata/consistent-snapshot-true/1/repository/2.snapshot.json
+++ b/tests/metadata/consistent-snapshot-true/1/repository/2.snapshot.json
@@ -2,7 +2,7 @@
   "signatures": [
     {
       "keyid": "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45",
-      "sig": "a6cb00a2106e095857edb20d9e59c6d722af93c1a58f15c4d4384a46efa98a1d0e39f745717662603f47e048966fff6e9d0d2f366cdb33e774ce1bf70da1a404"
+      "sig": "c3eaa4ff63e189db79bac83d03ba6ac4fce89202535a3634ff9ec1df8a77537b01ada21cfd7f7426a918047e86145f60cafbd451142f382a4618c0f27b19d207"
     }
   ],
   "signed": {
@@ -11,13 +11,13 @@
     "meta": {
       "targets.json": {
         "hashes": {
-          "sha256": "b94550c5ca58966c848a41a3b8c2c81f247fe42309f44591ce785824b175691d"
+          "sha256": "5975a125ea2a25f4ef671597937c0ed2aee4a3d403c3b4f28c3b265d3acae79f"
         },
         "length": 733,
-        "version": 1
+        "version": 2
       }
     },
     "spec_version": "1.0",
-    "version": 1
+    "version": 2
   }
 }

--- a/tests/metadata/consistent-snapshot-true/1/repository/2.targets.json
+++ b/tests/metadata/consistent-snapshot-true/1/repository/2.targets.json
@@ -2,7 +2,7 @@
   "signatures": [
     {
       "keyid": "808aa256a8172bb0cb961767c6768e55ccf732c99afccc6145752d7a328b7937",
-      "sig": "66bddbea0156eb594981fc24ac769cf325c8fed350e83827c375870d51daebdc9e695454eb4a01e8573da21c426440344f8de9ba2f1ef77c989eeb64df9f810d"
+      "sig": "286234d725c777e3b7361af91d92e509f83d9c9e53feb7daad291f34e49557af418716bc7bf88901fd1beb0d580848516cb7c1a2623d526b8d0c68d67624e80f"
     }
   ],
   "signed": {
@@ -23,6 +23,6 @@
         "length": 1
       }
     },
-    "version": 1
+    "version": 2
   }
 }

--- a/tests/metadata/consistent-snapshot-true/1/repository/root.json
+++ b/tests/metadata/consistent-snapshot-true/1/repository/root.json
@@ -2,7 +2,11 @@
   "signatures": [
     {
       "keyid": "ce72db3f938914205461a415c9b7b91267a2079df991fd6283aa8461988c1add",
-      "sig": "6658129fea318671119384ba07d53121ad14981730f1e6761c18358140fc1aa2ff8cfec9a50ce46642aa55d55369ce0ccec0aa7d3dea224ead3971747e58670a"
+      "sig": "e560f386c0c270bb44cedda965ad21526e65162b41a2c30d84fb3a80f58913432e8dc74e5e7b0635ccdf51a2b951dae3b0ba28b4aac4088641a2b2cd2933dd04"
+    },
+    {
+      "keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
+      "sig": "7ac71619b21fe3a076fbbf3e17f92177c5374f005c32f1818e7c92eee107e3c726ccf906e800878035a9caf7679610147d72cb515cd76164b08b5c8bf93c0f0e"
     }
   ],
   "signed": {
@@ -82,6 +86,6 @@
       }
     },
     "spec_version": "1.0",
-    "version": 1
+    "version": 2
   }
 }

--- a/tests/metadata/consistent-snapshot-true/1/repository/targets/5feceb66ffc86f38d952786c6d696c79c2dbc239dd4e91b46729d73a27fb57e9.0
+++ b/tests/metadata/consistent-snapshot-true/1/repository/targets/5feceb66ffc86f38d952786c6d696c79c2dbc239dd4e91b46729d73a27fb57e9.0
@@ -1,1 +1,1 @@
-../../../0/repository/targets/5feceb66ffc86f38d952786c6d696c79c2dbc239dd4e91b46729d73a27fb57e9.0
+0

--- a/tests/metadata/consistent-snapshot-true/1/repository/timestamp.json
+++ b/tests/metadata/consistent-snapshot-true/1/repository/timestamp.json
@@ -2,7 +2,7 @@
   "signatures": [
     {
       "keyid": "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8",
-      "sig": "f0dbea901a89a58b1e1500c7470a5d791f74850b8dfb317701ad9558f8f1d57737a2364ac776fef71e35eab48d232b16f3215e99ff469387699b890430e6640a"
+      "sig": "9a83f1f85472bd01726739d63bbc95b2ac5bb7146cfe73debfb6379e2aca2a30158b1420436c2f82f080d10e4b27bcbfdfcb1c93501416edc3ae73d6ad5c760d"
     }
   ],
   "signed": {
@@ -11,13 +11,13 @@
     "meta": {
       "snapshot.json": {
         "hashes": {
-          "sha256": "80e5b2e94e657b4ff468965369ee9981e67c973d6576e9a970ea4d7ca07fd87e"
+          "sha256": "57a4211414ea2fd5304683ad93b7187ef4145c98df54293389b8d978d98e5cce"
         },
         "length": 606,
-        "version": 1
+        "version": 2
       }
     },
     "spec_version": "1.0",
-    "version": 1
+    "version": 2
   }
 }

--- a/tests/metadata/consistent-snapshot-true/2/repository/1.root.json
+++ b/tests/metadata/consistent-snapshot-true/2/repository/1.root.json
@@ -1,1 +1,87 @@
-../../1/repository/1.root.json
+{
+  "signatures": [
+    {
+      "keyid": "ce72db3f938914205461a415c9b7b91267a2079df991fd6283aa8461988c1add",
+      "sig": "104eb78cba674adfc7ade1d4396c99466a7d4480e50aab89df53117faffd3d4d4ea87833fe6f83b8dc7f6e1e4a62c0329244c6e5f910627772df3c4d61a8900f"
+    }
+  ],
+  "signed": {
+    "_type": "root",
+    "consistent_snapshot": true,
+    "expires": "2100-01-01T00:00:00Z",
+    "keys": {
+      "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "d482fa4805a50870aa1356ace6b764f7ab47ed4dc38f49b1a189afa25f179e94"
+        },
+        "scheme": "ed25519"
+      },
+      "808aa256a8172bb0cb961767c6768e55ccf732c99afccc6145752d7a328b7937": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "62f71f99c788f16bcdc8bb252455e3a690350e4ddea5a6aab1f9a3aaabcf369a"
+        },
+        "scheme": "ed25519"
+      },
+      "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "8656ad20568cd3534c405e4d9a84b0c6e6163f7f66434df77416502835b9b160"
+        },
+        "scheme": "ed25519"
+      },
+      "ce72db3f938914205461a415c9b7b91267a2079df991fd6283aa8461988c1add": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "bca152214dbfd3e7a1b7a7b3e2cc179fb00520fd7212c8a60ba99f14dfc0e1ca"
+        },
+        "scheme": "ed25519"
+      }
+    },
+    "roles": {
+      "root": {
+        "keyids": [
+          "ce72db3f938914205461a415c9b7b91267a2079df991fd6283aa8461988c1add"
+        ],
+        "threshold": 1
+      },
+      "snapshot": {
+        "keyids": [
+          "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45"
+        ],
+        "threshold": 1
+      },
+      "targets": {
+        "keyids": [
+          "808aa256a8172bb0cb961767c6768e55ccf732c99afccc6145752d7a328b7937"
+        ],
+        "threshold": 1
+      },
+      "timestamp": {
+        "keyids": [
+          "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8"
+        ],
+        "threshold": 1
+      }
+    },
+    "spec_version": "1.0",
+    "version": 1
+  }
+}

--- a/tests/metadata/consistent-snapshot-true/2/repository/1.snapshot.json
+++ b/tests/metadata/consistent-snapshot-true/2/repository/1.snapshot.json
@@ -1,1 +1,23 @@
-../../1/repository/1.snapshot.json
+{
+  "signatures": [
+    {
+      "keyid": "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45",
+      "sig": "4b1d5d95b627df2724ac1cfaac5c724b1ff30417e79806b3b4bbf6b2bc82d503a550b67cf61c6d6ba75c946c83f01d37e5b91a7e523347f031a6e5c911ec9b0e"
+    }
+  ],
+  "signed": {
+    "_type": "snapshot",
+    "expires": "2100-01-01T00:00:00Z",
+    "meta": {
+      "targets.json": {
+        "hashes": {
+          "sha256": "6f3dfc94b76f43571cb0ae35a2624059fc423c920c983d4d4be65a48e5b1e0f4"
+        },
+        "length": 573,
+        "version": 1
+      }
+    },
+    "spec_version": "1.0",
+    "version": 1
+  }
+}

--- a/tests/metadata/consistent-snapshot-true/2/repository/1.targets.json
+++ b/tests/metadata/consistent-snapshot-true/2/repository/1.targets.json
@@ -1,1 +1,22 @@
-../../1/repository/1.targets.json
+{
+  "signatures": [
+    {
+      "keyid": "808aa256a8172bb0cb961767c6768e55ccf732c99afccc6145752d7a328b7937",
+      "sig": "4c52ea661f1d5177a0c8d2b2f1187fbdc41e3bf2e25d134a89c7955317c783f36de6c224121f643916115a46061769f527465b23a481dd14c26eec4b58342607"
+    }
+  ],
+  "signed": {
+    "_type": "targets",
+    "expires": "2100-01-01T00:00:00Z",
+    "spec_version": "1.0",
+    "targets": {
+      "0": {
+        "hashes": {
+          "sha256": "5feceb66ffc86f38d952786c6d696c79c2dbc239dd4e91b46729d73a27fb57e9"
+        },
+        "length": 1
+      }
+    },
+    "version": 1
+  }
+}

--- a/tests/metadata/consistent-snapshot-true/2/repository/2.root.json
+++ b/tests/metadata/consistent-snapshot-true/2/repository/2.root.json
@@ -1,1 +1,91 @@
-../../1/repository/2.root.json
+{
+  "signatures": [
+    {
+      "keyid": "ce72db3f938914205461a415c9b7b91267a2079df991fd6283aa8461988c1add",
+      "sig": "e560f386c0c270bb44cedda965ad21526e65162b41a2c30d84fb3a80f58913432e8dc74e5e7b0635ccdf51a2b951dae3b0ba28b4aac4088641a2b2cd2933dd04"
+    },
+    {
+      "keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
+      "sig": "7ac71619b21fe3a076fbbf3e17f92177c5374f005c32f1818e7c92eee107e3c726ccf906e800878035a9caf7679610147d72cb515cd76164b08b5c8bf93c0f0e"
+    }
+  ],
+  "signed": {
+    "_type": "root",
+    "consistent_snapshot": true,
+    "expires": "2100-01-01T00:00:00Z",
+    "keys": {
+      "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "d482fa4805a50870aa1356ace6b764f7ab47ed4dc38f49b1a189afa25f179e94"
+        },
+        "scheme": "ed25519"
+      },
+      "808aa256a8172bb0cb961767c6768e55ccf732c99afccc6145752d7a328b7937": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "62f71f99c788f16bcdc8bb252455e3a690350e4ddea5a6aab1f9a3aaabcf369a"
+        },
+        "scheme": "ed25519"
+      },
+      "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "8656ad20568cd3534c405e4d9a84b0c6e6163f7f66434df77416502835b9b160"
+        },
+        "scheme": "ed25519"
+      },
+      "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "153986a7370e002f377dd68797e7466c421180c1571e233de2f8ab41c8af4f54"
+        },
+        "scheme": "ed25519"
+      }
+    },
+    "roles": {
+      "root": {
+        "keyids": [
+          "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f"
+        ],
+        "threshold": 1
+      },
+      "snapshot": {
+        "keyids": [
+          "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45"
+        ],
+        "threshold": 1
+      },
+      "targets": {
+        "keyids": [
+          "808aa256a8172bb0cb961767c6768e55ccf732c99afccc6145752d7a328b7937"
+        ],
+        "threshold": 1
+      },
+      "timestamp": {
+        "keyids": [
+          "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8"
+        ],
+        "threshold": 1
+      }
+    },
+    "spec_version": "1.0",
+    "version": 2
+  }
+}

--- a/tests/metadata/consistent-snapshot-true/2/repository/2.snapshot.json
+++ b/tests/metadata/consistent-snapshot-true/2/repository/2.snapshot.json
@@ -1,1 +1,23 @@
-../../1/repository/2.snapshot.json
+{
+  "signatures": [
+    {
+      "keyid": "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45",
+      "sig": "c3eaa4ff63e189db79bac83d03ba6ac4fce89202535a3634ff9ec1df8a77537b01ada21cfd7f7426a918047e86145f60cafbd451142f382a4618c0f27b19d207"
+    }
+  ],
+  "signed": {
+    "_type": "snapshot",
+    "expires": "2100-01-01T00:00:00Z",
+    "meta": {
+      "targets.json": {
+        "hashes": {
+          "sha256": "5975a125ea2a25f4ef671597937c0ed2aee4a3d403c3b4f28c3b265d3acae79f"
+        },
+        "length": 733,
+        "version": 2
+      }
+    },
+    "spec_version": "1.0",
+    "version": 2
+  }
+}

--- a/tests/metadata/consistent-snapshot-true/2/repository/2.targets.json
+++ b/tests/metadata/consistent-snapshot-true/2/repository/2.targets.json
@@ -1,1 +1,28 @@
-../../1/repository/2.targets.json
+{
+  "signatures": [
+    {
+      "keyid": "808aa256a8172bb0cb961767c6768e55ccf732c99afccc6145752d7a328b7937",
+      "sig": "286234d725c777e3b7361af91d92e509f83d9c9e53feb7daad291f34e49557af418716bc7bf88901fd1beb0d580848516cb7c1a2623d526b8d0c68d67624e80f"
+    }
+  ],
+  "signed": {
+    "_type": "targets",
+    "expires": "2100-01-01T00:00:00Z",
+    "spec_version": "1.0",
+    "targets": {
+      "0": {
+        "hashes": {
+          "sha256": "5feceb66ffc86f38d952786c6d696c79c2dbc239dd4e91b46729d73a27fb57e9"
+        },
+        "length": 1
+      },
+      "1": {
+        "hashes": {
+          "sha256": "6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b"
+        },
+        "length": 1
+      }
+    },
+    "version": 2
+  }
+}

--- a/tests/metadata/consistent-snapshot-true/2/repository/3.root.json
+++ b/tests/metadata/consistent-snapshot-true/2/repository/3.root.json
@@ -2,7 +2,7 @@
   "signatures": [
     {
       "keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
-      "sig": "4842fe74732b866401ef512ca8f4536cc49ca38ea7eecd5f015ad33395a7d605f3627e51ecb079ac53806fdf5b3820c2c42fce285714806e1f4dded689c3e50c"
+      "sig": "475436056dca79fd151ae830ad2f4dbc7ecc5b146a79319c20a1167d4f214047d8f3847d1cda4ccd32a48acb13acbea55ba7e8254cffaa07e3de9ecdd0c13d03"
     }
   ],
   "signed": {
@@ -82,6 +82,6 @@
       }
     },
     "spec_version": "1.0",
-    "version": 1
+    "version": 3
   }
 }

--- a/tests/metadata/consistent-snapshot-true/2/repository/3.snapshot.json
+++ b/tests/metadata/consistent-snapshot-true/2/repository/3.snapshot.json
@@ -2,7 +2,7 @@
   "signatures": [
     {
       "keyid": "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45",
-      "sig": "5be4664c0ada239accc1a52f005aaeafd84ef7836586b62122802c9b0566707dab0323e3e7a132614d3451c565e9406abf9fa56bbdd7889de9573922e1b66609"
+      "sig": "88450c663d32ed78e937ba759c106349bf94c1c44307ef07191cb595a7e4328abcea952134533f2ef5d7ce56d0ca68899636d3037e497d2f034b5e4ba27b3c00"
     }
   ],
   "signed": {
@@ -11,13 +11,13 @@
     "meta": {
       "targets.json": {
         "hashes": {
-          "sha256": "862027382b8c6b9300e04ca83246abc68e7210af75b5df70aa984c0c1ed9fc2f"
+          "sha256": "d9b3218dc3c3527b24f851212f352aa3d4ca07c40552a130b7ca45105ca96fa7"
         },
         "length": 893,
-        "version": 1
+        "version": 3
       }
     },
     "spec_version": "1.0",
-    "version": 1
+    "version": 3
   }
 }

--- a/tests/metadata/consistent-snapshot-true/2/repository/3.targets.json
+++ b/tests/metadata/consistent-snapshot-true/2/repository/3.targets.json
@@ -2,7 +2,7 @@
   "signatures": [
     {
       "keyid": "bc8f087663855564b358ddf314d5932ab920af17bd1df2f58b397afd82d76dc1",
-      "sig": "d45d0a32ad2b1f71589b5586a457aa7d27a4e8d64747edbd6e18b6d8499c37032eac36d68b05ecbe839058f1c78b5d26d8ad1cb83947594186e8500db21e8008"
+      "sig": "e19dc8a26f209a8422b21b71d1f0c2ffd5e2eea9d0f8848ca8395c496735860bafd28b62deb8f439a3b2e957494f751eca28399e406e062a0591e1549ab86508"
     }
   ],
   "signed": {
@@ -29,6 +29,6 @@
         "length": 1
       }
     },
-    "version": 1
+    "version": 3
   }
 }

--- a/tests/metadata/consistent-snapshot-true/2/repository/root.json
+++ b/tests/metadata/consistent-snapshot-true/2/repository/root.json
@@ -2,7 +2,7 @@
   "signatures": [
     {
       "keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
-      "sig": "4842fe74732b866401ef512ca8f4536cc49ca38ea7eecd5f015ad33395a7d605f3627e51ecb079ac53806fdf5b3820c2c42fce285714806e1f4dded689c3e50c"
+      "sig": "475436056dca79fd151ae830ad2f4dbc7ecc5b146a79319c20a1167d4f214047d8f3847d1cda4ccd32a48acb13acbea55ba7e8254cffaa07e3de9ecdd0c13d03"
     }
   ],
   "signed": {
@@ -82,6 +82,6 @@
       }
     },
     "spec_version": "1.0",
-    "version": 1
+    "version": 3
   }
 }

--- a/tests/metadata/consistent-snapshot-true/2/repository/targets/5feceb66ffc86f38d952786c6d696c79c2dbc239dd4e91b46729d73a27fb57e9.0
+++ b/tests/metadata/consistent-snapshot-true/2/repository/targets/5feceb66ffc86f38d952786c6d696c79c2dbc239dd4e91b46729d73a27fb57e9.0
@@ -1,1 +1,1 @@
-../../../1/repository/targets/5feceb66ffc86f38d952786c6d696c79c2dbc239dd4e91b46729d73a27fb57e9.0
+0

--- a/tests/metadata/consistent-snapshot-true/2/repository/targets/6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b.1
+++ b/tests/metadata/consistent-snapshot-true/2/repository/targets/6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b.1
@@ -1,1 +1,1 @@
-../../../1/repository/targets/6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b.1
+1

--- a/tests/metadata/consistent-snapshot-true/2/repository/timestamp.json
+++ b/tests/metadata/consistent-snapshot-true/2/repository/timestamp.json
@@ -2,7 +2,7 @@
   "signatures": [
     {
       "keyid": "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8",
-      "sig": "774139b1204af52960e5375cf775ffb6e0a5f6863d003b8eeeb9a333c92910a0518ddc98b958c75520e95dcbc944c42a49134370a8a5c3723794ae2c10c0f00d"
+      "sig": "6090861afdf2b0dc5b899291d4ff3af9ab731b84660351a929c649b6cd5e0db6c63f480ffdbd70d9d22fd09f7144fae54df5c8db8a37757a3d0b83fce6acda09"
     }
   ],
   "signed": {
@@ -11,13 +11,13 @@
     "meta": {
       "snapshot.json": {
         "hashes": {
-          "sha256": "117d2ed64ce4baa4fdb0f097d3442d2558655ba5ee273a2eda7f8412e0cf9b12"
+          "sha256": "94fc023ccf37a06e6264117a3908f678f348b0a200faed236e68c1457b1faec3"
         },
         "length": 606,
-        "version": 1
+        "version": 3
       }
     },
     "spec_version": "1.0",
-    "version": 1
+    "version": 3
   }
 }

--- a/tests/metadata/consistent-snapshot-true/3/repository/1.root.json
+++ b/tests/metadata/consistent-snapshot-true/3/repository/1.root.json
@@ -1,1 +1,87 @@
-../../2/repository/1.root.json
+{
+  "signatures": [
+    {
+      "keyid": "ce72db3f938914205461a415c9b7b91267a2079df991fd6283aa8461988c1add",
+      "sig": "104eb78cba674adfc7ade1d4396c99466a7d4480e50aab89df53117faffd3d4d4ea87833fe6f83b8dc7f6e1e4a62c0329244c6e5f910627772df3c4d61a8900f"
+    }
+  ],
+  "signed": {
+    "_type": "root",
+    "consistent_snapshot": true,
+    "expires": "2100-01-01T00:00:00Z",
+    "keys": {
+      "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "d482fa4805a50870aa1356ace6b764f7ab47ed4dc38f49b1a189afa25f179e94"
+        },
+        "scheme": "ed25519"
+      },
+      "808aa256a8172bb0cb961767c6768e55ccf732c99afccc6145752d7a328b7937": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "62f71f99c788f16bcdc8bb252455e3a690350e4ddea5a6aab1f9a3aaabcf369a"
+        },
+        "scheme": "ed25519"
+      },
+      "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "8656ad20568cd3534c405e4d9a84b0c6e6163f7f66434df77416502835b9b160"
+        },
+        "scheme": "ed25519"
+      },
+      "ce72db3f938914205461a415c9b7b91267a2079df991fd6283aa8461988c1add": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "bca152214dbfd3e7a1b7a7b3e2cc179fb00520fd7212c8a60ba99f14dfc0e1ca"
+        },
+        "scheme": "ed25519"
+      }
+    },
+    "roles": {
+      "root": {
+        "keyids": [
+          "ce72db3f938914205461a415c9b7b91267a2079df991fd6283aa8461988c1add"
+        ],
+        "threshold": 1
+      },
+      "snapshot": {
+        "keyids": [
+          "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45"
+        ],
+        "threshold": 1
+      },
+      "targets": {
+        "keyids": [
+          "808aa256a8172bb0cb961767c6768e55ccf732c99afccc6145752d7a328b7937"
+        ],
+        "threshold": 1
+      },
+      "timestamp": {
+        "keyids": [
+          "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8"
+        ],
+        "threshold": 1
+      }
+    },
+    "spec_version": "1.0",
+    "version": 1
+  }
+}

--- a/tests/metadata/consistent-snapshot-true/3/repository/1.snapshot.json
+++ b/tests/metadata/consistent-snapshot-true/3/repository/1.snapshot.json
@@ -1,1 +1,23 @@
-../../2/repository/1.snapshot.json
+{
+  "signatures": [
+    {
+      "keyid": "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45",
+      "sig": "4b1d5d95b627df2724ac1cfaac5c724b1ff30417e79806b3b4bbf6b2bc82d503a550b67cf61c6d6ba75c946c83f01d37e5b91a7e523347f031a6e5c911ec9b0e"
+    }
+  ],
+  "signed": {
+    "_type": "snapshot",
+    "expires": "2100-01-01T00:00:00Z",
+    "meta": {
+      "targets.json": {
+        "hashes": {
+          "sha256": "6f3dfc94b76f43571cb0ae35a2624059fc423c920c983d4d4be65a48e5b1e0f4"
+        },
+        "length": 573,
+        "version": 1
+      }
+    },
+    "spec_version": "1.0",
+    "version": 1
+  }
+}

--- a/tests/metadata/consistent-snapshot-true/3/repository/1.targets.json
+++ b/tests/metadata/consistent-snapshot-true/3/repository/1.targets.json
@@ -1,1 +1,22 @@
-../../2/repository/1.targets.json
+{
+  "signatures": [
+    {
+      "keyid": "808aa256a8172bb0cb961767c6768e55ccf732c99afccc6145752d7a328b7937",
+      "sig": "4c52ea661f1d5177a0c8d2b2f1187fbdc41e3bf2e25d134a89c7955317c783f36de6c224121f643916115a46061769f527465b23a481dd14c26eec4b58342607"
+    }
+  ],
+  "signed": {
+    "_type": "targets",
+    "expires": "2100-01-01T00:00:00Z",
+    "spec_version": "1.0",
+    "targets": {
+      "0": {
+        "hashes": {
+          "sha256": "5feceb66ffc86f38d952786c6d696c79c2dbc239dd4e91b46729d73a27fb57e9"
+        },
+        "length": 1
+      }
+    },
+    "version": 1
+  }
+}

--- a/tests/metadata/consistent-snapshot-true/3/repository/2.root.json
+++ b/tests/metadata/consistent-snapshot-true/3/repository/2.root.json
@@ -1,1 +1,91 @@
-../../2/repository/2.root.json
+{
+  "signatures": [
+    {
+      "keyid": "ce72db3f938914205461a415c9b7b91267a2079df991fd6283aa8461988c1add",
+      "sig": "e560f386c0c270bb44cedda965ad21526e65162b41a2c30d84fb3a80f58913432e8dc74e5e7b0635ccdf51a2b951dae3b0ba28b4aac4088641a2b2cd2933dd04"
+    },
+    {
+      "keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
+      "sig": "7ac71619b21fe3a076fbbf3e17f92177c5374f005c32f1818e7c92eee107e3c726ccf906e800878035a9caf7679610147d72cb515cd76164b08b5c8bf93c0f0e"
+    }
+  ],
+  "signed": {
+    "_type": "root",
+    "consistent_snapshot": true,
+    "expires": "2100-01-01T00:00:00Z",
+    "keys": {
+      "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "d482fa4805a50870aa1356ace6b764f7ab47ed4dc38f49b1a189afa25f179e94"
+        },
+        "scheme": "ed25519"
+      },
+      "808aa256a8172bb0cb961767c6768e55ccf732c99afccc6145752d7a328b7937": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "62f71f99c788f16bcdc8bb252455e3a690350e4ddea5a6aab1f9a3aaabcf369a"
+        },
+        "scheme": "ed25519"
+      },
+      "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "8656ad20568cd3534c405e4d9a84b0c6e6163f7f66434df77416502835b9b160"
+        },
+        "scheme": "ed25519"
+      },
+      "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "153986a7370e002f377dd68797e7466c421180c1571e233de2f8ab41c8af4f54"
+        },
+        "scheme": "ed25519"
+      }
+    },
+    "roles": {
+      "root": {
+        "keyids": [
+          "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f"
+        ],
+        "threshold": 1
+      },
+      "snapshot": {
+        "keyids": [
+          "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45"
+        ],
+        "threshold": 1
+      },
+      "targets": {
+        "keyids": [
+          "808aa256a8172bb0cb961767c6768e55ccf732c99afccc6145752d7a328b7937"
+        ],
+        "threshold": 1
+      },
+      "timestamp": {
+        "keyids": [
+          "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8"
+        ],
+        "threshold": 1
+      }
+    },
+    "spec_version": "1.0",
+    "version": 2
+  }
+}

--- a/tests/metadata/consistent-snapshot-true/3/repository/2.snapshot.json
+++ b/tests/metadata/consistent-snapshot-true/3/repository/2.snapshot.json
@@ -1,1 +1,23 @@
-../../2/repository/2.snapshot.json
+{
+  "signatures": [
+    {
+      "keyid": "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45",
+      "sig": "c3eaa4ff63e189db79bac83d03ba6ac4fce89202535a3634ff9ec1df8a77537b01ada21cfd7f7426a918047e86145f60cafbd451142f382a4618c0f27b19d207"
+    }
+  ],
+  "signed": {
+    "_type": "snapshot",
+    "expires": "2100-01-01T00:00:00Z",
+    "meta": {
+      "targets.json": {
+        "hashes": {
+          "sha256": "5975a125ea2a25f4ef671597937c0ed2aee4a3d403c3b4f28c3b265d3acae79f"
+        },
+        "length": 733,
+        "version": 2
+      }
+    },
+    "spec_version": "1.0",
+    "version": 2
+  }
+}

--- a/tests/metadata/consistent-snapshot-true/3/repository/2.targets.json
+++ b/tests/metadata/consistent-snapshot-true/3/repository/2.targets.json
@@ -1,1 +1,28 @@
-../../2/repository/2.targets.json
+{
+  "signatures": [
+    {
+      "keyid": "808aa256a8172bb0cb961767c6768e55ccf732c99afccc6145752d7a328b7937",
+      "sig": "286234d725c777e3b7361af91d92e509f83d9c9e53feb7daad291f34e49557af418716bc7bf88901fd1beb0d580848516cb7c1a2623d526b8d0c68d67624e80f"
+    }
+  ],
+  "signed": {
+    "_type": "targets",
+    "expires": "2100-01-01T00:00:00Z",
+    "spec_version": "1.0",
+    "targets": {
+      "0": {
+        "hashes": {
+          "sha256": "5feceb66ffc86f38d952786c6d696c79c2dbc239dd4e91b46729d73a27fb57e9"
+        },
+        "length": 1
+      },
+      "1": {
+        "hashes": {
+          "sha256": "6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b"
+        },
+        "length": 1
+      }
+    },
+    "version": 2
+  }
+}

--- a/tests/metadata/consistent-snapshot-true/3/repository/3.root.json
+++ b/tests/metadata/consistent-snapshot-true/3/repository/3.root.json
@@ -1,1 +1,87 @@
-../../2/repository/3.root.json
+{
+  "signatures": [
+    {
+      "keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
+      "sig": "475436056dca79fd151ae830ad2f4dbc7ecc5b146a79319c20a1167d4f214047d8f3847d1cda4ccd32a48acb13acbea55ba7e8254cffaa07e3de9ecdd0c13d03"
+    }
+  ],
+  "signed": {
+    "_type": "root",
+    "consistent_snapshot": true,
+    "expires": "2100-01-01T00:00:00Z",
+    "keys": {
+      "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "d482fa4805a50870aa1356ace6b764f7ab47ed4dc38f49b1a189afa25f179e94"
+        },
+        "scheme": "ed25519"
+      },
+      "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "8656ad20568cd3534c405e4d9a84b0c6e6163f7f66434df77416502835b9b160"
+        },
+        "scheme": "ed25519"
+      },
+      "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "153986a7370e002f377dd68797e7466c421180c1571e233de2f8ab41c8af4f54"
+        },
+        "scheme": "ed25519"
+      },
+      "bc8f087663855564b358ddf314d5932ab920af17bd1df2f58b397afd82d76dc1": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "aee574e56780ea1709a8b56e02d4ffdd9a3a1deaed61e2eb0701f376a4422e42"
+        },
+        "scheme": "ed25519"
+      }
+    },
+    "roles": {
+      "root": {
+        "keyids": [
+          "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f"
+        ],
+        "threshold": 1
+      },
+      "snapshot": {
+        "keyids": [
+          "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45"
+        ],
+        "threshold": 1
+      },
+      "targets": {
+        "keyids": [
+          "bc8f087663855564b358ddf314d5932ab920af17bd1df2f58b397afd82d76dc1"
+        ],
+        "threshold": 1
+      },
+      "timestamp": {
+        "keyids": [
+          "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8"
+        ],
+        "threshold": 1
+      }
+    },
+    "spec_version": "1.0",
+    "version": 3
+  }
+}

--- a/tests/metadata/consistent-snapshot-true/3/repository/3.snapshot.json
+++ b/tests/metadata/consistent-snapshot-true/3/repository/3.snapshot.json
@@ -1,1 +1,23 @@
-../../2/repository/3.snapshot.json
+{
+  "signatures": [
+    {
+      "keyid": "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45",
+      "sig": "88450c663d32ed78e937ba759c106349bf94c1c44307ef07191cb595a7e4328abcea952134533f2ef5d7ce56d0ca68899636d3037e497d2f034b5e4ba27b3c00"
+    }
+  ],
+  "signed": {
+    "_type": "snapshot",
+    "expires": "2100-01-01T00:00:00Z",
+    "meta": {
+      "targets.json": {
+        "hashes": {
+          "sha256": "d9b3218dc3c3527b24f851212f352aa3d4ca07c40552a130b7ca45105ca96fa7"
+        },
+        "length": 893,
+        "version": 3
+      }
+    },
+    "spec_version": "1.0",
+    "version": 3
+  }
+}

--- a/tests/metadata/consistent-snapshot-true/3/repository/3.targets.json
+++ b/tests/metadata/consistent-snapshot-true/3/repository/3.targets.json
@@ -1,1 +1,34 @@
-../../2/repository/3.targets.json
+{
+  "signatures": [
+    {
+      "keyid": "bc8f087663855564b358ddf314d5932ab920af17bd1df2f58b397afd82d76dc1",
+      "sig": "e19dc8a26f209a8422b21b71d1f0c2ffd5e2eea9d0f8848ca8395c496735860bafd28b62deb8f439a3b2e957494f751eca28399e406e062a0591e1549ab86508"
+    }
+  ],
+  "signed": {
+    "_type": "targets",
+    "expires": "2100-01-01T00:00:00Z",
+    "spec_version": "1.0",
+    "targets": {
+      "0": {
+        "hashes": {
+          "sha256": "5feceb66ffc86f38d952786c6d696c79c2dbc239dd4e91b46729d73a27fb57e9"
+        },
+        "length": 1
+      },
+      "1": {
+        "hashes": {
+          "sha256": "6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b"
+        },
+        "length": 1
+      },
+      "2": {
+        "hashes": {
+          "sha256": "d4735e3a265e16eee03f59718b9b5d03019c07d8b6c51f90da3a666eec13ab35"
+        },
+        "length": 1
+      }
+    },
+    "version": 3
+  }
+}

--- a/tests/metadata/consistent-snapshot-true/3/repository/4.root.json
+++ b/tests/metadata/consistent-snapshot-true/3/repository/4.root.json
@@ -2,7 +2,7 @@
   "signatures": [
     {
       "keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
-      "sig": "9e36e50d82e225e3337bd0f3ae260956903e5123f220a76eaf99cec7c44b1a94c88a80b36cf041da90b72b7b78871f057cf3b13f982efe5962f73c0faf560306"
+      "sig": "15431a0217deb636e2e79876cfdfc8b78fdda1119e6c8512c7dc61af240a7d2303f172e7fc28de7dfe58d92c84f5118ccd09d0f29f49aaa3f7ef95edf21e2d0a"
     }
   ],
   "signed": {
@@ -82,6 +82,6 @@
       }
     },
     "spec_version": "1.0",
-    "version": 1
+    "version": 4
   }
 }

--- a/tests/metadata/consistent-snapshot-true/3/repository/4.snapshot.json
+++ b/tests/metadata/consistent-snapshot-true/3/repository/4.snapshot.json
@@ -2,7 +2,7 @@
   "signatures": [
     {
       "keyid": "b096bc2d67080cec22e6c0bbaa69cfd9d714b9e9ad847d255f950b2728855fef",
-      "sig": "de676dd15bf3535afc7f95fb81384a14d81454cbb980cfef623332d7f7df9e5837f748afbef04004cc5d8a03bef05394990757850767cd71e63264a8e5c4d709"
+      "sig": "46ec63e7984f022a3338eacb86e385f5dc464ec72ec876735b3522d5857ceef8a7f44264e3bc326233e54717c488e7ae37c72226ca62f1c75ab9000436ffff0f"
     }
   ],
   "signed": {
@@ -11,13 +11,13 @@
     "meta": {
       "targets.json": {
         "hashes": {
-          "sha256": "7b64a146874838bfa0c88d81914a1216f0c721eb9b2d53037a41231066c208f6"
+          "sha256": "618ad46b2eb62ce9842ebd490b4e6f38d34c1c9318b43bd87dc2fe963a2acbfc"
         },
         "length": 1053,
-        "version": 1
+        "version": 4
       }
     },
     "spec_version": "1.0",
-    "version": 1
+    "version": 4
   }
 }

--- a/tests/metadata/consistent-snapshot-true/3/repository/4.targets.json
+++ b/tests/metadata/consistent-snapshot-true/3/repository/4.targets.json
@@ -2,7 +2,7 @@
   "signatures": [
     {
       "keyid": "bc8f087663855564b358ddf314d5932ab920af17bd1df2f58b397afd82d76dc1",
-      "sig": "c809aed78c8475ac1e87e9c9fe6ba5c1bc69acc70777d81821d6727a7718004ce8ada721fe1c59b7dfe452c787dc5e36b6c506555782bdb5ae0ff9d1baaff60f"
+      "sig": "44c8222aedd3e8e5818f12cf6373ebe025487212db45eeb479330f69f14de163e212541bd1d0aa1c294da901be866241209182033e3874416e023d4963d78905"
     }
   ],
   "signed": {
@@ -35,6 +35,6 @@
         "length": 1
       }
     },
-    "version": 1
+    "version": 4
   }
 }

--- a/tests/metadata/consistent-snapshot-true/3/repository/root.json
+++ b/tests/metadata/consistent-snapshot-true/3/repository/root.json
@@ -2,7 +2,7 @@
   "signatures": [
     {
       "keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
-      "sig": "9e36e50d82e225e3337bd0f3ae260956903e5123f220a76eaf99cec7c44b1a94c88a80b36cf041da90b72b7b78871f057cf3b13f982efe5962f73c0faf560306"
+      "sig": "15431a0217deb636e2e79876cfdfc8b78fdda1119e6c8512c7dc61af240a7d2303f172e7fc28de7dfe58d92c84f5118ccd09d0f29f49aaa3f7ef95edf21e2d0a"
     }
   ],
   "signed": {
@@ -82,6 +82,6 @@
       }
     },
     "spec_version": "1.0",
-    "version": 1
+    "version": 4
   }
 }

--- a/tests/metadata/consistent-snapshot-true/3/repository/targets/5feceb66ffc86f38d952786c6d696c79c2dbc239dd4e91b46729d73a27fb57e9.0
+++ b/tests/metadata/consistent-snapshot-true/3/repository/targets/5feceb66ffc86f38d952786c6d696c79c2dbc239dd4e91b46729d73a27fb57e9.0
@@ -1,1 +1,1 @@
-../../../2/repository/targets/5feceb66ffc86f38d952786c6d696c79c2dbc239dd4e91b46729d73a27fb57e9.0
+0

--- a/tests/metadata/consistent-snapshot-true/3/repository/targets/6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b.1
+++ b/tests/metadata/consistent-snapshot-true/3/repository/targets/6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b.1
@@ -1,1 +1,1 @@
-../../../2/repository/targets/6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b.1
+1

--- a/tests/metadata/consistent-snapshot-true/3/repository/targets/d4735e3a265e16eee03f59718b9b5d03019c07d8b6c51f90da3a666eec13ab35.2
+++ b/tests/metadata/consistent-snapshot-true/3/repository/targets/d4735e3a265e16eee03f59718b9b5d03019c07d8b6c51f90da3a666eec13ab35.2
@@ -1,1 +1,1 @@
-../../../2/repository/targets/d4735e3a265e16eee03f59718b9b5d03019c07d8b6c51f90da3a666eec13ab35.2
+2

--- a/tests/metadata/consistent-snapshot-true/3/repository/timestamp.json
+++ b/tests/metadata/consistent-snapshot-true/3/repository/timestamp.json
@@ -2,7 +2,7 @@
   "signatures": [
     {
       "keyid": "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8",
-      "sig": "f622bda68466c12c267848cd75880b57fb95b3728c691bd81f0d3d593179dcd7a35976bc35e4b5a715509b85647589dc1dc9410c3c4a974f9de06dbcc3f88d04"
+      "sig": "92f5824f6ec91a018362ec9da77f0f44b5894ae1d1cdc4aa21149c652842e9056208e2f7b6aa579a93169bf7ee32ae0933f4494ed6a4dbeb294eac6ad548510f"
     }
   ],
   "signed": {
@@ -11,13 +11,13 @@
     "meta": {
       "snapshot.json": {
         "hashes": {
-          "sha256": "d89d289cdf4473c9a0fa6eab7a4c40289f44cf5c68de0ac23bef02b31d5798f9"
+          "sha256": "4071731205e7ab717878f787ce16709bf4fe7794c1f16a2ee275d8dafe435f4f"
         },
         "length": 607,
-        "version": 1
+        "version": 4
       }
     },
     "spec_version": "1.0",
-    "version": 1
+    "version": 4
   }
 }

--- a/tests/metadata/consistent-snapshot-true/4/repository/1.root.json
+++ b/tests/metadata/consistent-snapshot-true/4/repository/1.root.json
@@ -1,1 +1,87 @@
-../../3/repository/1.root.json
+{
+  "signatures": [
+    {
+      "keyid": "ce72db3f938914205461a415c9b7b91267a2079df991fd6283aa8461988c1add",
+      "sig": "104eb78cba674adfc7ade1d4396c99466a7d4480e50aab89df53117faffd3d4d4ea87833fe6f83b8dc7f6e1e4a62c0329244c6e5f910627772df3c4d61a8900f"
+    }
+  ],
+  "signed": {
+    "_type": "root",
+    "consistent_snapshot": true,
+    "expires": "2100-01-01T00:00:00Z",
+    "keys": {
+      "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "d482fa4805a50870aa1356ace6b764f7ab47ed4dc38f49b1a189afa25f179e94"
+        },
+        "scheme": "ed25519"
+      },
+      "808aa256a8172bb0cb961767c6768e55ccf732c99afccc6145752d7a328b7937": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "62f71f99c788f16bcdc8bb252455e3a690350e4ddea5a6aab1f9a3aaabcf369a"
+        },
+        "scheme": "ed25519"
+      },
+      "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "8656ad20568cd3534c405e4d9a84b0c6e6163f7f66434df77416502835b9b160"
+        },
+        "scheme": "ed25519"
+      },
+      "ce72db3f938914205461a415c9b7b91267a2079df991fd6283aa8461988c1add": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "bca152214dbfd3e7a1b7a7b3e2cc179fb00520fd7212c8a60ba99f14dfc0e1ca"
+        },
+        "scheme": "ed25519"
+      }
+    },
+    "roles": {
+      "root": {
+        "keyids": [
+          "ce72db3f938914205461a415c9b7b91267a2079df991fd6283aa8461988c1add"
+        ],
+        "threshold": 1
+      },
+      "snapshot": {
+        "keyids": [
+          "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45"
+        ],
+        "threshold": 1
+      },
+      "targets": {
+        "keyids": [
+          "808aa256a8172bb0cb961767c6768e55ccf732c99afccc6145752d7a328b7937"
+        ],
+        "threshold": 1
+      },
+      "timestamp": {
+        "keyids": [
+          "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8"
+        ],
+        "threshold": 1
+      }
+    },
+    "spec_version": "1.0",
+    "version": 1
+  }
+}

--- a/tests/metadata/consistent-snapshot-true/4/repository/1.snapshot.json
+++ b/tests/metadata/consistent-snapshot-true/4/repository/1.snapshot.json
@@ -1,1 +1,23 @@
-../../3/repository/1.snapshot.json
+{
+  "signatures": [
+    {
+      "keyid": "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45",
+      "sig": "4b1d5d95b627df2724ac1cfaac5c724b1ff30417e79806b3b4bbf6b2bc82d503a550b67cf61c6d6ba75c946c83f01d37e5b91a7e523347f031a6e5c911ec9b0e"
+    }
+  ],
+  "signed": {
+    "_type": "snapshot",
+    "expires": "2100-01-01T00:00:00Z",
+    "meta": {
+      "targets.json": {
+        "hashes": {
+          "sha256": "6f3dfc94b76f43571cb0ae35a2624059fc423c920c983d4d4be65a48e5b1e0f4"
+        },
+        "length": 573,
+        "version": 1
+      }
+    },
+    "spec_version": "1.0",
+    "version": 1
+  }
+}

--- a/tests/metadata/consistent-snapshot-true/4/repository/1.targets.json
+++ b/tests/metadata/consistent-snapshot-true/4/repository/1.targets.json
@@ -1,1 +1,22 @@
-../../3/repository/1.targets.json
+{
+  "signatures": [
+    {
+      "keyid": "808aa256a8172bb0cb961767c6768e55ccf732c99afccc6145752d7a328b7937",
+      "sig": "4c52ea661f1d5177a0c8d2b2f1187fbdc41e3bf2e25d134a89c7955317c783f36de6c224121f643916115a46061769f527465b23a481dd14c26eec4b58342607"
+    }
+  ],
+  "signed": {
+    "_type": "targets",
+    "expires": "2100-01-01T00:00:00Z",
+    "spec_version": "1.0",
+    "targets": {
+      "0": {
+        "hashes": {
+          "sha256": "5feceb66ffc86f38d952786c6d696c79c2dbc239dd4e91b46729d73a27fb57e9"
+        },
+        "length": 1
+      }
+    },
+    "version": 1
+  }
+}

--- a/tests/metadata/consistent-snapshot-true/4/repository/2.root.json
+++ b/tests/metadata/consistent-snapshot-true/4/repository/2.root.json
@@ -1,1 +1,91 @@
-../../3/repository/2.root.json
+{
+  "signatures": [
+    {
+      "keyid": "ce72db3f938914205461a415c9b7b91267a2079df991fd6283aa8461988c1add",
+      "sig": "e560f386c0c270bb44cedda965ad21526e65162b41a2c30d84fb3a80f58913432e8dc74e5e7b0635ccdf51a2b951dae3b0ba28b4aac4088641a2b2cd2933dd04"
+    },
+    {
+      "keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
+      "sig": "7ac71619b21fe3a076fbbf3e17f92177c5374f005c32f1818e7c92eee107e3c726ccf906e800878035a9caf7679610147d72cb515cd76164b08b5c8bf93c0f0e"
+    }
+  ],
+  "signed": {
+    "_type": "root",
+    "consistent_snapshot": true,
+    "expires": "2100-01-01T00:00:00Z",
+    "keys": {
+      "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "d482fa4805a50870aa1356ace6b764f7ab47ed4dc38f49b1a189afa25f179e94"
+        },
+        "scheme": "ed25519"
+      },
+      "808aa256a8172bb0cb961767c6768e55ccf732c99afccc6145752d7a328b7937": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "62f71f99c788f16bcdc8bb252455e3a690350e4ddea5a6aab1f9a3aaabcf369a"
+        },
+        "scheme": "ed25519"
+      },
+      "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "8656ad20568cd3534c405e4d9a84b0c6e6163f7f66434df77416502835b9b160"
+        },
+        "scheme": "ed25519"
+      },
+      "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "153986a7370e002f377dd68797e7466c421180c1571e233de2f8ab41c8af4f54"
+        },
+        "scheme": "ed25519"
+      }
+    },
+    "roles": {
+      "root": {
+        "keyids": [
+          "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f"
+        ],
+        "threshold": 1
+      },
+      "snapshot": {
+        "keyids": [
+          "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45"
+        ],
+        "threshold": 1
+      },
+      "targets": {
+        "keyids": [
+          "808aa256a8172bb0cb961767c6768e55ccf732c99afccc6145752d7a328b7937"
+        ],
+        "threshold": 1
+      },
+      "timestamp": {
+        "keyids": [
+          "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8"
+        ],
+        "threshold": 1
+      }
+    },
+    "spec_version": "1.0",
+    "version": 2
+  }
+}

--- a/tests/metadata/consistent-snapshot-true/4/repository/2.snapshot.json
+++ b/tests/metadata/consistent-snapshot-true/4/repository/2.snapshot.json
@@ -1,1 +1,23 @@
-../../3/repository/2.snapshot.json
+{
+  "signatures": [
+    {
+      "keyid": "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45",
+      "sig": "c3eaa4ff63e189db79bac83d03ba6ac4fce89202535a3634ff9ec1df8a77537b01ada21cfd7f7426a918047e86145f60cafbd451142f382a4618c0f27b19d207"
+    }
+  ],
+  "signed": {
+    "_type": "snapshot",
+    "expires": "2100-01-01T00:00:00Z",
+    "meta": {
+      "targets.json": {
+        "hashes": {
+          "sha256": "5975a125ea2a25f4ef671597937c0ed2aee4a3d403c3b4f28c3b265d3acae79f"
+        },
+        "length": 733,
+        "version": 2
+      }
+    },
+    "spec_version": "1.0",
+    "version": 2
+  }
+}

--- a/tests/metadata/consistent-snapshot-true/4/repository/2.targets.json
+++ b/tests/metadata/consistent-snapshot-true/4/repository/2.targets.json
@@ -1,1 +1,28 @@
-../../3/repository/2.targets.json
+{
+  "signatures": [
+    {
+      "keyid": "808aa256a8172bb0cb961767c6768e55ccf732c99afccc6145752d7a328b7937",
+      "sig": "286234d725c777e3b7361af91d92e509f83d9c9e53feb7daad291f34e49557af418716bc7bf88901fd1beb0d580848516cb7c1a2623d526b8d0c68d67624e80f"
+    }
+  ],
+  "signed": {
+    "_type": "targets",
+    "expires": "2100-01-01T00:00:00Z",
+    "spec_version": "1.0",
+    "targets": {
+      "0": {
+        "hashes": {
+          "sha256": "5feceb66ffc86f38d952786c6d696c79c2dbc239dd4e91b46729d73a27fb57e9"
+        },
+        "length": 1
+      },
+      "1": {
+        "hashes": {
+          "sha256": "6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b"
+        },
+        "length": 1
+      }
+    },
+    "version": 2
+  }
+}

--- a/tests/metadata/consistent-snapshot-true/4/repository/3.root.json
+++ b/tests/metadata/consistent-snapshot-true/4/repository/3.root.json
@@ -1,1 +1,87 @@
-../../3/repository/3.root.json
+{
+  "signatures": [
+    {
+      "keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
+      "sig": "475436056dca79fd151ae830ad2f4dbc7ecc5b146a79319c20a1167d4f214047d8f3847d1cda4ccd32a48acb13acbea55ba7e8254cffaa07e3de9ecdd0c13d03"
+    }
+  ],
+  "signed": {
+    "_type": "root",
+    "consistent_snapshot": true,
+    "expires": "2100-01-01T00:00:00Z",
+    "keys": {
+      "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "d482fa4805a50870aa1356ace6b764f7ab47ed4dc38f49b1a189afa25f179e94"
+        },
+        "scheme": "ed25519"
+      },
+      "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "8656ad20568cd3534c405e4d9a84b0c6e6163f7f66434df77416502835b9b160"
+        },
+        "scheme": "ed25519"
+      },
+      "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "153986a7370e002f377dd68797e7466c421180c1571e233de2f8ab41c8af4f54"
+        },
+        "scheme": "ed25519"
+      },
+      "bc8f087663855564b358ddf314d5932ab920af17bd1df2f58b397afd82d76dc1": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "aee574e56780ea1709a8b56e02d4ffdd9a3a1deaed61e2eb0701f376a4422e42"
+        },
+        "scheme": "ed25519"
+      }
+    },
+    "roles": {
+      "root": {
+        "keyids": [
+          "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f"
+        ],
+        "threshold": 1
+      },
+      "snapshot": {
+        "keyids": [
+          "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45"
+        ],
+        "threshold": 1
+      },
+      "targets": {
+        "keyids": [
+          "bc8f087663855564b358ddf314d5932ab920af17bd1df2f58b397afd82d76dc1"
+        ],
+        "threshold": 1
+      },
+      "timestamp": {
+        "keyids": [
+          "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8"
+        ],
+        "threshold": 1
+      }
+    },
+    "spec_version": "1.0",
+    "version": 3
+  }
+}

--- a/tests/metadata/consistent-snapshot-true/4/repository/3.snapshot.json
+++ b/tests/metadata/consistent-snapshot-true/4/repository/3.snapshot.json
@@ -1,1 +1,23 @@
-../../3/repository/3.snapshot.json
+{
+  "signatures": [
+    {
+      "keyid": "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45",
+      "sig": "88450c663d32ed78e937ba759c106349bf94c1c44307ef07191cb595a7e4328abcea952134533f2ef5d7ce56d0ca68899636d3037e497d2f034b5e4ba27b3c00"
+    }
+  ],
+  "signed": {
+    "_type": "snapshot",
+    "expires": "2100-01-01T00:00:00Z",
+    "meta": {
+      "targets.json": {
+        "hashes": {
+          "sha256": "d9b3218dc3c3527b24f851212f352aa3d4ca07c40552a130b7ca45105ca96fa7"
+        },
+        "length": 893,
+        "version": 3
+      }
+    },
+    "spec_version": "1.0",
+    "version": 3
+  }
+}

--- a/tests/metadata/consistent-snapshot-true/4/repository/3.targets.json
+++ b/tests/metadata/consistent-snapshot-true/4/repository/3.targets.json
@@ -1,1 +1,34 @@
-../../3/repository/3.targets.json
+{
+  "signatures": [
+    {
+      "keyid": "bc8f087663855564b358ddf314d5932ab920af17bd1df2f58b397afd82d76dc1",
+      "sig": "e19dc8a26f209a8422b21b71d1f0c2ffd5e2eea9d0f8848ca8395c496735860bafd28b62deb8f439a3b2e957494f751eca28399e406e062a0591e1549ab86508"
+    }
+  ],
+  "signed": {
+    "_type": "targets",
+    "expires": "2100-01-01T00:00:00Z",
+    "spec_version": "1.0",
+    "targets": {
+      "0": {
+        "hashes": {
+          "sha256": "5feceb66ffc86f38d952786c6d696c79c2dbc239dd4e91b46729d73a27fb57e9"
+        },
+        "length": 1
+      },
+      "1": {
+        "hashes": {
+          "sha256": "6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b"
+        },
+        "length": 1
+      },
+      "2": {
+        "hashes": {
+          "sha256": "d4735e3a265e16eee03f59718b9b5d03019c07d8b6c51f90da3a666eec13ab35"
+        },
+        "length": 1
+      }
+    },
+    "version": 3
+  }
+}

--- a/tests/metadata/consistent-snapshot-true/4/repository/4.root.json
+++ b/tests/metadata/consistent-snapshot-true/4/repository/4.root.json
@@ -1,1 +1,87 @@
-../../3/repository/4.root.json
+{
+  "signatures": [
+    {
+      "keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
+      "sig": "15431a0217deb636e2e79876cfdfc8b78fdda1119e6c8512c7dc61af240a7d2303f172e7fc28de7dfe58d92c84f5118ccd09d0f29f49aaa3f7ef95edf21e2d0a"
+    }
+  ],
+  "signed": {
+    "_type": "root",
+    "consistent_snapshot": true,
+    "expires": "2100-01-01T00:00:00Z",
+    "keys": {
+      "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "8656ad20568cd3534c405e4d9a84b0c6e6163f7f66434df77416502835b9b160"
+        },
+        "scheme": "ed25519"
+      },
+      "b096bc2d67080cec22e6c0bbaa69cfd9d714b9e9ad847d255f950b2728855fef": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "722dbc861813bb5b568524d62083e875c08e66fed1694d9161d253fa163dd86f"
+        },
+        "scheme": "ed25519"
+      },
+      "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "153986a7370e002f377dd68797e7466c421180c1571e233de2f8ab41c8af4f54"
+        },
+        "scheme": "ed25519"
+      },
+      "bc8f087663855564b358ddf314d5932ab920af17bd1df2f58b397afd82d76dc1": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "aee574e56780ea1709a8b56e02d4ffdd9a3a1deaed61e2eb0701f376a4422e42"
+        },
+        "scheme": "ed25519"
+      }
+    },
+    "roles": {
+      "root": {
+        "keyids": [
+          "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f"
+        ],
+        "threshold": 1
+      },
+      "snapshot": {
+        "keyids": [
+          "b096bc2d67080cec22e6c0bbaa69cfd9d714b9e9ad847d255f950b2728855fef"
+        ],
+        "threshold": 1
+      },
+      "targets": {
+        "keyids": [
+          "bc8f087663855564b358ddf314d5932ab920af17bd1df2f58b397afd82d76dc1"
+        ],
+        "threshold": 1
+      },
+      "timestamp": {
+        "keyids": [
+          "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8"
+        ],
+        "threshold": 1
+      }
+    },
+    "spec_version": "1.0",
+    "version": 4
+  }
+}

--- a/tests/metadata/consistent-snapshot-true/4/repository/4.snapshot.json
+++ b/tests/metadata/consistent-snapshot-true/4/repository/4.snapshot.json
@@ -1,1 +1,23 @@
-../../3/repository/4.snapshot.json
+{
+  "signatures": [
+    {
+      "keyid": "b096bc2d67080cec22e6c0bbaa69cfd9d714b9e9ad847d255f950b2728855fef",
+      "sig": "46ec63e7984f022a3338eacb86e385f5dc464ec72ec876735b3522d5857ceef8a7f44264e3bc326233e54717c488e7ae37c72226ca62f1c75ab9000436ffff0f"
+    }
+  ],
+  "signed": {
+    "_type": "snapshot",
+    "expires": "2100-01-01T00:00:00Z",
+    "meta": {
+      "targets.json": {
+        "hashes": {
+          "sha256": "618ad46b2eb62ce9842ebd490b4e6f38d34c1c9318b43bd87dc2fe963a2acbfc"
+        },
+        "length": 1053,
+        "version": 4
+      }
+    },
+    "spec_version": "1.0",
+    "version": 4
+  }
+}

--- a/tests/metadata/consistent-snapshot-true/4/repository/4.targets.json
+++ b/tests/metadata/consistent-snapshot-true/4/repository/4.targets.json
@@ -1,1 +1,40 @@
-../../3/repository/4.targets.json
+{
+  "signatures": [
+    {
+      "keyid": "bc8f087663855564b358ddf314d5932ab920af17bd1df2f58b397afd82d76dc1",
+      "sig": "44c8222aedd3e8e5818f12cf6373ebe025487212db45eeb479330f69f14de163e212541bd1d0aa1c294da901be866241209182033e3874416e023d4963d78905"
+    }
+  ],
+  "signed": {
+    "_type": "targets",
+    "expires": "2100-01-01T00:00:00Z",
+    "spec_version": "1.0",
+    "targets": {
+      "0": {
+        "hashes": {
+          "sha256": "5feceb66ffc86f38d952786c6d696c79c2dbc239dd4e91b46729d73a27fb57e9"
+        },
+        "length": 1
+      },
+      "1": {
+        "hashes": {
+          "sha256": "6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b"
+        },
+        "length": 1
+      },
+      "2": {
+        "hashes": {
+          "sha256": "d4735e3a265e16eee03f59718b9b5d03019c07d8b6c51f90da3a666eec13ab35"
+        },
+        "length": 1
+      },
+      "3": {
+        "hashes": {
+          "sha256": "4e07408562bedb8b60ce05c1decfe3ad16b72230967de01f640b7e4729b49fce"
+        },
+        "length": 1
+      }
+    },
+    "version": 4
+  }
+}

--- a/tests/metadata/consistent-snapshot-true/4/repository/5.root.json
+++ b/tests/metadata/consistent-snapshot-true/4/repository/5.root.json
@@ -2,7 +2,7 @@
   "signatures": [
     {
       "keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
-      "sig": "dbf58a65ede5376df919fc15874289ad8f0cb87d3fde3bd1ffebc1a29d63fafd5f82fefd6281b954ae56798aaa3e43038fdee46450c3983c2912ca4482160f08"
+      "sig": "2b6f30258eaf8b4b2d900a2efb4a597b45a9c0c5a0720d5521dd37d63c34d1db62aafaa1d95b6d881f9c991615ab68930c24ef247d2f45836bca3659e36d9c0b"
     }
   ],
   "signed": {
@@ -82,6 +82,6 @@
       }
     },
     "spec_version": "1.0",
-    "version": 1
+    "version": 5
   }
 }

--- a/tests/metadata/consistent-snapshot-true/4/repository/5.snapshot.json
+++ b/tests/metadata/consistent-snapshot-true/4/repository/5.snapshot.json
@@ -2,7 +2,7 @@
   "signatures": [
     {
       "keyid": "b096bc2d67080cec22e6c0bbaa69cfd9d714b9e9ad847d255f950b2728855fef",
-      "sig": "941fe32e73659117ace6990ae8e0c160975142514df09bb60c07b7ca9b2884ed290f8857555b2914800cb09205e58a1e3ee8f5907c1716836734bfb639146400"
+      "sig": "e909ae39d5724cb05788dac7b81f7c91bb2f1a9badebeb09a485b58665f6d471090df92c5bf76a92fd36e5af0655b144cfc2cd8a1d11de3fc43f739145c5fa02"
     }
   ],
   "signed": {
@@ -11,13 +11,13 @@
     "meta": {
       "targets.json": {
         "hashes": {
-          "sha256": "0b5b663a36df0f3821756bac1d028c1eaeeacc2f783ac0cd328969ea5e5ea0b1"
+          "sha256": "e981f082145fd093e0469ad7f88f6cc2b9ccc8058e6b081b4f85eea0178e72ad"
         },
         "length": 1213,
-        "version": 1
+        "version": 5
       }
     },
     "spec_version": "1.0",
-    "version": 1
+    "version": 5
   }
 }

--- a/tests/metadata/consistent-snapshot-true/4/repository/5.targets.json
+++ b/tests/metadata/consistent-snapshot-true/4/repository/5.targets.json
@@ -2,7 +2,7 @@
   "signatures": [
     {
       "keyid": "bc8f087663855564b358ddf314d5932ab920af17bd1df2f58b397afd82d76dc1",
-      "sig": "9a75e06f5fdd92bc91d2921ddefd22aa5cfdd83bf79dadc1954d044259478a8392d41494611845d67ef9d8e747fe99cc2d322f35666cd6eba37ef845fb7e1f05"
+      "sig": "c88a8309f966fb794f41acf864c2b204ecb32ada9c4f4844657fa67f174735f75bdd799dfe6850ea8a775b8d2acba5bf82def8b909d3633a0f289eb246cd9f05"
     }
   ],
   "signed": {
@@ -41,6 +41,6 @@
         "length": 1
       }
     },
-    "version": 1
+    "version": 5
   }
 }

--- a/tests/metadata/consistent-snapshot-true/4/repository/root.json
+++ b/tests/metadata/consistent-snapshot-true/4/repository/root.json
@@ -2,7 +2,7 @@
   "signatures": [
     {
       "keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
-      "sig": "dbf58a65ede5376df919fc15874289ad8f0cb87d3fde3bd1ffebc1a29d63fafd5f82fefd6281b954ae56798aaa3e43038fdee46450c3983c2912ca4482160f08"
+      "sig": "2b6f30258eaf8b4b2d900a2efb4a597b45a9c0c5a0720d5521dd37d63c34d1db62aafaa1d95b6d881f9c991615ab68930c24ef247d2f45836bca3659e36d9c0b"
     }
   ],
   "signed": {
@@ -82,6 +82,6 @@
       }
     },
     "spec_version": "1.0",
-    "version": 1
+    "version": 5
   }
 }

--- a/tests/metadata/consistent-snapshot-true/4/repository/targets/4e07408562bedb8b60ce05c1decfe3ad16b72230967de01f640b7e4729b49fce.3
+++ b/tests/metadata/consistent-snapshot-true/4/repository/targets/4e07408562bedb8b60ce05c1decfe3ad16b72230967de01f640b7e4729b49fce.3
@@ -1,1 +1,1 @@
-../../../3/repository/targets/4e07408562bedb8b60ce05c1decfe3ad16b72230967de01f640b7e4729b49fce.3
+3

--- a/tests/metadata/consistent-snapshot-true/4/repository/targets/5feceb66ffc86f38d952786c6d696c79c2dbc239dd4e91b46729d73a27fb57e9.0
+++ b/tests/metadata/consistent-snapshot-true/4/repository/targets/5feceb66ffc86f38d952786c6d696c79c2dbc239dd4e91b46729d73a27fb57e9.0
@@ -1,1 +1,1 @@
-../../../3/repository/targets/5feceb66ffc86f38d952786c6d696c79c2dbc239dd4e91b46729d73a27fb57e9.0
+0

--- a/tests/metadata/consistent-snapshot-true/4/repository/targets/6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b.1
+++ b/tests/metadata/consistent-snapshot-true/4/repository/targets/6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b.1
@@ -1,1 +1,1 @@
-../../../3/repository/targets/6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b.1
+1

--- a/tests/metadata/consistent-snapshot-true/4/repository/targets/d4735e3a265e16eee03f59718b9b5d03019c07d8b6c51f90da3a666eec13ab35.2
+++ b/tests/metadata/consistent-snapshot-true/4/repository/targets/d4735e3a265e16eee03f59718b9b5d03019c07d8b6c51f90da3a666eec13ab35.2
@@ -1,1 +1,1 @@
-../../../3/repository/targets/d4735e3a265e16eee03f59718b9b5d03019c07d8b6c51f90da3a666eec13ab35.2
+2

--- a/tests/metadata/consistent-snapshot-true/4/repository/timestamp.json
+++ b/tests/metadata/consistent-snapshot-true/4/repository/timestamp.json
@@ -2,7 +2,7 @@
   "signatures": [
     {
       "keyid": "a8eaf6de5aecfd0a72b60295b1e1cd12f349079ebcbbb63dbe7072f162e85315",
-      "sig": "9ebda34a99eaf35c066c126efc5af3d6eb94cbb70310c54eaef45623f29a9de11cabb964982f25c7983f374d51fb850424a8348fcd1425147cb8e5e447a67a04"
+      "sig": "8388bf58e18024922f5c24f091cf372d3991f3aa7fbe85ce68d81cb12c894bd422d542f1e9d9d1f83ab5957db50692f974476a2dcc9ee8c7f0ad5b16e4a05801"
     }
   ],
   "signed": {
@@ -11,13 +11,13 @@
     "meta": {
       "snapshot.json": {
         "hashes": {
-          "sha256": "7d68a04ca089190ebdcb79e5430bd033d40378ccf98c67af33779658f294763c"
+          "sha256": "fce145d30b6375b4eba810a95f143cf8e6209b37f696ce10fe084f0e0ca09bd5"
         },
         "length": 607,
-        "version": 1
+        "version": 5
       }
     },
     "spec_version": "1.0",
-    "version": 1
+    "version": 5
   }
 }

--- a/tests/metadata/consistent-snapshot-true/5/repository/1.root.json
+++ b/tests/metadata/consistent-snapshot-true/5/repository/1.root.json
@@ -1,1 +1,87 @@
-../../4/repository/1.root.json
+{
+  "signatures": [
+    {
+      "keyid": "ce72db3f938914205461a415c9b7b91267a2079df991fd6283aa8461988c1add",
+      "sig": "104eb78cba674adfc7ade1d4396c99466a7d4480e50aab89df53117faffd3d4d4ea87833fe6f83b8dc7f6e1e4a62c0329244c6e5f910627772df3c4d61a8900f"
+    }
+  ],
+  "signed": {
+    "_type": "root",
+    "consistent_snapshot": true,
+    "expires": "2100-01-01T00:00:00Z",
+    "keys": {
+      "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "d482fa4805a50870aa1356ace6b764f7ab47ed4dc38f49b1a189afa25f179e94"
+        },
+        "scheme": "ed25519"
+      },
+      "808aa256a8172bb0cb961767c6768e55ccf732c99afccc6145752d7a328b7937": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "62f71f99c788f16bcdc8bb252455e3a690350e4ddea5a6aab1f9a3aaabcf369a"
+        },
+        "scheme": "ed25519"
+      },
+      "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "8656ad20568cd3534c405e4d9a84b0c6e6163f7f66434df77416502835b9b160"
+        },
+        "scheme": "ed25519"
+      },
+      "ce72db3f938914205461a415c9b7b91267a2079df991fd6283aa8461988c1add": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "bca152214dbfd3e7a1b7a7b3e2cc179fb00520fd7212c8a60ba99f14dfc0e1ca"
+        },
+        "scheme": "ed25519"
+      }
+    },
+    "roles": {
+      "root": {
+        "keyids": [
+          "ce72db3f938914205461a415c9b7b91267a2079df991fd6283aa8461988c1add"
+        ],
+        "threshold": 1
+      },
+      "snapshot": {
+        "keyids": [
+          "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45"
+        ],
+        "threshold": 1
+      },
+      "targets": {
+        "keyids": [
+          "808aa256a8172bb0cb961767c6768e55ccf732c99afccc6145752d7a328b7937"
+        ],
+        "threshold": 1
+      },
+      "timestamp": {
+        "keyids": [
+          "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8"
+        ],
+        "threshold": 1
+      }
+    },
+    "spec_version": "1.0",
+    "version": 1
+  }
+}

--- a/tests/metadata/consistent-snapshot-true/5/repository/1.snapshot.json
+++ b/tests/metadata/consistent-snapshot-true/5/repository/1.snapshot.json
@@ -1,1 +1,23 @@
-../../4/repository/1.snapshot.json
+{
+  "signatures": [
+    {
+      "keyid": "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45",
+      "sig": "4b1d5d95b627df2724ac1cfaac5c724b1ff30417e79806b3b4bbf6b2bc82d503a550b67cf61c6d6ba75c946c83f01d37e5b91a7e523347f031a6e5c911ec9b0e"
+    }
+  ],
+  "signed": {
+    "_type": "snapshot",
+    "expires": "2100-01-01T00:00:00Z",
+    "meta": {
+      "targets.json": {
+        "hashes": {
+          "sha256": "6f3dfc94b76f43571cb0ae35a2624059fc423c920c983d4d4be65a48e5b1e0f4"
+        },
+        "length": 573,
+        "version": 1
+      }
+    },
+    "spec_version": "1.0",
+    "version": 1
+  }
+}

--- a/tests/metadata/consistent-snapshot-true/5/repository/1.targets.json
+++ b/tests/metadata/consistent-snapshot-true/5/repository/1.targets.json
@@ -1,1 +1,22 @@
-../../4/repository/1.targets.json
+{
+  "signatures": [
+    {
+      "keyid": "808aa256a8172bb0cb961767c6768e55ccf732c99afccc6145752d7a328b7937",
+      "sig": "4c52ea661f1d5177a0c8d2b2f1187fbdc41e3bf2e25d134a89c7955317c783f36de6c224121f643916115a46061769f527465b23a481dd14c26eec4b58342607"
+    }
+  ],
+  "signed": {
+    "_type": "targets",
+    "expires": "2100-01-01T00:00:00Z",
+    "spec_version": "1.0",
+    "targets": {
+      "0": {
+        "hashes": {
+          "sha256": "5feceb66ffc86f38d952786c6d696c79c2dbc239dd4e91b46729d73a27fb57e9"
+        },
+        "length": 1
+      }
+    },
+    "version": 1
+  }
+}

--- a/tests/metadata/consistent-snapshot-true/5/repository/2.root.json
+++ b/tests/metadata/consistent-snapshot-true/5/repository/2.root.json
@@ -1,1 +1,91 @@
-../../4/repository/2.root.json
+{
+  "signatures": [
+    {
+      "keyid": "ce72db3f938914205461a415c9b7b91267a2079df991fd6283aa8461988c1add",
+      "sig": "e560f386c0c270bb44cedda965ad21526e65162b41a2c30d84fb3a80f58913432e8dc74e5e7b0635ccdf51a2b951dae3b0ba28b4aac4088641a2b2cd2933dd04"
+    },
+    {
+      "keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
+      "sig": "7ac71619b21fe3a076fbbf3e17f92177c5374f005c32f1818e7c92eee107e3c726ccf906e800878035a9caf7679610147d72cb515cd76164b08b5c8bf93c0f0e"
+    }
+  ],
+  "signed": {
+    "_type": "root",
+    "consistent_snapshot": true,
+    "expires": "2100-01-01T00:00:00Z",
+    "keys": {
+      "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "d482fa4805a50870aa1356ace6b764f7ab47ed4dc38f49b1a189afa25f179e94"
+        },
+        "scheme": "ed25519"
+      },
+      "808aa256a8172bb0cb961767c6768e55ccf732c99afccc6145752d7a328b7937": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "62f71f99c788f16bcdc8bb252455e3a690350e4ddea5a6aab1f9a3aaabcf369a"
+        },
+        "scheme": "ed25519"
+      },
+      "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "8656ad20568cd3534c405e4d9a84b0c6e6163f7f66434df77416502835b9b160"
+        },
+        "scheme": "ed25519"
+      },
+      "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "153986a7370e002f377dd68797e7466c421180c1571e233de2f8ab41c8af4f54"
+        },
+        "scheme": "ed25519"
+      }
+    },
+    "roles": {
+      "root": {
+        "keyids": [
+          "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f"
+        ],
+        "threshold": 1
+      },
+      "snapshot": {
+        "keyids": [
+          "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45"
+        ],
+        "threshold": 1
+      },
+      "targets": {
+        "keyids": [
+          "808aa256a8172bb0cb961767c6768e55ccf732c99afccc6145752d7a328b7937"
+        ],
+        "threshold": 1
+      },
+      "timestamp": {
+        "keyids": [
+          "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8"
+        ],
+        "threshold": 1
+      }
+    },
+    "spec_version": "1.0",
+    "version": 2
+  }
+}

--- a/tests/metadata/consistent-snapshot-true/5/repository/2.snapshot.json
+++ b/tests/metadata/consistent-snapshot-true/5/repository/2.snapshot.json
@@ -1,1 +1,23 @@
-../../4/repository/2.snapshot.json
+{
+  "signatures": [
+    {
+      "keyid": "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45",
+      "sig": "c3eaa4ff63e189db79bac83d03ba6ac4fce89202535a3634ff9ec1df8a77537b01ada21cfd7f7426a918047e86145f60cafbd451142f382a4618c0f27b19d207"
+    }
+  ],
+  "signed": {
+    "_type": "snapshot",
+    "expires": "2100-01-01T00:00:00Z",
+    "meta": {
+      "targets.json": {
+        "hashes": {
+          "sha256": "5975a125ea2a25f4ef671597937c0ed2aee4a3d403c3b4f28c3b265d3acae79f"
+        },
+        "length": 733,
+        "version": 2
+      }
+    },
+    "spec_version": "1.0",
+    "version": 2
+  }
+}

--- a/tests/metadata/consistent-snapshot-true/5/repository/2.targets.json
+++ b/tests/metadata/consistent-snapshot-true/5/repository/2.targets.json
@@ -1,1 +1,28 @@
-../../4/repository/2.targets.json
+{
+  "signatures": [
+    {
+      "keyid": "808aa256a8172bb0cb961767c6768e55ccf732c99afccc6145752d7a328b7937",
+      "sig": "286234d725c777e3b7361af91d92e509f83d9c9e53feb7daad291f34e49557af418716bc7bf88901fd1beb0d580848516cb7c1a2623d526b8d0c68d67624e80f"
+    }
+  ],
+  "signed": {
+    "_type": "targets",
+    "expires": "2100-01-01T00:00:00Z",
+    "spec_version": "1.0",
+    "targets": {
+      "0": {
+        "hashes": {
+          "sha256": "5feceb66ffc86f38d952786c6d696c79c2dbc239dd4e91b46729d73a27fb57e9"
+        },
+        "length": 1
+      },
+      "1": {
+        "hashes": {
+          "sha256": "6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b"
+        },
+        "length": 1
+      }
+    },
+    "version": 2
+  }
+}

--- a/tests/metadata/consistent-snapshot-true/5/repository/3.root.json
+++ b/tests/metadata/consistent-snapshot-true/5/repository/3.root.json
@@ -1,1 +1,87 @@
-../../4/repository/3.root.json
+{
+  "signatures": [
+    {
+      "keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
+      "sig": "475436056dca79fd151ae830ad2f4dbc7ecc5b146a79319c20a1167d4f214047d8f3847d1cda4ccd32a48acb13acbea55ba7e8254cffaa07e3de9ecdd0c13d03"
+    }
+  ],
+  "signed": {
+    "_type": "root",
+    "consistent_snapshot": true,
+    "expires": "2100-01-01T00:00:00Z",
+    "keys": {
+      "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "d482fa4805a50870aa1356ace6b764f7ab47ed4dc38f49b1a189afa25f179e94"
+        },
+        "scheme": "ed25519"
+      },
+      "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "8656ad20568cd3534c405e4d9a84b0c6e6163f7f66434df77416502835b9b160"
+        },
+        "scheme": "ed25519"
+      },
+      "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "153986a7370e002f377dd68797e7466c421180c1571e233de2f8ab41c8af4f54"
+        },
+        "scheme": "ed25519"
+      },
+      "bc8f087663855564b358ddf314d5932ab920af17bd1df2f58b397afd82d76dc1": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "aee574e56780ea1709a8b56e02d4ffdd9a3a1deaed61e2eb0701f376a4422e42"
+        },
+        "scheme": "ed25519"
+      }
+    },
+    "roles": {
+      "root": {
+        "keyids": [
+          "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f"
+        ],
+        "threshold": 1
+      },
+      "snapshot": {
+        "keyids": [
+          "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45"
+        ],
+        "threshold": 1
+      },
+      "targets": {
+        "keyids": [
+          "bc8f087663855564b358ddf314d5932ab920af17bd1df2f58b397afd82d76dc1"
+        ],
+        "threshold": 1
+      },
+      "timestamp": {
+        "keyids": [
+          "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8"
+        ],
+        "threshold": 1
+      }
+    },
+    "spec_version": "1.0",
+    "version": 3
+  }
+}

--- a/tests/metadata/consistent-snapshot-true/5/repository/3.snapshot.json
+++ b/tests/metadata/consistent-snapshot-true/5/repository/3.snapshot.json
@@ -1,1 +1,23 @@
-../../4/repository/3.snapshot.json
+{
+  "signatures": [
+    {
+      "keyid": "289e5a9e71afd7909326aa4caea92f7557ee0e2283d8c31f0c3401ce67248a45",
+      "sig": "88450c663d32ed78e937ba759c106349bf94c1c44307ef07191cb595a7e4328abcea952134533f2ef5d7ce56d0ca68899636d3037e497d2f034b5e4ba27b3c00"
+    }
+  ],
+  "signed": {
+    "_type": "snapshot",
+    "expires": "2100-01-01T00:00:00Z",
+    "meta": {
+      "targets.json": {
+        "hashes": {
+          "sha256": "d9b3218dc3c3527b24f851212f352aa3d4ca07c40552a130b7ca45105ca96fa7"
+        },
+        "length": 893,
+        "version": 3
+      }
+    },
+    "spec_version": "1.0",
+    "version": 3
+  }
+}

--- a/tests/metadata/consistent-snapshot-true/5/repository/3.targets.json
+++ b/tests/metadata/consistent-snapshot-true/5/repository/3.targets.json
@@ -1,1 +1,34 @@
-../../4/repository/3.targets.json
+{
+  "signatures": [
+    {
+      "keyid": "bc8f087663855564b358ddf314d5932ab920af17bd1df2f58b397afd82d76dc1",
+      "sig": "e19dc8a26f209a8422b21b71d1f0c2ffd5e2eea9d0f8848ca8395c496735860bafd28b62deb8f439a3b2e957494f751eca28399e406e062a0591e1549ab86508"
+    }
+  ],
+  "signed": {
+    "_type": "targets",
+    "expires": "2100-01-01T00:00:00Z",
+    "spec_version": "1.0",
+    "targets": {
+      "0": {
+        "hashes": {
+          "sha256": "5feceb66ffc86f38d952786c6d696c79c2dbc239dd4e91b46729d73a27fb57e9"
+        },
+        "length": 1
+      },
+      "1": {
+        "hashes": {
+          "sha256": "6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b"
+        },
+        "length": 1
+      },
+      "2": {
+        "hashes": {
+          "sha256": "d4735e3a265e16eee03f59718b9b5d03019c07d8b6c51f90da3a666eec13ab35"
+        },
+        "length": 1
+      }
+    },
+    "version": 3
+  }
+}

--- a/tests/metadata/consistent-snapshot-true/5/repository/4.root.json
+++ b/tests/metadata/consistent-snapshot-true/5/repository/4.root.json
@@ -1,1 +1,87 @@
-../../4/repository/4.root.json
+{
+  "signatures": [
+    {
+      "keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
+      "sig": "15431a0217deb636e2e79876cfdfc8b78fdda1119e6c8512c7dc61af240a7d2303f172e7fc28de7dfe58d92c84f5118ccd09d0f29f49aaa3f7ef95edf21e2d0a"
+    }
+  ],
+  "signed": {
+    "_type": "root",
+    "consistent_snapshot": true,
+    "expires": "2100-01-01T00:00:00Z",
+    "keys": {
+      "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "8656ad20568cd3534c405e4d9a84b0c6e6163f7f66434df77416502835b9b160"
+        },
+        "scheme": "ed25519"
+      },
+      "b096bc2d67080cec22e6c0bbaa69cfd9d714b9e9ad847d255f950b2728855fef": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "722dbc861813bb5b568524d62083e875c08e66fed1694d9161d253fa163dd86f"
+        },
+        "scheme": "ed25519"
+      },
+      "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "153986a7370e002f377dd68797e7466c421180c1571e233de2f8ab41c8af4f54"
+        },
+        "scheme": "ed25519"
+      },
+      "bc8f087663855564b358ddf314d5932ab920af17bd1df2f58b397afd82d76dc1": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "aee574e56780ea1709a8b56e02d4ffdd9a3a1deaed61e2eb0701f376a4422e42"
+        },
+        "scheme": "ed25519"
+      }
+    },
+    "roles": {
+      "root": {
+        "keyids": [
+          "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f"
+        ],
+        "threshold": 1
+      },
+      "snapshot": {
+        "keyids": [
+          "b096bc2d67080cec22e6c0bbaa69cfd9d714b9e9ad847d255f950b2728855fef"
+        ],
+        "threshold": 1
+      },
+      "targets": {
+        "keyids": [
+          "bc8f087663855564b358ddf314d5932ab920af17bd1df2f58b397afd82d76dc1"
+        ],
+        "threshold": 1
+      },
+      "timestamp": {
+        "keyids": [
+          "aa3255b4e8e17e566d2bdbea0e5842978f9fa1d2fa9ec76ae76b146164acbfc8"
+        ],
+        "threshold": 1
+      }
+    },
+    "spec_version": "1.0",
+    "version": 4
+  }
+}

--- a/tests/metadata/consistent-snapshot-true/5/repository/4.snapshot.json
+++ b/tests/metadata/consistent-snapshot-true/5/repository/4.snapshot.json
@@ -1,1 +1,23 @@
-../../4/repository/4.snapshot.json
+{
+  "signatures": [
+    {
+      "keyid": "b096bc2d67080cec22e6c0bbaa69cfd9d714b9e9ad847d255f950b2728855fef",
+      "sig": "46ec63e7984f022a3338eacb86e385f5dc464ec72ec876735b3522d5857ceef8a7f44264e3bc326233e54717c488e7ae37c72226ca62f1c75ab9000436ffff0f"
+    }
+  ],
+  "signed": {
+    "_type": "snapshot",
+    "expires": "2100-01-01T00:00:00Z",
+    "meta": {
+      "targets.json": {
+        "hashes": {
+          "sha256": "618ad46b2eb62ce9842ebd490b4e6f38d34c1c9318b43bd87dc2fe963a2acbfc"
+        },
+        "length": 1053,
+        "version": 4
+      }
+    },
+    "spec_version": "1.0",
+    "version": 4
+  }
+}

--- a/tests/metadata/consistent-snapshot-true/5/repository/4.targets.json
+++ b/tests/metadata/consistent-snapshot-true/5/repository/4.targets.json
@@ -1,1 +1,40 @@
-../../4/repository/4.targets.json
+{
+  "signatures": [
+    {
+      "keyid": "bc8f087663855564b358ddf314d5932ab920af17bd1df2f58b397afd82d76dc1",
+      "sig": "44c8222aedd3e8e5818f12cf6373ebe025487212db45eeb479330f69f14de163e212541bd1d0aa1c294da901be866241209182033e3874416e023d4963d78905"
+    }
+  ],
+  "signed": {
+    "_type": "targets",
+    "expires": "2100-01-01T00:00:00Z",
+    "spec_version": "1.0",
+    "targets": {
+      "0": {
+        "hashes": {
+          "sha256": "5feceb66ffc86f38d952786c6d696c79c2dbc239dd4e91b46729d73a27fb57e9"
+        },
+        "length": 1
+      },
+      "1": {
+        "hashes": {
+          "sha256": "6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b"
+        },
+        "length": 1
+      },
+      "2": {
+        "hashes": {
+          "sha256": "d4735e3a265e16eee03f59718b9b5d03019c07d8b6c51f90da3a666eec13ab35"
+        },
+        "length": 1
+      },
+      "3": {
+        "hashes": {
+          "sha256": "4e07408562bedb8b60ce05c1decfe3ad16b72230967de01f640b7e4729b49fce"
+        },
+        "length": 1
+      }
+    },
+    "version": 4
+  }
+}

--- a/tests/metadata/consistent-snapshot-true/5/repository/5.root.json
+++ b/tests/metadata/consistent-snapshot-true/5/repository/5.root.json
@@ -1,1 +1,87 @@
-../../4/repository/5.root.json
+{
+  "signatures": [
+    {
+      "keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
+      "sig": "2b6f30258eaf8b4b2d900a2efb4a597b45a9c0c5a0720d5521dd37d63c34d1db62aafaa1d95b6d881f9c991615ab68930c24ef247d2f45836bca3659e36d9c0b"
+    }
+  ],
+  "signed": {
+    "_type": "root",
+    "consistent_snapshot": true,
+    "expires": "2100-01-01T00:00:00Z",
+    "keys": {
+      "a8eaf6de5aecfd0a72b60295b1e1cd12f349079ebcbbb63dbe7072f162e85315": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "3ab34b0c2d4eadccaa0f0cf22ced07b552394063a9de2806993d022360dffc76"
+        },
+        "scheme": "ed25519"
+      },
+      "b096bc2d67080cec22e6c0bbaa69cfd9d714b9e9ad847d255f950b2728855fef": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "722dbc861813bb5b568524d62083e875c08e66fed1694d9161d253fa163dd86f"
+        },
+        "scheme": "ed25519"
+      },
+      "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "153986a7370e002f377dd68797e7466c421180c1571e233de2f8ab41c8af4f54"
+        },
+        "scheme": "ed25519"
+      },
+      "bc8f087663855564b358ddf314d5932ab920af17bd1df2f58b397afd82d76dc1": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "aee574e56780ea1709a8b56e02d4ffdd9a3a1deaed61e2eb0701f376a4422e42"
+        },
+        "scheme": "ed25519"
+      }
+    },
+    "roles": {
+      "root": {
+        "keyids": [
+          "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f"
+        ],
+        "threshold": 1
+      },
+      "snapshot": {
+        "keyids": [
+          "b096bc2d67080cec22e6c0bbaa69cfd9d714b9e9ad847d255f950b2728855fef"
+        ],
+        "threshold": 1
+      },
+      "targets": {
+        "keyids": [
+          "bc8f087663855564b358ddf314d5932ab920af17bd1df2f58b397afd82d76dc1"
+        ],
+        "threshold": 1
+      },
+      "timestamp": {
+        "keyids": [
+          "a8eaf6de5aecfd0a72b60295b1e1cd12f349079ebcbbb63dbe7072f162e85315"
+        ],
+        "threshold": 1
+      }
+    },
+    "spec_version": "1.0",
+    "version": 5
+  }
+}

--- a/tests/metadata/consistent-snapshot-true/5/repository/5.snapshot.json
+++ b/tests/metadata/consistent-snapshot-true/5/repository/5.snapshot.json
@@ -1,1 +1,23 @@
-../../4/repository/5.snapshot.json
+{
+  "signatures": [
+    {
+      "keyid": "b096bc2d67080cec22e6c0bbaa69cfd9d714b9e9ad847d255f950b2728855fef",
+      "sig": "e909ae39d5724cb05788dac7b81f7c91bb2f1a9badebeb09a485b58665f6d471090df92c5bf76a92fd36e5af0655b144cfc2cd8a1d11de3fc43f739145c5fa02"
+    }
+  ],
+  "signed": {
+    "_type": "snapshot",
+    "expires": "2100-01-01T00:00:00Z",
+    "meta": {
+      "targets.json": {
+        "hashes": {
+          "sha256": "e981f082145fd093e0469ad7f88f6cc2b9ccc8058e6b081b4f85eea0178e72ad"
+        },
+        "length": 1213,
+        "version": 5
+      }
+    },
+    "spec_version": "1.0",
+    "version": 5
+  }
+}

--- a/tests/metadata/consistent-snapshot-true/5/repository/5.targets.json
+++ b/tests/metadata/consistent-snapshot-true/5/repository/5.targets.json
@@ -1,1 +1,46 @@
-../../4/repository/5.targets.json
+{
+  "signatures": [
+    {
+      "keyid": "bc8f087663855564b358ddf314d5932ab920af17bd1df2f58b397afd82d76dc1",
+      "sig": "c88a8309f966fb794f41acf864c2b204ecb32ada9c4f4844657fa67f174735f75bdd799dfe6850ea8a775b8d2acba5bf82def8b909d3633a0f289eb246cd9f05"
+    }
+  ],
+  "signed": {
+    "_type": "targets",
+    "expires": "2100-01-01T00:00:00Z",
+    "spec_version": "1.0",
+    "targets": {
+      "0": {
+        "hashes": {
+          "sha256": "5feceb66ffc86f38d952786c6d696c79c2dbc239dd4e91b46729d73a27fb57e9"
+        },
+        "length": 1
+      },
+      "1": {
+        "hashes": {
+          "sha256": "6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b"
+        },
+        "length": 1
+      },
+      "2": {
+        "hashes": {
+          "sha256": "d4735e3a265e16eee03f59718b9b5d03019c07d8b6c51f90da3a666eec13ab35"
+        },
+        "length": 1
+      },
+      "3": {
+        "hashes": {
+          "sha256": "4e07408562bedb8b60ce05c1decfe3ad16b72230967de01f640b7e4729b49fce"
+        },
+        "length": 1
+      },
+      "4": {
+        "hashes": {
+          "sha256": "4b227777d4dd1fc61c6f884f48641d02b4d121d3fd328cb08b5531fcacdabf8a"
+        },
+        "length": 1
+      }
+    },
+    "version": 5
+  }
+}

--- a/tests/metadata/consistent-snapshot-true/5/repository/6.root.json
+++ b/tests/metadata/consistent-snapshot-true/5/repository/6.root.json
@@ -2,7 +2,7 @@
   "signatures": [
     {
       "keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
-      "sig": "dbf58a65ede5376df919fc15874289ad8f0cb87d3fde3bd1ffebc1a29d63fafd5f82fefd6281b954ae56798aaa3e43038fdee46450c3983c2912ca4482160f08"
+      "sig": "992e80ded22ecccfbf6b09b9e43a953d8247e97624f9b0a40f262dcfe93a94b0126bde5f3b79ec7d21cdd6c95324de3efaba59f9dab77bfd80d9d400a4c3be0a"
     }
   ],
   "signed": {
@@ -82,6 +82,6 @@
       }
     },
     "spec_version": "1.0",
-    "version": 1
+    "version": 6
   }
 }

--- a/tests/metadata/consistent-snapshot-true/5/repository/6.snapshot.json
+++ b/tests/metadata/consistent-snapshot-true/5/repository/6.snapshot.json
@@ -2,7 +2,7 @@
   "signatures": [
     {
       "keyid": "b096bc2d67080cec22e6c0bbaa69cfd9d714b9e9ad847d255f950b2728855fef",
-      "sig": "98de73b5a6b84c678acc887e8d79af8a5d210344f301433a8b67488fc84bee0f9953229749c94fe0a15e26eb7f3441b6546019aa3f9b79eca07ec371d565d103"
+      "sig": "f3944db41af91bf423e6615d58ab53946266190a74a791fb0bd0dc54b2a355666c116616ee377322161d49d6c34560f1a845fd375deaa4e3489ccbcdfccca604"
     }
   ],
   "signed": {
@@ -11,13 +11,13 @@
     "meta": {
       "targets.json": {
         "hashes": {
-          "sha256": "ec57b871bed358e266a3a6c3d84b53a534901b411ba1dcb2be7f99331e39e16a"
+          "sha256": "c9d177e880cb5e0f9d3c03c5e6e3afff18633dbf8299d6fd30e21d56f4b7a7cd"
         },
         "length": 1373,
-        "version": 1
+        "version": 6
       }
     },
     "spec_version": "1.0",
-    "version": 1
+    "version": 6
   }
 }

--- a/tests/metadata/consistent-snapshot-true/5/repository/6.targets.json
+++ b/tests/metadata/consistent-snapshot-true/5/repository/6.targets.json
@@ -2,7 +2,7 @@
   "signatures": [
     {
       "keyid": "bc8f087663855564b358ddf314d5932ab920af17bd1df2f58b397afd82d76dc1",
-      "sig": "eb6cf42a042e2e5e78a896158670cdb5a10f59bed5f521dccd2456a6f8a6bdcfcb5ae43ad88281aa9c84a38a806db20fc66130f009cb1f78d272c6d0dd7e2a02"
+      "sig": "5a69e9de1f932e72dc54d3df21fbe4b601203fe1a1b9d84cf9ac5f964639ff996718432a1fe6f90e44275423b0acea173ba0a5706db14b217864ca8639f99c03"
     }
   ],
   "signed": {
@@ -47,6 +47,6 @@
         "length": 1
       }
     },
-    "version": 1
+    "version": 6
   }
 }

--- a/tests/metadata/consistent-snapshot-true/5/repository/root.json
+++ b/tests/metadata/consistent-snapshot-true/5/repository/root.json
@@ -1,1 +1,87 @@
-../../4/repository/root.json
+{
+  "signatures": [
+    {
+      "keyid": "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f",
+      "sig": "992e80ded22ecccfbf6b09b9e43a953d8247e97624f9b0a40f262dcfe93a94b0126bde5f3b79ec7d21cdd6c95324de3efaba59f9dab77bfd80d9d400a4c3be0a"
+    }
+  ],
+  "signed": {
+    "_type": "root",
+    "consistent_snapshot": true,
+    "expires": "2100-01-01T00:00:00Z",
+    "keys": {
+      "a8eaf6de5aecfd0a72b60295b1e1cd12f349079ebcbbb63dbe7072f162e85315": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "3ab34b0c2d4eadccaa0f0cf22ced07b552394063a9de2806993d022360dffc76"
+        },
+        "scheme": "ed25519"
+      },
+      "b096bc2d67080cec22e6c0bbaa69cfd9d714b9e9ad847d255f950b2728855fef": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "722dbc861813bb5b568524d62083e875c08e66fed1694d9161d253fa163dd86f"
+        },
+        "scheme": "ed25519"
+      },
+      "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "153986a7370e002f377dd68797e7466c421180c1571e233de2f8ab41c8af4f54"
+        },
+        "scheme": "ed25519"
+      },
+      "bc8f087663855564b358ddf314d5932ab920af17bd1df2f58b397afd82d76dc1": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ed25519",
+        "keyval": {
+          "public": "aee574e56780ea1709a8b56e02d4ffdd9a3a1deaed61e2eb0701f376a4422e42"
+        },
+        "scheme": "ed25519"
+      }
+    },
+    "roles": {
+      "root": {
+        "keyids": [
+          "b2403f96ae9b1089d8cbc15bbc35e9acbacd7984571f951b43aab56aedcfa84f"
+        ],
+        "threshold": 1
+      },
+      "snapshot": {
+        "keyids": [
+          "b096bc2d67080cec22e6c0bbaa69cfd9d714b9e9ad847d255f950b2728855fef"
+        ],
+        "threshold": 1
+      },
+      "targets": {
+        "keyids": [
+          "bc8f087663855564b358ddf314d5932ab920af17bd1df2f58b397afd82d76dc1"
+        ],
+        "threshold": 1
+      },
+      "timestamp": {
+        "keyids": [
+          "a8eaf6de5aecfd0a72b60295b1e1cd12f349079ebcbbb63dbe7072f162e85315"
+        ],
+        "threshold": 1
+      }
+    },
+    "spec_version": "1.0",
+    "version": 6
+  }
+}

--- a/tests/metadata/consistent-snapshot-true/5/repository/targets/4b227777d4dd1fc61c6f884f48641d02b4d121d3fd328cb08b5531fcacdabf8a.4
+++ b/tests/metadata/consistent-snapshot-true/5/repository/targets/4b227777d4dd1fc61c6f884f48641d02b4d121d3fd328cb08b5531fcacdabf8a.4
@@ -1,1 +1,1 @@
-../../../4/repository/targets/4b227777d4dd1fc61c6f884f48641d02b4d121d3fd328cb08b5531fcacdabf8a.4
+4

--- a/tests/metadata/consistent-snapshot-true/5/repository/targets/4e07408562bedb8b60ce05c1decfe3ad16b72230967de01f640b7e4729b49fce.3
+++ b/tests/metadata/consistent-snapshot-true/5/repository/targets/4e07408562bedb8b60ce05c1decfe3ad16b72230967de01f640b7e4729b49fce.3
@@ -1,1 +1,1 @@
-../../../4/repository/targets/4e07408562bedb8b60ce05c1decfe3ad16b72230967de01f640b7e4729b49fce.3
+3

--- a/tests/metadata/consistent-snapshot-true/5/repository/targets/5feceb66ffc86f38d952786c6d696c79c2dbc239dd4e91b46729d73a27fb57e9.0
+++ b/tests/metadata/consistent-snapshot-true/5/repository/targets/5feceb66ffc86f38d952786c6d696c79c2dbc239dd4e91b46729d73a27fb57e9.0
@@ -1,1 +1,1 @@
-../../../4/repository/targets/5feceb66ffc86f38d952786c6d696c79c2dbc239dd4e91b46729d73a27fb57e9.0
+0

--- a/tests/metadata/consistent-snapshot-true/5/repository/targets/6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b.1
+++ b/tests/metadata/consistent-snapshot-true/5/repository/targets/6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b.1
@@ -1,1 +1,1 @@
-../../../4/repository/targets/6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b.1
+1

--- a/tests/metadata/consistent-snapshot-true/5/repository/targets/d4735e3a265e16eee03f59718b9b5d03019c07d8b6c51f90da3a666eec13ab35.2
+++ b/tests/metadata/consistent-snapshot-true/5/repository/targets/d4735e3a265e16eee03f59718b9b5d03019c07d8b6c51f90da3a666eec13ab35.2
@@ -1,1 +1,1 @@
-../../../4/repository/targets/d4735e3a265e16eee03f59718b9b5d03019c07d8b6c51f90da3a666eec13ab35.2
+2

--- a/tests/metadata/consistent-snapshot-true/5/repository/timestamp.json
+++ b/tests/metadata/consistent-snapshot-true/5/repository/timestamp.json
@@ -2,7 +2,7 @@
   "signatures": [
     {
       "keyid": "a8eaf6de5aecfd0a72b60295b1e1cd12f349079ebcbbb63dbe7072f162e85315",
-      "sig": "358e037beae1485097a86c6bcde2a4494985eddb81a8f910a226cb78e61b1994c7a6e701906b0a1f2431a344a12e3559d923e5fc22ff740c07605e573e21880b"
+      "sig": "95ff2508f9913723413ab07e61c21932080af120a162a28b02c5a07eaebe1a9211b30889c44f30dbfa194f7718b059db47046e5e3aea08b5dbbed4b29757140d"
     }
   ],
   "signed": {
@@ -11,13 +11,13 @@
     "meta": {
       "snapshot.json": {
         "hashes": {
-          "sha256": "d2fde7e9b8ec33b3da54a4ae590bad682c57280d95ea57be85b5c245df587c6d"
+          "sha256": "c36eec1e1c876d3cd3be47ecd7f962a1e50dae30be7ab09943c2160b8c28ca8c"
         },
         "length": 607,
-        "version": 1
+        "version": 6
       }
     },
     "spec_version": "1.0",
-    "version": 1
+    "version": 6
   }
 }

--- a/tests/metadata/regenerate-metadata.sh
+++ b/tests/metadata/regenerate-metadata.sh
@@ -11,4 +11,5 @@ for d in consistent-snapshot-false consistent-snapshot-true; do
 done
 
 cargo run generate
-go run ./tools/linkify-metadata.go
+# TODO: re-enable when figure out how to make it play nicely with Windows.
+#go run ./tools/linkify-metadata.go


### PR DESCRIPTION
This patch adds a step to the interop_test that makes sure we can read in the generated metadata. At some point, the interop test will do the work of comparing the metadata exactly so that we can catch changes to the way we generate metadata.

Bugs found and fixed:
- copy repos function should use output() not spawn() to make sure the call completes
- need to explicitly set the metadata versions for each step
- when rotating the root key, both the old and new roots need to sign the metadata

Tested: fuchsia_rust_tuf_identity_consistent_snapshot_false passes

The regenerated metadata is a separate patch to make review easier. 