### PR TITLE
Split SafeReader into separate types

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -727,6 +727,10 @@ where
     }
 
     /// Fetch a target from the remote repo and write it to the provided writer.
+    ///
+    /// It is **critical** that none of the bytes written to the `write` are used until this future
+    /// returns `Ok`, as the hash of the target is not verified until all bytes are read from the
+    /// repository.
     pub async fn fetch_target_to_writer<'a, W>(
         &'a mut self,
         target: &'a TargetPath,

--- a/src/repository/ephemeral.rs
+++ b/src/repository/ephemeral.rs
@@ -15,7 +15,7 @@ use crate::metadata::{
     Metadata, MetadataPath, MetadataVersion, SignedMetadata, TargetDescription, TargetPath,
 };
 use crate::repository::Repository;
-use crate::util::SafeReader;
+use crate::util::SafeAsyncRead;
 use crate::Result;
 
 type ArcHashMap<K, V> = Arc<RwLock<HashMap<K, V>>>;
@@ -26,8 +26,8 @@ pub struct EphemeralRepository<D>
 where
     D: DataInterchange,
 {
-    metadata: ArcHashMap<(MetadataPath, MetadataVersion), Vec<u8>>,
-    targets: ArcHashMap<TargetPath, Arc<Vec<u8>>>,
+    metadata: ArcHashMap<(MetadataPath, MetadataVersion), Arc<[u8]>>,
+    targets: ArcHashMap<TargetPath, Arc<[u8]>>,
     interchange: PhantomData<D>,
 }
 
@@ -73,7 +73,7 @@ where
             D::to_writer(&mut buf, metadata)?;
             self.metadata
                 .write()
-                .insert((meta_path.clone(), version.clone()), buf);
+                .insert((meta_path.clone(), version.clone()), Arc::from(buf));
             Ok(())
         }
         .boxed()
@@ -97,18 +97,14 @@ where
                 .read()
                 .get(&(meta_path.clone(), version.clone()))
             {
-                Some(bytes) => bytes.clone(),
+                Some(bytes) => Arc::clone(&bytes),
                 None => {
                     return Err(Error::NotFound);
                 }
             };
 
-            let mut reader = SafeReader::new(
-                &*bytes,
-                max_length.unwrap_or(::std::usize::MAX) as u64,
-                0,
-                hash_data,
-            )?;
+            let mut reader = Cursor::new(bytes)
+                .check_length_and_hash(max_length.unwrap_or(::std::usize::MAX) as u64, hash_data)?;
 
             let mut buf = Vec::with_capacity(max_length.unwrap_or(0));
             reader.read_to_end(&mut buf).await?;
@@ -131,7 +127,7 @@ where
             read.read_to_end(&mut buf).await?;
             self.targets
                 .write()
-                .insert(target_path.clone(), Arc::new(buf));
+                .insert(target_path.clone(), Arc::from(buf));
             Ok(())
         }
         .boxed()
@@ -142,17 +138,9 @@ where
         target_path: &'a TargetPath,
         target_description: &'a TargetDescription,
     ) -> BoxFuture<'a, Result<Box<dyn AsyncRead + Send + Unpin>>> {
-        // Helper wrapper in order to get Arc<Vec<u8>> to be compatible with Cursor.
-        struct Wrapper(Arc<Vec<u8>>);
-        impl AsRef<[u8]> for Wrapper {
-            fn as_ref(&self) -> &[u8] {
-                &**self.0
-            }
-        }
-
         async move {
             let bytes = match self.targets.read().get(target_path) {
-                Some(bytes) => bytes.clone(),
+                Some(bytes) => Arc::clone(&bytes),
                 None => {
                     return Err(Error::NotFound);
                 }
@@ -160,13 +148,11 @@ where
 
             let (alg, value) = crypto::hash_preference(target_description.hashes())?;
 
-            let reader: Box<dyn AsyncRead + Send + Unpin> = Box::new(SafeReader::new(
-                Cursor::new(Wrapper(bytes)),
-                target_description.length(),
-                0,
-                Some((alg, value.clone())),
-            )?);
-
+            let reader: Box<dyn AsyncRead + Send + Unpin> =
+                Box::new(Cursor::new(bytes).check_length_and_hash(
+                    target_description.length(),
+                    Some((alg, value.clone())),
+                )?);
             Ok(reader)
         }
         .boxed()

--- a/src/repository/file_system.rs
+++ b/src/repository/file_system.rs
@@ -16,7 +16,7 @@ use crate::metadata::{
     Metadata, MetadataPath, MetadataVersion, SignedMetadata, TargetDescription, TargetPath,
 };
 use crate::repository::Repository;
-use crate::util::SafeReader;
+use crate::util::SafeAsyncRead;
 use crate::Result;
 
 /// A builder to create a repository contained on the local file system.
@@ -155,12 +155,8 @@ where
             let mut path = self.metadata_path.clone();
             path.extend(meta_path.components::<D>(&version));
 
-            let mut reader = SafeReader::new(
-                AllowStdIo::new(File::open(&path)?),
-                max_length.unwrap_or(::std::usize::MAX) as u64,
-                0,
-                hash_data,
-            )?;
+            let mut reader = AllowStdIo::new(File::open(&path)?)
+                .check_length_and_hash(max_length.unwrap_or(::std::usize::MAX) as u64, hash_data)?;
 
             let mut buf = Vec::with_capacity(max_length.unwrap_or(0));
             reader.read_to_end(&mut buf).await?;
@@ -210,12 +206,11 @@ where
 
             let (alg, value) = crypto::hash_preference(target_description.hashes())?;
 
-            let reader: Box<dyn AsyncRead + Send + Unpin> = Box::new(SafeReader::new(
-                AllowStdIo::new(File::open(&path)?),
-                target_description.length(),
-                0,
-                Some((alg, value.clone())),
-            )?);
+            let reader: Box<dyn AsyncRead + Send + Unpin> =
+                Box::new(AllowStdIo::new(File::open(&path)?).check_length_and_hash(
+                    target_description.length(),
+                    Some((alg, value.clone())),
+                )?);
 
             Ok(reader)
         }


### PR DESCRIPTION
Since the Repository traits can be implemented outside this crate, it is
not safe to assume that those implementations will verify the maximum
length or hash of metadata/targets before succeeding a fetch request.

In preparation to move the length check and hash verification into the
tuf client, this change splits the SafeReader into 2 types:
 * EnforceMinimumBitrate enforces a minimum transfer rate, currently
   utilized by only the http repository implementation
 * SafeReader, which retains the logic to enforce a maximum file size
   and hash value.
This change also defines an extension trait on AsyncRead to easily wrap
an AsyncRead in these types.

A future change will move hash and length enforcement out of the
Repository implementations.