### PR TITLE
Signature preserves unknown fields

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -559,10 +559,7 @@ where
         // Root metadata is signed by its own keys, but we should only trust it if it is also
         // signed by the previous root metadata, which we can't check without knowing what version
         // this root metadata claims to be.
-        let latest_version = {
-            let untrusted_latest_info = latest_root.untrusted_info()?;
-            untrusted_latest_info.version()
-        };
+        let latest_version = latest_root.parse_version_untrusted()?;
 
         if latest_version < self.tuf.root().version() {
             return Err(Error::VerificationFailure(format!(

--- a/src/client.rs
+++ b/src/client.rs
@@ -10,8 +10,7 @@
 //! # use tuf::{Result, Tuf};
 //! # use tuf::crypto::KeyId;
 //! # use tuf::client::{Client, Config};
-//! # use tuf::metadata::{RootMetadata, SignedMetadata, Role, MetadataPath,
-//! #     MetadataVersion};
+//! # use tuf::metadata::{RootMetadata, Role, MetadataPath, MetadataVersion};
 //! # use tuf::interchange::Json;
 //! # use tuf::repository::{FileSystemRepository, HttpRepositoryBuilder};
 //!
@@ -271,7 +270,7 @@ where
         remote: R,
     ) -> Result<Self> {
         let (local, remote) = (Repository::new(local), Repository::new(remote));
-        let tuf = Tuf::from_trusted_root(trusted_root.clone())?;
+        let tuf = Tuf::from_trusted_root(trusted_root)?;
 
         Ok(Client {
             tuf,
@@ -367,23 +366,19 @@ where
         )
         .await?;
 
-        // FIXME(#253) verify the trusted root version matches the provided version.
-        let root_version = MetadataVersion::Number(trusted_root.version());
-
         let tuf = {
-            let root: &RootMetadata = trusted_root.as_ref();
-
-            // Extract out the keys that correspond by the provided key ids.
+            // Extract the necessary information from the not-yet-verified root metadata to verify
+            // it is signed by the trusted root key_ids.
+            let root: RootMetadata = trusted_root.assume_valid()?;
             let trusted_root_keys = trusted_root_key_ids
                 .into_iter()
                 .filter_map(|key_id| root.keys().get(key_id));
 
-            Tuf::from_root_with_trusted_keys(
-                trusted_root.clone(),
-                root_threshold,
-                trusted_root_keys,
-            )?
+            Tuf::from_root_with_trusted_keys(trusted_root, root_threshold, trusted_root_keys)?
         };
+
+        // FIXME(#253) verify the trusted root version matches the provided version.
+        let root_version = MetadataVersion::Number(tuf.root().version());
 
         let mut client = Client {
             tuf,
@@ -488,10 +483,10 @@ where
         )
         .await?;
 
-        // FIXME(#253) verify the trusted root version matches the provided version.
-        let root_version = MetadataVersion::Number(root.version());
-
         let tuf = Tuf::from_root_with_trusted_keys(root, root_threshold, trusted_root_keys)?;
+
+        // FIXME(#253) verify the trusted root version matches the provided version.
+        let root_version = MetadataVersion::Number(tuf.root().version());
 
         let mut client = Client {
             tuf,
@@ -560,7 +555,14 @@ where
                 None,
             )
             .await?;
-        let latest_version = latest_root.version();
+
+        // Root metadata is signed by its own keys, but we should only trust it if it is also
+        // signed by the previous root metadata, which we can't check without knowing what version
+        // this root metadata claims to be.
+        let latest_version = {
+            let untrusted_latest_info = latest_root.untrusted_info()?;
+            untrusted_latest_info.version()
+        };
 
         if latest_version < self.tuf.root().version() {
             return Err(Error::VerificationFailure(format!(
@@ -625,10 +627,9 @@ where
                 None,
             )
             .await?;
-        let latest_version = signed_timestamp.version();
-        let latest_version = MetadataVersion::Number(latest_version);
 
-        if self.tuf.update_timestamp(signed_timestamp)? {
+        if let Some(updated_timestamp) = self.tuf.update_timestamp(signed_timestamp)? {
+            let latest_version = MetadataVersion::Number(updated_timestamp.version());
             self.store_metadata(&timestamp_path, &latest_version, &raw_signed_timestamp)
                 .await;
 

--- a/tests/interop/main.rs
+++ b/tests/interop/main.rs
@@ -216,9 +216,11 @@ async fn extract_keys(dir: &Path) -> Vec<KeyId> {
     reader.read_to_end(&mut buf).await.unwrap();
     let metadata = RawSignedMetadata::<Json, RootMetadata>::new(buf)
         .parse()
+        .unwrap()
+        .assume_valid()
         .unwrap();
 
-    metadata.as_ref().root().key_ids().iter().cloned().collect()
+    metadata.root().key_ids().iter().cloned().collect()
 }
 
 fn init_remote(dir: &Path) -> Result<FileSystemRepository<Json>> {

--- a/tests/metadata/generate.rs
+++ b/tests/metadata/generate.rs
@@ -159,12 +159,12 @@ async fn add_target(
     let step_str = format!("{}", step);
     let target_data = step_str.as_bytes();
 
-    let targets = targets_builder
+    let signed_targets = targets_builder
         .signed::<JsonPretty>(&keys.get("targets").unwrap())
         .unwrap();
+    let targets = signed_targets.assume_valid().unwrap();
 
     let hash = targets
-        .as_ref()
         .targets()
         .get(&VirtualTargetPath::new(step.to_string().into()).unwrap())
         .unwrap()
@@ -189,7 +189,7 @@ async fn add_target(
     repo.store_metadata(
         &targets_path,
         &version_prefix,
-        targets.to_raw().unwrap().as_bytes(),
+        signed_targets.to_raw().unwrap().as_bytes(),
     )
     .await
     .unwrap();
@@ -198,7 +198,7 @@ async fn add_target(
     let snapshot = SnapshotMetadataBuilder::new()
         .expires(expiration)
         .version(version)
-        .insert_metadata(&targets, &[HashAlgorithm::Sha256])
+        .insert_metadata(&signed_targets, &[HashAlgorithm::Sha256])
         .unwrap()
         .signed::<JsonPretty>(&keys.get("snapshot").unwrap())
         .unwrap();


### PR DESCRIPTION
Per the TUF spec, all metadata formats "include the ability to add more attribute-value fields for backwards-compatible format changes." So, if the signed portion of some metadata contains unexpected fields, those fields should not be ignored until after verifying the signature of the metdata.

These changes:
 * replace the parsed metadata in the SignedMetadata struct with a D::RawData, which will preserve unknown fields.
 * changes the verify method on SignedMetadata to produce the fully parsed metadata without any attached signatures, as those are no longer able to verify the parsed metadata.
 * verify that signatures of metadata containing unknown fields verify correctly.

Fixed: #223