### PR TITLE
Derive Error implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ serde_json = "1"
 tempfile = "3"
 untrusted = "0.7"
 url = "2"
+thiserror = "1.0"
 
 [dev-dependencies]
 lazy_static = "1"


### PR DESCRIPTION
Replace the manual implementation of std::error::Error for Error with the thiserror::Error derive macro. Other than the error strings containing more information and thiserror::Error implementing std::error::Error::description() with a static string indicating the method is deprecated, no observable changes expected.

Related to #136