### PR TITLE
Verify top-level delegated targets signatures

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -782,7 +782,7 @@ where
         current_depth: u32,
         target: &'a VirtualTargetPath,
         snapshot: &'a SnapshotMetadata,
-        targets: Option<&'a TargetsMetadata>,
+        targets: Option<(&'a TargetsMetadata, MetadataPath)>,
     ) -> (bool, Result<TargetDescription>) {
         if current_depth > self.config.max_delegation_depth {
             warn!(
@@ -794,10 +794,10 @@ where
 
         // these clones are dumb, but we need immutable values and not references for update
         // tuf in the loop below
-        let targets = match targets {
-            Some(t) => t.clone(),
+        let (targets, targets_role) = match targets {
+            Some((t, role)) => (t.clone(), role),
             None => match self.tuf.targets() {
-                Some(t) => t.clone(),
+                Some(t) => (t.clone(), MetadataPath::from_role(&Role::Targets)),
                 None => {
                     return (
                         default_terminate,
@@ -881,7 +881,7 @@ where
 
             match self
                 .tuf
-                .update_delegation(delegation.role(), signed_meta.clone())
+                .update_delegation(&targets_role, delegation.role(), signed_meta.clone())
             {
                 Ok(_) => {
                     match self
@@ -909,7 +909,7 @@ where
                             current_depth + 1,
                             target,
                             snapshot,
-                            Some(meta.as_ref()),
+                            Some((meta.as_ref(), delegation.role().clone())),
                         ));
                     let (term, res) = f.await;
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,11 +1,13 @@
 use maplit::hashmap;
+use matches::assert_matches;
 use std::iter::once;
 use tuf::crypto::{HashAlgorithm, PrivateKey, SignatureScheme};
 use tuf::interchange::Json;
 use tuf::metadata::{
-    Delegation, Delegations, MetadataDescription, MetadataPath, RootMetadataBuilder,
+    Delegation, Delegations, MetadataDescription, MetadataPath, Role, RootMetadataBuilder,
     SnapshotMetadataBuilder, TargetsMetadataBuilder, TimestampMetadataBuilder, VirtualTargetPath,
 };
+use tuf::Error;
 use tuf::Tuf;
 
 const ED25519_1_PK8: &'static [u8] = include_bytes!("./ed25519/ed25519-1.pk8.der");
@@ -96,8 +98,12 @@ fn simple_delegation() {
         .signed::<Json>(&delegation_key)
         .unwrap();
 
-    tuf.update_delegation(&MetadataPath::new("delegation").unwrap(), delegation)
-        .unwrap();
+    tuf.update_delegation(
+        &MetadataPath::from_role(&Role::Targets),
+        &MetadataPath::new("delegation").unwrap(),
+        delegation,
+    )
+    .unwrap();
 
     assert!(tuf
         .target_description(&VirtualTargetPath::new("foo".into()).unwrap())
@@ -201,8 +207,12 @@ fn nested_delegation() {
         .signed::<Json>(&delegation_a_key)
         .unwrap();
 
-    tuf.update_delegation(&MetadataPath::new("delegation-a").unwrap(), delegation)
-        .unwrap();
+    tuf.update_delegation(
+        &MetadataPath::from_role(&Role::Targets),
+        &MetadataPath::new("delegation-a").unwrap(),
+        delegation,
+    )
+    .unwrap();
 
     //// build delegation B ////
 
@@ -218,10 +228,329 @@ fn nested_delegation() {
         .signed::<Json>(&delegation_b_key)
         .unwrap();
 
-    tuf.update_delegation(&MetadataPath::new("delegation-b").unwrap(), delegation)
-        .unwrap();
+    tuf.update_delegation(
+        &MetadataPath::new("delegation-a").unwrap(),
+        &MetadataPath::new("delegation-b").unwrap(),
+        delegation,
+    )
+    .unwrap();
 
     assert!(tuf
         .target_description(&VirtualTargetPath::new("foo".into()).unwrap())
         .is_ok());
+}
+
+#[test]
+fn rejects_bad_delegation_signatures() {
+    let root_key = PrivateKey::from_pkcs8(ED25519_1_PK8, SignatureScheme::Ed25519).unwrap();
+    let snapshot_key = PrivateKey::from_pkcs8(ED25519_2_PK8, SignatureScheme::Ed25519).unwrap();
+    let targets_key = PrivateKey::from_pkcs8(ED25519_3_PK8, SignatureScheme::Ed25519).unwrap();
+    let timestamp_key = PrivateKey::from_pkcs8(ED25519_4_PK8, SignatureScheme::Ed25519).unwrap();
+    let delegation_key = PrivateKey::from_pkcs8(ED25519_5_PK8, SignatureScheme::Ed25519).unwrap();
+    let bad_delegation_key =
+        PrivateKey::from_pkcs8(ED25519_6_PK8, SignatureScheme::Ed25519).unwrap();
+
+    //// build the root ////
+
+    let root = RootMetadataBuilder::new()
+        .root_key(root_key.public().clone())
+        .snapshot_key(snapshot_key.public().clone())
+        .targets_key(targets_key.public().clone())
+        .timestamp_key(timestamp_key.public().clone())
+        .signed::<Json>(&root_key)
+        .unwrap();
+
+    let mut tuf =
+        Tuf::<Json>::from_root_with_trusted_keys(root, 1, once(root_key.public())).unwrap();
+
+    //// build the snapshot and timestamp ////
+
+    let snapshot = SnapshotMetadataBuilder::new()
+        .insert_metadata_description(
+            MetadataPath::new("targets").unwrap(),
+            MetadataDescription::from_reader(&*vec![0u8], 1, &[HashAlgorithm::Sha256]).unwrap(),
+        )
+        .insert_metadata_description(
+            MetadataPath::new("delegation").unwrap(),
+            MetadataDescription::from_reader(&*vec![0u8], 1, &[HashAlgorithm::Sha256]).unwrap(),
+        )
+        .signed::<Json>(&snapshot_key)
+        .unwrap();
+
+    let timestamp = TimestampMetadataBuilder::from_snapshot(&snapshot, &[HashAlgorithm::Sha256])
+        .unwrap()
+        .signed::<Json>(&timestamp_key)
+        .unwrap();
+
+    tuf.update_timestamp(timestamp).unwrap();
+    tuf.update_snapshot(snapshot).unwrap();
+
+    //// build the targets ////
+    let delegations = Delegations::new(
+        hashmap! { delegation_key.public().key_id().clone() => delegation_key.public().clone() },
+        vec![Delegation::new(
+            MetadataPath::new("delegation").unwrap(),
+            false,
+            1,
+            vec![delegation_key.key_id().clone()]
+                .iter()
+                .cloned()
+                .collect(),
+            vec![VirtualTargetPath::new("foo".into()).unwrap()]
+                .iter()
+                .cloned()
+                .collect(),
+        )
+        .unwrap()],
+    )
+    .unwrap();
+    let targets = TargetsMetadataBuilder::new()
+        .delegations(delegations)
+        .signed::<Json>(&targets_key)
+        .unwrap();
+
+    tuf.update_targets(targets).unwrap();
+
+    //// build the delegation ////
+    let target_file: &[u8] = b"bar";
+    let delegation = TargetsMetadataBuilder::new()
+        .insert_target_from_reader(
+            VirtualTargetPath::new("foo".into()).unwrap(),
+            target_file,
+            &[HashAlgorithm::Sha256],
+        )
+        .unwrap()
+        .signed::<Json>(&bad_delegation_key)
+        .unwrap();
+
+    assert_matches!(
+        tuf.update_delegation(
+            &MetadataPath::from_role(&Role::Targets),
+            &MetadataPath::new("delegation").unwrap(),
+            delegation
+        ),
+        Err(Error::VerificationFailure(_))
+    );
+
+    assert_eq!(
+        tuf.target_description(&VirtualTargetPath::new("foo".into()).unwrap()),
+        Err(Error::TargetUnavailable)
+    );
+}
+
+#[test]
+fn diamond_delegation() {
+    let etc_key = PrivateKey::from_pkcs8(ED25519_1_PK8, SignatureScheme::Ed25519).unwrap();
+    let targets_key = PrivateKey::from_pkcs8(ED25519_2_PK8, SignatureScheme::Ed25519).unwrap();
+    let delegation_a_key = PrivateKey::from_pkcs8(ED25519_3_PK8, SignatureScheme::Ed25519).unwrap();
+    let delegation_b_key = PrivateKey::from_pkcs8(ED25519_4_PK8, SignatureScheme::Ed25519).unwrap();
+    let delegation_c_key = PrivateKey::from_pkcs8(ED25519_5_PK8, SignatureScheme::Ed25519).unwrap();
+
+    // Given delegations a, b, and c, targets delegates "foo" to delegation-a and "bar" to
+    // delegation-b.
+    //
+    //             targets
+    //              /  \
+    //   delegation-a  delegation-b
+    //              \  /
+    //          delegation-c
+    //
+    // if delegation-a delegates "foo" to delegation-c, and
+    //    delegation-b delegates "bar" to delegation-c, but
+    //    delegation-b's signature is invalid, then delegation-c
+    // can contain target "bar" which is unaccessible and target "foo" which is.
+    //
+    // Verify tuf::Tuf handles this situation correctly.
+
+    //// build the root ////
+
+    let root = RootMetadataBuilder::new()
+        .root_key(etc_key.public().clone())
+        .snapshot_key(etc_key.public().clone())
+        .targets_key(targets_key.public().clone())
+        .timestamp_key(etc_key.public().clone())
+        .signed::<Json>(&etc_key)
+        .unwrap();
+
+    let mut tuf =
+        Tuf::<Json>::from_root_with_trusted_keys(root, 1, once(etc_key.public())).unwrap();
+
+    //// build the snapshot and timestamp ////
+
+    let snapshot = SnapshotMetadataBuilder::new()
+        .insert_metadata_description(
+            MetadataPath::new("targets").unwrap(),
+            MetadataDescription::from_reader(&*vec![0u8], 1, &[HashAlgorithm::Sha256]).unwrap(),
+        )
+        .insert_metadata_description(
+            MetadataPath::new("delegation-a").unwrap(),
+            MetadataDescription::from_reader(&*vec![0u8], 1, &[HashAlgorithm::Sha256]).unwrap(),
+        )
+        .insert_metadata_description(
+            MetadataPath::new("delegation-b").unwrap(),
+            MetadataDescription::from_reader(&*vec![0u8], 1, &[HashAlgorithm::Sha256]).unwrap(),
+        )
+        .insert_metadata_description(
+            MetadataPath::new("delegation-c").unwrap(),
+            MetadataDescription::from_reader(&*vec![0u8], 1, &[HashAlgorithm::Sha256]).unwrap(),
+        )
+        .signed::<Json>(&etc_key)
+        .unwrap();
+
+    let timestamp = TimestampMetadataBuilder::from_snapshot(&snapshot, &[HashAlgorithm::Sha256])
+        .unwrap()
+        .signed::<Json>(&etc_key)
+        .unwrap();
+
+    tuf.update_timestamp(timestamp).unwrap();
+    tuf.update_snapshot(snapshot).unwrap();
+
+    //// build the targets ////
+
+    let delegations = Delegations::new(
+        hashmap! {
+            delegation_a_key.public().key_id().clone() => delegation_a_key.public().clone(),
+            delegation_b_key.public().key_id().clone() => delegation_b_key.public().clone(),
+        },
+        vec![
+            Delegation::new(
+                MetadataPath::new("delegation-a").unwrap(),
+                false,
+                1,
+                vec![delegation_a_key.key_id().clone()]
+                    .iter()
+                    .cloned()
+                    .collect(),
+                vec![VirtualTargetPath::new("foo".into()).unwrap()]
+                    .iter()
+                    .cloned()
+                    .collect(),
+            )
+            .unwrap(),
+            Delegation::new(
+                MetadataPath::new("delegation-b").unwrap(),
+                false,
+                1,
+                vec![delegation_b_key.key_id().clone()]
+                    .iter()
+                    .cloned()
+                    .collect(),
+                vec![VirtualTargetPath::new("bar".into()).unwrap()]
+                    .iter()
+                    .cloned()
+                    .collect(),
+            )
+            .unwrap(),
+        ],
+    )
+    .unwrap();
+    let targets = TargetsMetadataBuilder::new()
+        .delegations(delegations)
+        .signed::<Json>(&targets_key)
+        .unwrap();
+
+    tuf.update_targets(targets).unwrap();
+
+    //// build delegation A ////
+
+    let delegations = Delegations::new(
+        hashmap! { delegation_c_key.public().key_id().clone() => delegation_c_key.public().clone() },
+        vec![Delegation::new(
+            MetadataPath::new("delegation-c").unwrap(),
+            false,
+            1,
+            vec![delegation_c_key.key_id().clone()].iter().cloned().collect(),
+            vec![VirtualTargetPath::new("foo".into()).unwrap()].iter().cloned().collect(),
+        )
+        .unwrap()],
+    )
+    .unwrap();
+
+    let delegation = TargetsMetadataBuilder::new()
+        .delegations(delegations)
+        .signed::<Json>(&delegation_a_key)
+        .unwrap();
+
+    tuf.update_delegation(
+        &MetadataPath::from_role(&Role::Targets),
+        &MetadataPath::new("delegation-a").unwrap(),
+        delegation,
+    )
+    .unwrap();
+
+    //// build delegation B ////
+
+    let delegations = Delegations::new(
+        hashmap! { delegation_c_key.public().key_id().clone() => delegation_c_key.public().clone() },
+        vec![Delegation::new(
+            MetadataPath::new("delegation-c").unwrap(),
+            false,
+            1,
+            // oops, wrong key.
+            vec![delegation_b_key.key_id().clone()].iter().cloned().collect(),
+            vec![VirtualTargetPath::new("bar".into()).unwrap()].iter().cloned().collect(),
+        )
+        .unwrap()],
+    )
+    .unwrap();
+
+    let delegation = TargetsMetadataBuilder::new()
+        .delegations(delegations)
+        .signed::<Json>(&delegation_b_key)
+        .unwrap();
+
+    tuf.update_delegation(
+        &MetadataPath::from_role(&Role::Targets),
+        &MetadataPath::new("delegation-b").unwrap(),
+        delegation,
+    )
+    .unwrap();
+
+    //// build delegation C ////
+
+    let foo_target_file: &[u8] = b"foo contents";
+    let bar_target_file: &[u8] = b"bar contents";
+
+    let delegation = TargetsMetadataBuilder::new()
+        .insert_target_from_reader(
+            VirtualTargetPath::new("foo".into()).unwrap(),
+            foo_target_file,
+            &[HashAlgorithm::Sha256],
+        )
+        .unwrap()
+        .insert_target_from_reader(
+            VirtualTargetPath::new("bar".into()).unwrap(),
+            bar_target_file,
+            &[HashAlgorithm::Sha256],
+        )
+        .unwrap()
+        .signed::<Json>(&delegation_c_key)
+        .unwrap();
+
+    //// Verify delegation-c is valid, but only when updated through delegation-a.
+
+    tuf.update_delegation(
+        &MetadataPath::new("delegation-a").unwrap(),
+        &MetadataPath::new("delegation-c").unwrap(),
+        delegation.clone(),
+    )
+    .unwrap();
+
+    assert_matches!(
+        tuf.update_delegation(
+            &MetadataPath::new("delegation-b").unwrap(),
+            &MetadataPath::new("delegation-c").unwrap(),
+            delegation
+        ),
+        Err(Error::VerificationFailure(_))
+    );
+
+    assert!(tuf
+        .target_description(&VirtualTargetPath::new("foo".into()).unwrap())
+        .is_ok());
+
+    assert_matches!(
+        tuf.target_description(&VirtualTargetPath::new("bar".into()).unwrap()),
+        Err(Error::TargetUnavailable)
+    );
 }


### PR DESCRIPTION
The previous implementation did not consider delegated roles from the
top-level "targets" role when looking for keys to verify the delegated
targets with, which would result in delegated targets being accepted by
Tuf without signature verification.