### PR TITLE
Fixup io::Error not_found conversion

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -86,7 +86,10 @@ impl Error {
 
 impl From<io::Error> for Error {
     fn from(err: io::Error) -> Error {
-        Error::Opaque(format!("IO: {:?}", err))
+        match err.kind() {
+            std::io::ErrorKind::NotFound => Error::NotFound,
+            _ => Error::Opaque(format!("IO: {:?}", err)),
+        }
     }
 }
 

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -839,6 +839,7 @@ where
 mod test {
     use super::*;
     use crate::interchange::Json;
+    use crate::metadata::{Role, RootMetadata};
     use futures_executor::block_on;
     use tempfile;
 
@@ -1004,6 +1005,30 @@ mod test {
             repo.store_target(bad_data, &path).await.unwrap();
             let mut read = repo.fetch_target(&path, &target_description).await.unwrap();
             assert!(read.read_to_end(&mut buf).await.is_err());
+        })
+    }
+
+    #[test]
+    fn file_system_repo_metadata_not_found_error() {
+        block_on(async {
+            let temp_dir = tempfile::Builder::new()
+                .prefix("rust-tuf")
+                .tempdir()
+                .unwrap();
+            let repo = FileSystemRepositoryBuilder::new(temp_dir.path())
+                .build::<Json>()
+                .unwrap();
+
+            assert_eq!(
+                repo.fetch_metadata::<RootMetadata>(
+                    &MetadataPath::from_role(&Role::Root),
+                    &MetadataVersion::None,
+                    None,
+                    None
+                )
+                .await,
+                Err(Error::NotFound)
+            );
         })
     }
 


### PR DESCRIPTION
When a Client is configured with a local FileSystemRepository, it is
expected that it does not contain metadata until it is fetched from a
remote repository. The client initializer will first check the local
repository for root.json metadata before checking with the remote
repository, but it will only try the remote repository if the local
fetch_metadata fails with Error::NotFound and the current implementation
of FileSystemRepository produces an Error::Opaque when the requested
metadata does not exist.

This change maps io errors with kind() == io::ErrorKind::NotFound to
Error::NotFound. and adds a test for a blank FileSystemRepository to
show it produces the expected error.