### PR TITLE
Rename Tuf methods and variables

### DIFF
--- a/src/repository.rs
+++ b/src/repository.rs
@@ -305,10 +305,10 @@ where
 mod test {
     use super::*;
     use crate::interchange::Json;
-    use matches::assert_matches;
     use crate::metadata::{MetadataPath, MetadataVersion, Role, RootMetadata, SnapshotMetadata};
     use crate::repository::EphemeralRepository;
     use futures_executor::block_on;
+    use matches::assert_matches;
 
     #[test]
     fn repository_forwards_not_found_error() {
@@ -425,7 +425,7 @@ mod test {
             let path = MetadataPath::from_role(&Role::Root);
             let version = MetadataVersion::None;
             let data: &[u8] = b"reasonably sized metadata";
-            let _metadata  = RawSignedMetadata::<Json, RootMetadata>::new(data.to_vec());
+            let _metadata = RawSignedMetadata::<Json, RootMetadata>::new(data.to_vec());
 
             let repo = EphemeralRepository::new();
             repo.store_metadata(&path, &version, data).await.unwrap();

--- a/src/tuf.rs
+++ b/src/tuf.rs
@@ -180,7 +180,7 @@ impl<D: DataInterchange> Tuf<D> {
     /// Returns a reference to the parsed metadata if the metadata was newer.
     pub fn update_timestamp(
         &mut self,
-        signed_timestamp: SignedMetadata<D, TimestampMetadata>,
+        new_signed_timestamp: SignedMetadata<D, TimestampMetadata>,
     ) -> Result<Option<&TimestampMetadata>> {
         let verified = {
             // FIXME(https://github.com/theupdateframework/specification/issues/113) Should we
@@ -189,7 +189,7 @@ impl<D: DataInterchange> Tuf<D> {
             let trusted_root = &self.trusted_root;
 
             // First, make sure the root signed the metadata.
-            let new_timestamp = signed_timestamp.verify(
+            let new_timestamp = new_signed_timestamp.verify(
                 trusted_root.timestamp().threshold(),
                 trusted_root.keys().iter().filter_map(|(k, v)| {
                     if trusted_root.timestamp().key_ids().contains(k) {
@@ -232,7 +232,7 @@ impl<D: DataInterchange> Tuf<D> {
     /// Verify and update the snapshot metadata.
     pub fn update_snapshot(
         &mut self,
-        signed_snapshot: SignedMetadata<D, SnapshotMetadata>,
+        new_signed_snapshot: SignedMetadata<D, SnapshotMetadata>,
     ) -> Result<bool> {
         let verified = {
             // FIXME(https://github.com/theupdateframework/specification/issues/113) Checking if
@@ -251,7 +251,7 @@ impl<D: DataInterchange> Tuf<D> {
                 return Ok(false);
             }
 
-            let new_snapshot = signed_snapshot.verify(
+            let new_snapshot = new_signed_snapshot.verify(
                 trusted_root.snapshot().threshold(),
                 trusted_root.keys().iter().filter_map(|(k, v)| {
                     if trusted_root.snapshot().key_ids().contains(k) {
@@ -325,7 +325,7 @@ impl<D: DataInterchange> Tuf<D> {
     /// Verify and update the targets metadata.
     pub fn update_targets(
         &mut self,
-        signed_targets: SignedMetadata<D, TargetsMetadata>,
+        new_signed_targets: SignedMetadata<D, TargetsMetadata>,
     ) -> Result<bool> {
         let verified = {
             // FIXME(https://github.com/theupdateframework/specification/issues/113) Checking if
@@ -354,7 +354,7 @@ impl<D: DataInterchange> Tuf<D> {
                 return Ok(false);
             }
 
-            let new_targets = signed_targets.verify(
+            let new_targets = new_signed_targets.verify(
                 trusted_root.targets().threshold(),
                 trusted_root.keys().iter().filter_map(|(k, v)| {
                     if trusted_root.targets().key_ids().contains(k) {
@@ -444,7 +444,7 @@ impl<D: DataInterchange> Tuf<D> {
         &mut self,
         parent_role: &MetadataPath,
         role: &MetadataPath,
-        signed_delegation: SignedMetadata<D, TargetsMetadata>,
+        new_signed_delegation: SignedMetadata<D, TargetsMetadata>,
     ) -> Result<bool> {
         let verified = {
             // FIXME(https://github.com/theupdateframework/specification/issues/113) Checking if
@@ -492,7 +492,7 @@ impl<D: DataInterchange> Tuf<D> {
                     role
                 )))?;
 
-            let new_delegation = signed_delegation.verify(threshold, keys)?;
+            let new_delegation = new_signed_delegation.verify(threshold, keys)?;
 
             if trusted_delegation_version == trusted_delegation_description.version() {
                 return Ok(false);

--- a/src/tuf.rs
+++ b/src/tuf.rs
@@ -9,19 +9,19 @@ use crate::crypto::PublicKey;
 use crate::error::Error;
 use crate::interchange::DataInterchange;
 use crate::metadata::{
-    Delegation, Delegations, Metadata, MetadataPath, Role, RootMetadata, SignedMetadata,
-    SnapshotMetadata, TargetDescription, TargetsMetadata, TimestampMetadata, VirtualTargetPath,
+    Delegations, Metadata, MetadataPath, Role, RootMetadata, SignedMetadata, SnapshotMetadata,
+    TargetDescription, TargetsMetadata, TimestampMetadata, VirtualTargetPath,
 };
 use crate::Result;
 
 /// Contains trusted TUF metadata and can be used to verify other metadata and targets.
 #[derive(Debug)]
 pub struct Tuf<D: DataInterchange> {
-    root: RootMetadata,
-    snapshot: Option<SnapshotMetadata>,
-    targets: Option<TargetsMetadata>,
-    timestamp: Option<TimestampMetadata>,
-    delegations: HashMap<MetadataPath, TargetsMetadata>,
+    trusted_root: RootMetadata,
+    trusted_snapshot: Option<SnapshotMetadata>,
+    trusted_targets: Option<TargetsMetadata>,
+    trusted_timestamp: Option<TimestampMetadata>,
+    trusted_delegations: HashMap<MetadataPath, TargetsMetadata>,
     interchange: PhantomData<D>,
 }
 
@@ -62,66 +62,78 @@ impl<D: DataInterchange> Tuf<D> {
         };
 
         Ok(Tuf {
-            root: verified,
-            snapshot: None,
-            targets: None,
-            timestamp: None,
-            delegations: HashMap::new(),
+            trusted_root: verified,
+            trusted_snapshot: None,
+            trusted_targets: None,
+            trusted_timestamp: None,
+            trusted_delegations: HashMap::new(),
             interchange: PhantomData,
         })
     }
 
     /// An immutable reference to the root metadata.
-    pub fn root(&self) -> &RootMetadata {
-        &self.root
+    pub fn trusted_root(&self) -> &RootMetadata {
+        &self.trusted_root
     }
 
     /// An immutable reference to the optional snapshot metadata.
-    pub fn snapshot(&self) -> Option<&SnapshotMetadata> {
-        self.snapshot.as_ref()
+    pub fn trusted_snapshot(&self) -> Option<&SnapshotMetadata> {
+        self.trusted_snapshot.as_ref()
     }
 
     /// An immutable reference to the optional targets metadata.
-    pub fn targets(&self) -> Option<&TargetsMetadata> {
-        self.targets.as_ref()
+    pub fn trusted_targets(&self) -> Option<&TargetsMetadata> {
+        self.trusted_targets.as_ref()
     }
 
     /// An immutable reference to the optional timestamp metadata.
-    pub fn timestamp(&self) -> Option<&TimestampMetadata> {
-        self.timestamp.as_ref()
+    pub fn trusted_timestamp(&self) -> Option<&TimestampMetadata> {
+        self.trusted_timestamp.as_ref()
     }
 
     /// An immutable reference to the delegated metadata.
-    pub fn delegations(&self) -> &HashMap<MetadataPath, TargetsMetadata> {
-        &self.delegations
+    pub fn trusted_delegations(&self) -> &HashMap<MetadataPath, TargetsMetadata> {
+        &self.trusted_delegations
     }
 
-    fn current_timestamp_version(&self) -> u32 {
-        self.timestamp.as_ref().map(|t| t.version()).unwrap_or(0)
+    fn trusted_timestamp_version(&self) -> u32 {
+        self.trusted_timestamp
+            .as_ref()
+            .map(|t| t.version())
+            .unwrap_or(0)
     }
 
-    fn current_snapshot_version(&self) -> u32 {
-        self.snapshot.as_ref().map(|t| t.version()).unwrap_or(0)
+    fn trusted_snapshot_version(&self) -> u32 {
+        self.trusted_snapshot
+            .as_ref()
+            .map(|t| t.version())
+            .unwrap_or(0)
     }
 
-    fn current_targets_version(&self) -> u32 {
-        self.targets.as_ref().map(|t| t.version()).unwrap_or(0)
+    fn trusted_targets_version(&self) -> u32 {
+        self.trusted_targets
+            .as_ref()
+            .map(|t| t.version())
+            .unwrap_or(0)
     }
 
-    fn current_delegation_version(&self, role: &MetadataPath) -> u32 {
-        self.delegations.get(role).map(|t| t.version()).unwrap_or(0)
+    fn trusted_delegation_version(&self, role: &MetadataPath) -> u32 {
+        self.trusted_delegations
+            .get(role)
+            .map(|t| t.version())
+            .unwrap_or(0)
     }
 
     /// Verify and update the root metadata.
     pub fn update_root(&mut self, signed_root: SignedMetadata<D, RootMetadata>) -> Result<bool> {
         let verified = {
-            let old_root = &self.root;
+            let trusted_root = &self.trusted_root;
 
             // First, check that the new root was signed by the old root.
             let new_root = signed_root.verify(
-                old_root.root().threshold(),
-                old_root.keys().iter().filter_map(|(k, v)| {
-                    if old_root.root().key_ids().contains(k) {
+                trusted_root.root().threshold(),
+                trusted_root.keys().iter().filter_map(|(k, v)| {
+                    if trusted_root.root().key_ids().contains(k) {
                         Some(v)
                     } else {
                         None
@@ -130,16 +142,16 @@ impl<D: DataInterchange> Tuf<D> {
             )?;
 
             // Next, make sure the new root has a higher version than the old root.
-            if new_root.version() == old_root.version() {
+            if new_root.version() == trusted_root.version() {
                 info!(
                     "Attempted to update root to new metadata with the same version. \
                      Refusing to update."
                 );
                 return Ok(false);
-            } else if new_root.version() < old_root.version() {
+            } else if new_root.version() < trusted_root.version() {
                 return Err(Error::VerificationFailure(format!(
                     "Attempted to roll back root metadata at version {} to {}.",
-                    old_root.version(),
+                    trusted_root.version(),
                     new_root.version()
                 )));
             }
@@ -159,7 +171,7 @@ impl<D: DataInterchange> Tuf<D> {
 
         self.purge_metadata();
 
-        self.root = verified;
+        self.trusted_root = verified;
         Ok(true)
     }
 
@@ -171,13 +183,16 @@ impl<D: DataInterchange> Tuf<D> {
         signed_timestamp: SignedMetadata<D, TimestampMetadata>,
     ) -> Result<Option<&TimestampMetadata>> {
         let verified = {
-            let root = &self.root;
+            // FIXME(https://github.com/theupdateframework/specification/issues/113) Should we
+            // check if the root metadata is expired here? We do that in the other `Tuf::update_*`
+            // methods, but not here.
+            let trusted_root = &self.trusted_root;
 
             // First, make sure the root signed the metadata.
-            let timestamp = signed_timestamp.verify(
-                root.timestamp().threshold(),
-                root.keys().iter().filter_map(|(k, v)| {
-                    if root.timestamp().key_ids().contains(k) {
+            let new_timestamp = signed_timestamp.verify(
+                trusted_root.timestamp().threshold(),
+                trusted_root.keys().iter().filter_map(|(k, v)| {
+                    if trusted_root.timestamp().key_ids().contains(k) {
                         Some(v)
                     } else {
                         None
@@ -186,32 +201,32 @@ impl<D: DataInterchange> Tuf<D> {
             )?;
 
             // Next, make sure the timestamp hasn't expired.
-            if timestamp.expires() <= &Utc::now() {
+            if new_timestamp.expires() <= &Utc::now() {
                 return Err(Error::ExpiredMetadata(Role::Timestamp));
             }
 
             // Next, make sure the new metadata has a higher version than the old metadata.
-            let current_version = self.current_timestamp_version();
+            let trusted_timestamp_version = self.trusted_timestamp_version();
 
-            if timestamp.version() < current_version {
+            if new_timestamp.version() < trusted_timestamp_version {
                 return Err(Error::VerificationFailure(format!(
                     "Attempted to roll back timestamp metadata at version {} to {}.",
-                    current_version,
-                    timestamp.version()
+                    trusted_timestamp_version,
+                    new_timestamp.version()
                 )));
-            } else if timestamp.version() == current_version {
+            } else if new_timestamp.version() == trusted_timestamp_version {
                 return Ok(None);
             }
 
-            if self.current_snapshot_version() != timestamp.snapshot().version() {
-                self.snapshot = None;
+            if self.trusted_snapshot_version() != new_timestamp.snapshot().version() {
+                self.trusted_snapshot = None;
             }
 
-            timestamp
+            new_timestamp
         };
 
-        self.timestamp = Some(verified);
-        Ok(self.timestamp.as_ref())
+        self.trusted_timestamp = Some(verified);
+        Ok(self.trusted_timestamp.as_ref())
     }
 
     /// Verify and update the snapshot metadata.
@@ -220,24 +235,26 @@ impl<D: DataInterchange> Tuf<D> {
         signed_snapshot: SignedMetadata<D, SnapshotMetadata>,
     ) -> Result<bool> {
         let verified = {
-            let root = self.safe_root_ref()?;
-            let timestamp = self.safe_timestamp_ref()?;
-            let current_version = self.current_snapshot_version();
+            // FIXME(https://github.com/theupdateframework/specification/issues/113) Checking if
+            // this metadata expired isn't part of the spec. Do we actually want to do this?
+            let trusted_root = self.trusted_root_unexpired()?;
+            let trusted_timestamp = self.trusted_timestamp_unexpired()?;
+            let trusted_snapshot_version = self.trusted_snapshot_version();
 
-            if timestamp.snapshot().version() < current_version {
+            if trusted_timestamp.snapshot().version() < trusted_snapshot_version {
                 return Err(Error::VerificationFailure(format!(
                     "Attempted to roll back snapshot metadata at version {} to {}.",
-                    current_version,
-                    timestamp.snapshot().version()
+                    trusted_snapshot_version,
+                    trusted_timestamp.snapshot().version()
                 )));
-            } else if timestamp.snapshot().version() == current_version {
+            } else if trusted_timestamp.snapshot().version() == trusted_snapshot_version {
                 return Ok(false);
             }
 
-            let snapshot = signed_snapshot.verify(
-                root.snapshot().threshold(),
-                self.root.keys().iter().filter_map(|(k, v)| {
-                    if root.snapshot().key_ids().contains(k) {
+            let new_snapshot = signed_snapshot.verify(
+                trusted_root.snapshot().threshold(),
+                trusted_root.keys().iter().filter_map(|(k, v)| {
+                    if trusted_root.snapshot().key_ids().contains(k) {
                         Some(v)
                     } else {
                         None
@@ -245,49 +262,53 @@ impl<D: DataInterchange> Tuf<D> {
                 }),
             )?;
 
-            if snapshot.version() != timestamp.snapshot().version() {
+            if new_snapshot.version() != trusted_timestamp.snapshot().version() {
                 return Err(Error::VerificationFailure(format!(
                     "The timestamp metadata reported that the snapshot metadata should be at \
                      version {} but version {} was found instead.",
-                    timestamp.snapshot().version(),
-                    snapshot.version()
+                    trusted_timestamp.snapshot().version(),
+                    new_snapshot.version()
                 )));
             }
 
             // Note: this doesn't check the expiration because we need to be able to update it
             // regardless so we can prevent rollback attacks againsts targets/delegations.
-            snapshot
+            new_snapshot
         };
 
-        if self.targets.as_ref().map(|s| s.version()).unwrap_or(0)
+        if self
+            .trusted_targets
+            .as_ref()
+            .map(|s| s.version())
+            .unwrap_or(0)
             != verified
                 .meta()
                 .get(&MetadataPath::from_role(&Role::Targets))
                 .map(|m| m.version())
                 .unwrap_or(0)
         {
-            self.targets = None;
+            self.trusted_targets = None;
         }
 
-        self.snapshot = Some(verified);
+        self.trusted_snapshot = Some(verified);
         self.purge_delegations();
         Ok(true)
     }
 
     fn purge_delegations(&mut self) {
         let purge = {
-            let snapshot = match self.snapshot() {
+            let trusted_snapshot = match self.trusted_snapshot() {
                 Some(s) => s,
                 None => return,
             };
             let mut purge = HashSet::new();
-            for (role, definition) in snapshot.meta().iter() {
-                let delegation = match self.delegations.get(role) {
+            for (role, trusted_definition) in trusted_snapshot.meta().iter() {
+                let trusted_delegation = match self.trusted_delegations.get(role) {
                     Some(d) => d,
                     None => continue,
                 };
 
-                if delegation.version() > definition.version() {
+                if trusted_delegation.version() > trusted_definition.version() {
                     let _ = purge.insert(role.clone());
                     continue;
                 }
@@ -297,7 +318,7 @@ impl<D: DataInterchange> Tuf<D> {
         };
 
         for role in &purge {
-            let _ = self.delegations.remove(role);
+            let _ = self.trusted_delegations.remove(role);
         }
     }
 
@@ -307,9 +328,12 @@ impl<D: DataInterchange> Tuf<D> {
         signed_targets: SignedMetadata<D, TargetsMetadata>,
     ) -> Result<bool> {
         let verified = {
-            let root = self.safe_root_ref()?;
-            let snapshot = self.safe_snapshot_ref()?;
-            let targets_description = snapshot
+            // FIXME(https://github.com/theupdateframework/specification/issues/113) Checking if
+            // this metadata expired isn't part of the spec. Do we actually want to do this?
+            let trusted_root = self.trusted_root_unexpired()?;
+            let trusted_snapshot = self.trusted_snapshot_unexpired()?;
+
+            let trusted_targets_description = trusted_snapshot
                 .meta()
                 .get(&MetadataPath::from_role(&Role::Targets))
                 .ok_or_else(|| {
@@ -318,22 +342,22 @@ impl<D: DataInterchange> Tuf<D> {
                     )
                 })?;
 
-            let current_version = self.current_targets_version();
+            let trusted_targets_version = self.trusted_targets_version();
 
-            if targets_description.version() < current_version {
+            if trusted_targets_description.version() < trusted_targets_version {
                 return Err(Error::VerificationFailure(format!(
                     "Attempted to roll back targets metadata at version {} to {}.",
-                    current_version,
-                    targets_description.version()
+                    trusted_targets_version,
+                    trusted_targets_description.version()
                 )));
-            } else if targets_description.version() == current_version {
+            } else if trusted_targets_description.version() == trusted_targets_version {
                 return Ok(false);
             }
 
-            let targets = signed_targets.verify(
-                root.targets().threshold(),
-                root.keys().iter().filter_map(|(k, v)| {
-                    if root.targets().key_ids().contains(k) {
+            let new_targets = signed_targets.verify(
+                trusted_root.targets().threshold(),
+                trusted_root.keys().iter().filter_map(|(k, v)| {
+                    if trusted_root.targets().key_ids().contains(k) {
                         Some(v)
                     } else {
                         None
@@ -341,44 +365,44 @@ impl<D: DataInterchange> Tuf<D> {
                 }),
             )?;
 
-            if targets.version() != targets_description.version() {
+            if new_targets.version() != trusted_targets_description.version() {
                 return Err(Error::VerificationFailure(format!(
                     "The timestamp metadata reported that the targets metadata should be at \
                      version {} but version {} was found instead.",
-                    targets_description.version(),
-                    targets.version()
+                    trusted_targets_description.version(),
+                    new_targets.version()
                 )));
             }
 
-            if targets.expires() <= &Utc::now() {
+            if new_targets.expires() <= &Utc::now() {
                 return Err(Error::ExpiredMetadata(Role::Snapshot));
             }
 
-            targets
+            new_targets
         };
 
-        self.targets = Some(verified);
+        self.trusted_targets = Some(verified);
         Ok(true)
     }
 
     /// Find the signing keys and metadata for the delegation given by `role`, as seen from the
     /// point of view of `parent_role`.
-    fn find_delegation(
+    fn find_delegation_threshold_and_keys(
         &self,
         parent_role: &MetadataPath,
         role: &MetadataPath,
-    ) -> Option<(Vec<&PublicKey>, &Delegation)> {
+    ) -> Option<(u32, Vec<&PublicKey>)> {
         // Find the parent TargetsMetadata that is expected to refer to `role`.
-        let parent = {
+        let trusted_parent = {
             if parent_role == &MetadataPath::from_role(&Role::Targets) {
-                if let Some(targets) = self.targets() {
-                    targets
+                if let Some(trusted_targets) = self.trusted_targets() {
+                    trusted_targets
                 } else {
                     return None;
                 }
             } else {
-                if let Some(targets) = self.delegations.get(parent_role) {
-                    targets
+                if let Some(trusted_delegation) = self.trusted_delegations.get(parent_role) {
+                    trusted_delegation
                 } else {
                     return None;
                 }
@@ -386,22 +410,22 @@ impl<D: DataInterchange> Tuf<D> {
         };
 
         // Only consider targets metadata that define delegations.
-        let delegations = match parent.delegations() {
+        let trusted_delegations = match trusted_parent.delegations() {
             Some(d) => d,
             None => return None,
         };
 
-        for delegation in delegations.roles() {
-            if delegation.role() != role {
+        for trusted_delegation in trusted_delegations.roles() {
+            if trusted_delegation.role() != role {
                 continue;
             }
 
             // Filter the delegations keys to just the ones for this delegation.
-            let authorized_keys = delegations
+            let authorized_keys = trusted_delegations
                 .keys()
                 .iter()
                 .filter_map(|(k, v)| {
-                    if delegation.key_ids().contains(k) {
+                    if trusted_delegation.key_ids().contains(k) {
                         Some(v)
                     } else {
                         None
@@ -409,7 +433,7 @@ impl<D: DataInterchange> Tuf<D> {
                 })
                 .collect();
 
-            return Some((authorized_keys, delegation));
+            return Some((trusted_delegation.threshold(), authorized_keys));
         }
 
         None
@@ -423,16 +447,19 @@ impl<D: DataInterchange> Tuf<D> {
         signed_delegation: SignedMetadata<D, TargetsMetadata>,
     ) -> Result<bool> {
         let verified = {
-            let _ = self.safe_root_ref()?;
-            let snapshot = self.safe_snapshot_ref()?;
-            let targets = self.safe_targets_ref()?;
-            if targets.delegations().is_none() {
+            // FIXME(https://github.com/theupdateframework/specification/issues/113) Checking if
+            // this metadata expired isn't part of the spec. Do we actually want to do this?
+            let _ = self.trusted_root_unexpired()?;
+            let trusted_snapshot = self.trusted_snapshot_unexpired()?;
+            let trusted_targets = self.trusted_targets_unexpired()?;
+
+            if trusted_targets.delegations().is_none() {
                 return Err(Error::VerificationFailure(
                     "Delegations not authorized".into(),
                 ));
             };
 
-            let delegation_description = match snapshot.meta().get(role) {
+            let trusted_delegation_description = match trusted_snapshot.meta().get(role) {
                 Some(d) => d,
                 None => {
                     return Err(Error::VerificationFailure(format!(
@@ -442,53 +469,54 @@ impl<D: DataInterchange> Tuf<D> {
                 }
             };
 
-            let current_version = self.current_delegation_version(role);
+            let trusted_delegation_version = self.trusted_delegation_version(role);
 
-            if delegation_description.version() < current_version {
+            if trusted_delegation_description.version() < trusted_delegation_version {
                 return Err(Error::VerificationFailure(format!(
                     "Snapshot metadata did listed delegation {:?} version as {} but current\
                      version is {}",
                     role,
-                    delegation_description.version(),
-                    current_version
+                    trusted_delegation_description.version(),
+                    trusted_delegation_version
                 )));
             }
 
             // FIXME(#279) update_delegation trusts tuf::Client to provide too much information,
             // making this difficult to verify as correct.
 
-            let (keys, delegation) =
-                self.find_delegation(parent_role, role)
-                    .ok_or(Error::VerificationFailure(format!(
-                        "The delegated role {:?} is not known to the base \
+            let (threshold, keys) = self
+                .find_delegation_threshold_and_keys(parent_role, role)
+                .ok_or(Error::VerificationFailure(format!(
+                    "The delegated role {:?} is not known to the base \
                         targets metadata or any known delegated targets metadata",
-                        role
-                    )))?;
-            let delegation = signed_delegation.verify(delegation.threshold(), keys)?;
+                    role
+                )))?;
 
-            if current_version == delegation_description.version() {
+            let new_delegation = signed_delegation.verify(threshold, keys)?;
+
+            if trusted_delegation_version == trusted_delegation_description.version() {
                 return Ok(false);
             }
 
-            if delegation.version() != delegation_description.version() {
+            if new_delegation.version() != trusted_delegation_description.version() {
                 return Err(Error::VerificationFailure(format!(
                     "The snapshot metadata reported that the delegation {:?} should be at \
                      version {} but version {} was found instead.",
                     role,
-                    delegation_description.version(),
-                    delegation.version(),
+                    trusted_delegation_description.version(),
+                    new_delegation.version(),
                 )));
             }
 
-            if delegation.expires() <= &Utc::now() {
+            if new_delegation.expires() <= &Utc::now() {
                 // TODO this needs to be chagned to accept a MetadataPath and not Role
                 return Err(Error::ExpiredMetadata(Role::Targets));
             }
 
-            delegation
+            new_delegation
         };
 
-        let _ = self.delegations.insert(role.clone(), verified);
+        let _ = self.trusted_delegations.insert(role.clone(), verified);
 
         Ok(true)
     }
@@ -498,9 +526,9 @@ impl<D: DataInterchange> Tuf<D> {
     /// metadata. This may mean the target exists somewhere in the metadata, but the chain of trust
     /// to that target may be invalid or incomplete.
     pub fn target_description(&self, target_path: &VirtualTargetPath) -> Result<TargetDescription> {
-        let _ = self.safe_root_ref()?;
-        let _ = self.safe_snapshot_ref()?;
-        let targets = self.safe_targets_ref()?;
+        let _ = self.trusted_root_unexpired()?;
+        let _ = self.trusted_snapshot_unexpired()?;
+        let targets = self.trusted_targets_unexpired()?;
 
         if let Some(d) = targets.targets().get(target_path) {
             return Ok(d.clone());
@@ -528,20 +556,20 @@ impl<D: DataInterchange> Tuf<D> {
                     return (delegation.terminating(), None);
                 }
 
-                let targets = match tuf.delegations.get(delegation.role()) {
-                    Some(t) => t,
+                let trusted_delegation = match tuf.trusted_delegations.get(delegation.role()) {
+                    Some(trusted_delegation) => trusted_delegation,
                     None => return (delegation.terminating(), None),
                 };
 
-                if targets.expires() <= &Utc::now() {
+                if trusted_delegation.expires() <= &Utc::now() {
                     return (delegation.terminating(), None);
                 }
 
-                if let Some(d) = targets.targets().get(target_path) {
-                    return (delegation.terminating(), Some(d.clone()));
+                if let Some(target) = trusted_delegation.targets().get(target_path) {
+                    return (delegation.terminating(), Some(target.clone()));
                 }
 
-                if let Some(d) = targets.delegations() {
+                if let Some(trusted_child_delegation) = trusted_delegation.delegations() {
                     let mut new_parents = parents.to_vec();
                     new_parents.push(delegation.paths().clone());
                     let (term, res) = lookup(
@@ -549,7 +577,7 @@ impl<D: DataInterchange> Tuf<D> {
                         delegation.terminating(),
                         current_depth + 1,
                         target_path,
-                        d,
+                        trusted_child_delegation,
                         &new_parents,
                         visited,
                     );
@@ -575,50 +603,50 @@ impl<D: DataInterchange> Tuf<D> {
     }
 
     fn purge_metadata(&mut self) {
-        self.snapshot = None;
-        self.targets = None;
-        self.timestamp = None;
-        self.delegations.clear();
+        self.trusted_snapshot = None;
+        self.trusted_targets = None;
+        self.trusted_timestamp = None;
+        self.trusted_delegations.clear();
     }
 
-    fn safe_root_ref(&self) -> Result<&RootMetadata> {
-        let root = &self.root;
-        if root.expires() <= &Utc::now() {
+    fn trusted_root_unexpired(&self) -> Result<&RootMetadata> {
+        let trusted_root = &self.trusted_root;
+        if trusted_root.expires() <= &Utc::now() {
             return Err(Error::ExpiredMetadata(Role::Root));
         }
-        Ok(&root)
+        Ok(&trusted_root)
     }
 
-    fn safe_snapshot_ref(&self) -> Result<&SnapshotMetadata> {
-        match self.snapshot {
-            Some(ref snapshot) => {
-                if snapshot.expires() <= &Utc::now() {
+    fn trusted_snapshot_unexpired(&self) -> Result<&SnapshotMetadata> {
+        match self.trusted_snapshot {
+            Some(ref trusted_snapshot) => {
+                if trusted_snapshot.expires() <= &Utc::now() {
                     return Err(Error::ExpiredMetadata(Role::Snapshot));
                 }
-                Ok(snapshot)
+                Ok(trusted_snapshot)
             }
             None => Err(Error::MissingMetadata(Role::Snapshot)),
         }
     }
 
-    fn safe_targets_ref(&self) -> Result<&TargetsMetadata> {
-        match self.targets {
-            Some(ref targets) => {
-                if targets.expires() <= &Utc::now() {
+    fn trusted_targets_unexpired(&self) -> Result<&TargetsMetadata> {
+        match self.trusted_targets {
+            Some(ref trusted_targets) => {
+                if trusted_targets.expires() <= &Utc::now() {
                     return Err(Error::ExpiredMetadata(Role::Targets));
                 }
-                Ok(targets)
+                Ok(trusted_targets)
             }
             None => Err(Error::MissingMetadata(Role::Targets)),
         }
     }
-    fn safe_timestamp_ref(&self) -> Result<&TimestampMetadata> {
-        match self.timestamp {
-            Some(ref timestamp) => {
-                if timestamp.expires() <= &Utc::now() {
+    fn trusted_timestamp_unexpired(&self) -> Result<&TimestampMetadata> {
+        match self.trusted_timestamp {
+            Some(ref trusted_timestamp) => {
+                if trusted_timestamp.expires() <= &Utc::now() {
                     return Err(Error::ExpiredMetadata(Role::Timestamp));
                 }
-                Ok(timestamp)
+                Ok(trusted_timestamp)
             }
             None => Err(Error::MissingMetadata(Role::Timestamp)),
         }


### PR DESCRIPTION
There's a risk when reviewing `tuf.rs`'s code that one could mistake the trusted metadata with the untrusted metadata we are still validating. This adds:

* `trusted_` prefix to all the instances where we are deriving data from the trusted metadata.
* `new_` to all the instances where we are working with the new, untrusted metadata.
* renamed `safe_$ROLE_ref()` to `trusted_$ROLE_unexpired()` to make it clear it will err if the metadata is expired.

This makes it easier to check if the metadata is being used incorrectly.

Test: This doesn't have any functional changes, so it doesn't need tests.