### PR TITLE
Add RepoBuilder metadata generator, and tests

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -839,7 +839,8 @@ where
                         ));
 
                     match f.await {
-                        (term, res @ Ok(_)) => return (term, res),
+                        // exit early if we found our target.
+                        (_, res @ Ok(_)) => return (true, res),
                         (true, res @ Err(_)) => return (true, res),
                         (false, Err(Error::NotFound)) => {
                             // Don't log that we couldn't find the target.
@@ -1158,10 +1159,10 @@ mod test {
 
             //// First, create the root metadata version 1.
             let repo_keys1 = RepoKeys {
-                root_keys: vec![&KEYS[0]],
-                snapshot_keys: vec![&KEYS[0], &KEYS[1], &KEYS[2]],
-                targets_keys: vec![&KEYS[0], &KEYS[1], &KEYS[2]],
-                timestamp_keys: vec![&KEYS[0], &KEYS[1], &KEYS[2]],
+                root: vec![&KEYS[0]],
+                snapshot: vec![&KEYS[0], &KEYS[1], &KEYS[2]],
+                targets: vec![&KEYS[0], &KEYS[1], &KEYS[2]],
+                timestamp: vec![&KEYS[0], &KEYS[1], &KEYS[2]],
             };
             let root1 = RepoBuilder::new(repo_keys1, &repo)
                 .with_root(|b| b.version(1).expires(Utc.ymd(2038, 1, 1).and_hms(0, 0, 0)))
@@ -1205,10 +1206,10 @@ mod test {
 
             // Make sure the version 2 is signed by version 1's keys.
             let repo_keys2 = RepoKeys {
-                root_keys: vec![&KEYS[0], &KEYS[1]],
-                snapshot_keys: vec![&KEYS[0], &KEYS[1], &KEYS[2]],
-                targets_keys: vec![&KEYS[0], &KEYS[1], &KEYS[2]],
-                timestamp_keys: vec![&KEYS[0], &KEYS[1], &KEYS[2]],
+                root: vec![&KEYS[0], &KEYS[1]],
+                snapshot: vec![&KEYS[0], &KEYS[1], &KEYS[2]],
+                targets: vec![&KEYS[0], &KEYS[1], &KEYS[2]],
+                timestamp: vec![&KEYS[0], &KEYS[1], &KEYS[2]],
             };
             let _root2 = RepoBuilder::new(repo_keys2, &repo)
                 .with_root(|b| b.version(2).expires(Utc.ymd(2038, 1, 1).and_hms(0, 0, 0)))
@@ -1218,10 +1219,10 @@ mod test {
 
             // Make sure the version 3 is signed by version 2's keys.
             let repo_keys3 = RepoKeys {
-                root_keys: vec![&KEYS[0], &KEYS[1]],
-                snapshot_keys: vec![&KEYS[0], &KEYS[1], &KEYS[2]],
-                targets_keys: vec![&KEYS[0], &KEYS[1], &KEYS[2]],
-                timestamp_keys: vec![&KEYS[0], &KEYS[1], &KEYS[2]],
+                root: vec![&KEYS[1], &KEYS[2]],
+                snapshot: vec![&KEYS[0], &KEYS[1], &KEYS[2]],
+                targets: vec![&KEYS[0], &KEYS[1], &KEYS[2]],
+                timestamp: vec![&KEYS[0], &KEYS[1], &KEYS[2]],
             };
             let root3 = RepoBuilder::new(repo_keys3, &repo)
                 .with_root(|b| b.version(3).expires(Utc.ymd(2038, 1, 1).and_hms(0, 0, 0)))
@@ -1267,10 +1268,10 @@ mod test {
 
         //// First, create and register the root metadata.
         let repo_keys1 = RepoKeys {
-            root_keys: vec![&KEYS[0]],
-            snapshot_keys: vec![&KEYS[0], &KEYS[1]],
-            targets_keys: vec![&KEYS[0], &KEYS[1]],
-            timestamp_keys: vec![&KEYS[0], &KEYS[1]],
+            root: vec![&KEYS[0]],
+            snapshot: vec![&KEYS[0], &KEYS[1]],
+            targets: vec![&KEYS[0], &KEYS[1]],
+            timestamp: vec![&KEYS[0], &KEYS[1]],
         };
         let _root1 = RepoBuilder::new(repo_keys1, &repo)
             .with_root(|b| {
@@ -1285,10 +1286,10 @@ mod test {
         ////
         // Next, create and register version 2 of the root metadata.
         let repo_keys2 = RepoKeys {
-            root_keys: vec![&KEYS[0], &KEYS[1]],
-            snapshot_keys: vec![&KEYS[0], &KEYS[1]],
-            targets_keys: vec![&KEYS[0], &KEYS[1]],
-            timestamp_keys: vec![&KEYS[0], &KEYS[1]],
+            root: vec![&KEYS[0], &KEYS[1]],
+            snapshot: vec![&KEYS[0], &KEYS[1]],
+            targets: vec![&KEYS[0], &KEYS[1]],
+            timestamp: vec![&KEYS[0], &KEYS[1]],
         };
         let root2 = RepoBuilder::new(repo_keys2, &repo)
             .with_root(|b| b.version(2).expires(Utc.ymd(2038, 1, 1).and_hms(0, 0, 0)))
@@ -1411,10 +1412,10 @@ mod test {
     ) {
         // Generate an ephemeral repository with a single target.
         let repo_keys = RepoKeys {
-            root_keys: vec![&KEYS[0]],
-            snapshot_keys: vec![&KEYS[0]],
-            targets_keys: vec![&KEYS[0]],
-            timestamp_keys: vec![&KEYS[0]],
+            root: vec![&KEYS[0]],
+            snapshot: vec![&KEYS[0]],
+            targets: vec![&KEYS[0]],
+            timestamp: vec![&KEYS[0]],
         };
         let repo = EphemeralRepository::<Json>::new();
         let repo_builder = RepoBuilder::new(repo_keys, &repo);
@@ -1480,10 +1481,10 @@ mod test {
 
             // Generate an ephemeral repository with a single target.
             let repo_keys = RepoKeys {
-                root_keys: vec![&KEYS[0]],
-                snapshot_keys: vec![&KEYS[0]],
-                targets_keys: vec![&KEYS[0]],
-                timestamp_keys: vec![&KEYS[0]],
+                root: vec![&KEYS[0]],
+                snapshot: vec![&KEYS[0]],
+                targets: vec![&KEYS[0]],
+                timestamp: vec![&KEYS[0]],
             };
 
             let delegated_target = TargetsMetadataBuilder::new()
@@ -1571,10 +1572,10 @@ mod test {
             .unwrap();
 
             let repo_keys = RepoKeys {
-                root_keys: vec![&KEYS[0]],
-                snapshot_keys: vec![&KEYS[0]],
-                targets_keys: vec![&KEYS[0]],
-                timestamp_keys: vec![&KEYS[0]],
+                root: vec![&KEYS[0]],
+                snapshot: vec![&KEYS[0]],
+                targets: vec![&KEYS[0]],
+                timestamp: vec![&KEYS[0]],
             };
             let _ = RepoBuilder::new(repo_keys, &repo)
                 .delegations(delegations)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,6 +121,9 @@ pub mod tuf;
 mod format_hex;
 mod util;
 
+#[cfg(test)]
+mod repo_builder;
+
 pub use crate::error::*;
 pub use crate::tuf::*;
 

--- a/src/repo_builder.rs
+++ b/src/repo_builder.rs
@@ -1,0 +1,190 @@
+use crate::crypto::{HashAlgorithm, PrivateKey};
+use crate::interchange::DataInterchange;
+use crate::metadata::{
+    Metadata, MetadataPath, MetadataVersion, Role, RootMetadata, RootMetadataBuilder,
+    SignedMetadata, SnapshotMetadataBuilder, TargetDescription, TargetsMetadataBuilder,
+    TimestampMetadataBuilder, VirtualTargetPath,
+};
+use crate::repository::{Repository, RepositoryProvider, RepositoryStorage};
+use crate::Result;
+
+// This is a helper crate to keep track of the private keys necessary to create new metadata.
+//
+// FIXME: This is not ready yet for public use, it is only intended for internal testing until the
+// design is complete.
+pub(crate) struct RepoKeys<'a> {
+    pub(crate) root_keys: Vec<&'a PrivateKey>,
+    pub(crate) targets_keys: Vec<&'a PrivateKey>,
+    pub(crate) snapshot_keys: Vec<&'a PrivateKey>,
+    pub(crate) timestamp_keys: Vec<&'a PrivateKey>,
+}
+
+// This helper builder simplifies the process of creating new metadata.
+//
+// FIXME: This is not ready yet for public use, it is only intended for internal testing until the
+// design is complete.
+pub(crate) struct RepoBuilder<'a, R, D>
+where
+    R: RepositoryProvider<D> + RepositoryStorage<D>,
+    D: DataInterchange + Sync,
+{
+    repo_keys: RepoKeys<'a>,
+    repo: Repository<R, D>,
+    root_builder: RootMetadataBuilder,
+    targets_builder: TargetsMetadataBuilder,
+}
+
+impl<'a, R, D> RepoBuilder<'a, R, D>
+where
+    R: RepositoryProvider<D> + RepositoryStorage<D>,
+    D: DataInterchange + Sync,
+{
+    pub(crate) fn new(repo_keys: RepoKeys<'a>, repo: R) -> Self {
+        let repo = Repository::new(repo);
+
+        let mut root_builder = RootMetadataBuilder::new();
+
+        for key in &repo_keys.root_keys {
+            root_builder = root_builder.root_key(key.public().clone());
+        }
+
+        for key in &repo_keys.targets_keys {
+            root_builder = root_builder.targets_key(key.public().clone());
+        }
+
+        for key in &repo_keys.snapshot_keys {
+            root_builder = root_builder.snapshot_key(key.public().clone());
+        }
+
+        for key in &repo_keys.timestamp_keys {
+            root_builder = root_builder.timestamp_key(key.public().clone());
+        }
+
+        Self {
+            repo_keys,
+            repo,
+            root_builder,
+            targets_builder: TargetsMetadataBuilder::new(),
+        }
+    }
+
+    pub(crate) fn with_root<F>(mut self, f: F) -> Self
+    where
+        F: FnOnce(RootMetadataBuilder) -> RootMetadataBuilder,
+    {
+        self.root_builder = f(self.root_builder);
+        self
+    }
+
+    pub(crate) fn insert_target_description(
+        mut self,
+        path: VirtualTargetPath,
+        description: TargetDescription,
+    ) -> Self {
+        self.targets_builder = self
+            .targets_builder
+            .insert_target_description(path, description);
+        self
+    }
+
+    // Commit the metadata to the database.
+    //
+    // FIXME: this currently always generates the timestamp/snapshot/targets/delegation metadata,
+    // and will overwrite it if that version already exists.
+    pub(crate) async fn commit(mut self) -> Result<SignedMetadata<D, RootMetadata>> {
+        let root_path = MetadataPath::from_role(&Role::Root);
+        let targets_path = MetadataPath::from_role(&Role::Targets);
+        let snapshot_path = MetadataPath::from_role(&Role::Snapshot);
+        let timestamp_path = MetadataPath::from_role(&Role::Timestamp);
+
+        // Construct and sign the root metadata.
+        let root_metadata = self.root_builder.build()?;
+        let root = sign::<D, _>(&root_metadata, &self.repo_keys.root_keys)?;
+
+        // Sign the targets metadata.
+        let targets_metadata = self.targets_builder.build()?;
+        let targets = sign(&targets_metadata, &self.repo_keys.targets_keys)?;
+
+        // Construct and sign the snapshot metadata.
+        let snapshot_metadata = SnapshotMetadataBuilder::new()
+            .insert_metadata(&targets, &[HashAlgorithm::Sha256])?
+            .build()?;
+
+        let snapshot = sign(&snapshot_metadata, &self.repo_keys.snapshot_keys)?;
+
+        // Construct and sign the timestamp metadata.
+        let timestamp_metadata =
+            TimestampMetadataBuilder::from_snapshot(&snapshot, &[HashAlgorithm::Sha256])?
+                .build()?;
+        let timestamp = sign(&timestamp_metadata, &self.repo_keys.timestamp_keys)?;
+
+        // Commit the root metadata.
+        self.repo
+            .store_metadata(
+                &root_path,
+                &MetadataVersion::Number(root_metadata.version()),
+                &root.to_raw()?,
+            )
+            .await?;
+
+        self.repo
+            .store_metadata(&root_path, &MetadataVersion::None, &root.to_raw()?)
+            .await?;
+
+        // Commit the target metadata.
+        if root_metadata.consistent_snapshot() {
+            self.repo
+                .store_metadata(
+                    &targets_path,
+                    &MetadataVersion::Number(targets_metadata.version()),
+                    &targets.to_raw()?,
+                )
+                .await?;
+        }
+
+        self.repo
+            .store_metadata(&targets_path, &MetadataVersion::None, &targets.to_raw()?)
+            .await?;
+
+        // Commit the snapshot metadata.
+        if root_metadata.consistent_snapshot() {
+            self.repo
+                .store_metadata(
+                    &snapshot_path,
+                    &MetadataVersion::Number(snapshot_metadata.version()),
+                    &snapshot.to_raw()?,
+                )
+                .await?;
+        }
+
+        self.repo
+            .store_metadata(&snapshot_path, &MetadataVersion::None, &snapshot.to_raw()?)
+            .await?;
+
+        // Commit the timestamp metadata.
+        self.repo
+            .store_metadata(
+                &timestamp_path,
+                &MetadataVersion::None,
+                &timestamp.to_raw()?,
+            )
+            .await?;
+
+        Ok(root)
+    }
+}
+
+fn sign<D, M>(metadata: &M, private_keys: &[&PrivateKey]) -> Result<SignedMetadata<D, M>>
+where
+    D: DataInterchange,
+    M: Metadata,
+{
+    let mut private_keys = private_keys.into_iter();
+    let mut signed_metadata = SignedMetadata::new(metadata, private_keys.next().unwrap())?;
+
+    for private_key in private_keys {
+        signed_metadata.add_signature(private_key)?;
+    }
+
+    Ok(signed_metadata)
+}


### PR DESCRIPTION
This is a stack of a few patches. First, it introduces `RepoBuilder`, a helper builder that takes away some of the boilerplate for writing metadata. It's not complete though, so I've left it private and only exposed to tests. It needs the following fixed before I think we should expose it:

* Fetch and validate the old metadata before basing new metadata off of it.
* Don't overwrite metadata that already exists.
* Auto-increment the version numbers.
* Optionally allow the timestamp version number to be generated off of the current UTC time, to ease working with test repositories.
* Merge targets and delegates.
* Come up with a better way to handle delegation metadata.
* Add documentation and examples.
* Make a proper error for when `repo_builder::sign` is given an empty vec of private keys.

In addition, it adds and extends a of tests to use it, and finally, I found and fixed a bug that prevented delegated target descriptions from being fetched. I added a test for this as well to make sure it keeps working.