### PR TITLE
Update docs for keys generation.

### DIFF
--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -407,9 +407,6 @@ impl PrivateKey {
     ///
     /// # Generating Keys
     ///
-    /// If you use `cargo install tuf`, you will have access to the TUF CLI tool that will allow
-    /// you to generate keys. If you do not want to do this, the following can be used instead.
-    ///
     /// ## Ed25519
     ///
     /// ```bash


### PR DESCRIPTION
'cargo install tuf' does not work (probably outdated).

Running 'cargo run tuf' instead triggers tests/metadata/generate.rs
which panics for not being able to load keys. Again, misleading at best.