### PR TITLE
enable rust_tuf_consistent_snapshot_true test

### DIFF
--- a/tests/interop/main.rs
+++ b/tests/interop/main.rs
@@ -99,7 +99,6 @@ fn rust_tuf_identity_consistent_snapshot_false() {
 }
 
 #[test]
-#[ignore] // FIXME: Blocked on #225
 fn rust_tuf_identity_consistent_snapshot_true() {
     test_key_rotation(
         Path::new("tests")


### PR DESCRIPTION
#225 has landed, so this is good to go. 

tested: test passes