### PR TITLE
Fix directory existence check

### DIFF
--- a/tests/metadata/regenerate-metadata.sh
+++ b/tests/metadata/regenerate-metadata.sh
@@ -5,7 +5,7 @@ set -eu
 cd `dirname $0`
 
 for d in consistent-snapshot-false consistent-snapshot-true; do
-	if [[ -e $d ]]; then
+	if [ -e $d ]; then
 		rm -r $d
 	fi
 done


### PR DESCRIPTION
The _if [[ ... ]]_ construct is a bash-ism and fails to work if /bin/sh does not point to bash. An alternative fix is to use /bin/bash as shebang instead of /bin/sh. Feel free to edit as you prefer.