### PR TITLE
Remove unused signatures from tuf::Tuf

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -927,7 +927,7 @@ where
                             current_depth + 1,
                             target,
                             snapshot,
-                            Some((meta.as_ref(), delegation.role().clone())),
+                            Some((&meta, delegation.role().clone())),
                         ));
                     let (term, res) = f.await;
 

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -399,6 +399,11 @@ where
         Ok(())
     }
 
+    /// Unwraps the inner metadata, discarding the signatures.
+    pub fn into_inner(self) -> M {
+        self.metadata
+    }
+
     /// An immutable reference to the signatures.
     pub fn signatures(&self) -> &[Signature] {
         &self.signatures


### PR DESCRIPTION
Before SignedMetadata can store the D::RawData of inner metadata to verify signatures that contains unknown fields, tuf::Tuf needs to store the metadata in a form it will be able to use.  Once it verifies the signatures of the metadata, it can fully parse it and store just the parsed inner metadata.