### PR TITLE
Disable cargo-audit on pull requests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -40,11 +40,6 @@ jobs:
         with:
           command: test
 
-      - name: Audit for Security Vulnerabilities
-        uses: actions-rs/audit-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Generate Docs
         uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
This check is failing on https://github.com/heartsucker/rust-tuf/pull/259 , and I don't think that's the right place to be surfacing this warning. It also looks like it automatically cancels all the other workflows when this happens, which is unhelpful.

It's mildly useful info to know that spin's maintainer is gone, but completely un-actionable while writing or reviewing pull requests on rust-tuf.