### PR TITLE
hex encode public key in Debug impl

### DIFF
--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -848,7 +848,7 @@ struct PublicKeyValue(Vec<u8>);
 impl Debug for PublicKeyValue {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_tuple("PublicKeyValue")
-            .field(&BASE64URL.encode(&self.0))
+            .field(&HEXLOWER.encode(&self.0))
             .finish()
     }
 }


### PR DESCRIPTION
TUF-1.0 encodes public keys in hex, so outputting keys in hex makes it easier to debug issues.