### PR TITLE
Control when metadata is deserialized

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -63,6 +63,7 @@ use crate::metadata::{
 };
 use crate::repository::{Repository, RepositoryProvider, RepositoryStorage};
 use crate::tuf::Tuf;
+use crate::verify::Verified;
 use crate::Result;
 
 /// Translates real paths (where a file is stored) into virtual paths (how it is addressed in TUF)
@@ -197,9 +198,13 @@ where
         // FIXME should this be MetadataVersion::None so we bootstrap with the latest version?
         let root_version = MetadataVersion::Number(1);
 
-        let (_, root) = local
+        let raw_root: RawSignedMetadata<_, RootMetadata> = local
             .fetch_metadata(&root_path, &root_version, config.max_root_length, None)
             .await?;
+
+        // **WARNING**: By deserializing the metadata before verification, we are exposing us to
+        // parser exploits.
+        let root = raw_root.parse_untrusted()?;
 
         let tuf = Tuf::from_trusted_root(root)?;
 
@@ -350,7 +355,7 @@ where
         let (local, remote) = (Repository::new(local), Repository::new(remote));
 
         let root_path = MetadataPath::from_role(&Role::Root);
-        let (fetched, raw_root, root) = fetch_metadata_from_local_or_else_remote(
+        let (fetched, raw_root) = fetch_metadata_from_local_or_else_remote(
             &root_path,
             root_version,
             config.max_root_length,
@@ -360,7 +365,7 @@ where
         )
         .await?;
 
-        let tuf = Tuf::from_root_with_trusted_keys(root, root_threshold, trusted_root_keys)?;
+        let tuf = Tuf::from_root_with_trusted_keys(&raw_root, root_threshold, trusted_root_keys)?;
 
         // FIXME(#253) verify the trusted root version matches the provided version.
         let root_version = MetadataVersion::Number(tuf.trusted_root().version());
@@ -448,7 +453,7 @@ where
     async fn update_root(&mut self) -> Result<bool> {
         let root_path = MetadataPath::from_role(&Role::Root);
 
-        let (raw_latest_root, latest_root) = self
+        let raw_latest_root = self
             .remote
             .fetch_metadata(
                 &root_path,
@@ -461,7 +466,15 @@ where
         // Root metadata is signed by its own keys, but we should only trust it if it is also
         // signed by the previous root metadata, which we can't check without knowing what version
         // this root metadata claims to be.
-        let latest_version = latest_root.parse_version_untrusted()?;
+        let latest_version = {
+            // **WARNING**: By deserializing the metadata before verification, we are exposing us
+            // to parser exploits.
+            //
+            // FIXME(#292): Consider rewriting this logic to just fetching root version N+1 until
+            // we get a not found error. That allows us to avoid parsing the metadata here.
+            let latest_root = raw_latest_root.parse_untrusted()?;
+            latest_root.parse_version_untrusted()?
+        };
 
         if latest_version < self.tuf.trusted_root().version() {
             return Err(Error::VerificationFailure(format!(
@@ -479,12 +492,12 @@ where
         for i in (self.tuf.trusted_root().version() + 1)..latest_version {
             let version = MetadataVersion::Number(i);
 
-            let (raw_signed_root, signed_root) = self
+            let raw_signed_root = self
                 .remote
                 .fetch_metadata(&root_path, &version, self.config.max_root_length, None)
                 .await?;
 
-            if !self.tuf.update_root(signed_root)? {
+            if !self.tuf.update_root(&raw_signed_root)? {
                 error!("{}", err_msg);
                 return Err(Error::Programming(err_msg.into()));
             }
@@ -493,7 +506,7 @@ where
                 .await;
         }
 
-        if !self.tuf.update_root(latest_root)? {
+        if !self.tuf.update_root(&raw_latest_root)? {
             error!("{}", err_msg);
             return Err(Error::Programming(err_msg.into()));
         }
@@ -517,7 +530,7 @@ where
     async fn update_timestamp(&mut self) -> Result<bool> {
         let timestamp_path = MetadataPath::from_role(&Role::Timestamp);
 
-        let (raw_signed_timestamp, signed_timestamp) = self
+        let raw_signed_timestamp = self
             .remote
             .fetch_metadata(
                 &timestamp_path,
@@ -527,7 +540,7 @@ where
             )
             .await?;
 
-        if let Some(updated_timestamp) = self.tuf.update_timestamp(signed_timestamp)? {
+        if let Some(updated_timestamp) = self.tuf.update_timestamp(&raw_signed_timestamp)? {
             let latest_version = MetadataVersion::Number(updated_timestamp.version());
             self.store_metadata(&timestamp_path, &latest_version, &raw_signed_timestamp)
                 .await;
@@ -570,7 +583,7 @@ where
         let snapshot_path = MetadataPath::from_role(&Role::Snapshot);
         let snapshot_length = Some(snapshot_description.length());
 
-        let (raw_signed_snapshot, signed_snapshot) = self
+        let raw_signed_snapshot = self
             .remote
             .fetch_metadata(
                 &snapshot_path,
@@ -580,7 +593,7 @@ where
             )
             .await?;
 
-        if self.tuf.update_snapshot(signed_snapshot)? {
+        if self.tuf.update_snapshot(&raw_signed_snapshot)? {
             self.store_metadata(&snapshot_path, &version, &raw_signed_snapshot)
                 .await;
 
@@ -622,7 +635,7 @@ where
         let targets_path = MetadataPath::from_role(&Role::Targets);
         let targets_length = Some(targets_description.length());
 
-        let (raw_signed_targets, signed_targets) = self
+        let raw_signed_targets = self
             .remote
             .fetch_metadata(
                 &targets_path,
@@ -632,7 +645,7 @@ where
             )
             .await?;
 
-        if self.tuf.update_targets(signed_targets)? {
+        if self.tuf.update_targets(&raw_signed_targets)? {
             self.store_metadata(&targets_path, &version, &raw_signed_targets)
                 .await;
 
@@ -708,7 +721,7 @@ where
         current_depth: u32,
         target: &'a VirtualTargetPath,
         snapshot: &'a SnapshotMetadata,
-        targets: Option<(&'a TargetsMetadata, MetadataPath)>,
+        targets: Option<(&'a Verified<TargetsMetadata>, MetadataPath)>,
     ) -> (bool, Result<TargetDescription>) {
         if current_depth > self.config.max_delegation_depth {
             warn!(
@@ -768,6 +781,8 @@ where
                 MetadataVersion::None
             };
 
+            // FIXME: Other than root, this is the only place that first tries using the local
+            // metadata before failing back to the remote server. Is this logic correct?
             let role_length = Some(role_meta.length());
             let raw_signed_meta = self
                 .local
@@ -779,7 +794,7 @@ where
                 )
                 .await;
 
-            let (raw_signed_meta, signed_meta) = match raw_signed_meta {
+            let raw_signed_meta = match raw_signed_meta {
                 Ok(m) => m,
                 Err(_) => {
                     match self
@@ -807,7 +822,7 @@ where
 
             match self
                 .tuf
-                .update_delegation(&targets_role, delegation.role(), signed_meta)
+                .update_delegation(&targets_role, delegation.role(), &raw_signed_meta)
             {
                 Ok(_) => {
                     match self
@@ -863,7 +878,7 @@ async fn fetch_metadata_from_local_or_else_remote<'a, D, L, R, M>(
     hash_data: Option<(&'static HashAlgorithm, HashValue)>,
     local: &'a Repository<L, D>,
     remote: &'a Repository<R, D>,
-) -> Result<(bool, RawSignedMetadata<D, M>, SignedMetadata<D, M>)>
+) -> Result<(bool, RawSignedMetadata<D, M>)>
 where
     D: DataInterchange + Sync,
     L: RepositoryProvider<D> + RepositoryStorage<D>,
@@ -874,12 +889,12 @@ where
         .fetch_metadata(path, version, max_length, hash_data.clone())
         .await
     {
-        Ok((raw_meta, meta)) => Ok((false, raw_meta, meta)),
+        Ok(raw_meta) => Ok((false, raw_meta)),
         Err(Error::NotFound) => {
-            let (raw_meta, meta) = remote
+            let raw_meta = remote
                 .fetch_metadata(path, version, max_length, hash_data)
                 .await?;
-            Ok((true, raw_meta, meta))
+            Ok((true, raw_meta))
         }
         Err(err) => Err(err),
     }
@@ -1320,7 +1335,6 @@ mod test {
                     )
                     .await
                     .unwrap()
-                    .0
             );
 
             ////
@@ -1376,7 +1390,6 @@ mod test {
                     )
                     .await
                     .unwrap()
-                    .0
             );
         });
     }
@@ -1539,7 +1552,6 @@ mod test {
                 .fetch_metadata::<RootMetadata>(&root_path, &MetadataVersion::Number(2), None, None)
                 .await
                 .unwrap()
-                .0
         );
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,10 +117,10 @@ pub mod interchange;
 pub mod metadata;
 pub mod repository;
 pub mod tuf;
+pub mod verify;
 
 mod format_hex;
 mod util;
-mod verify;
 
 pub use crate::error::*;
 pub use crate::tuf::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,6 +120,7 @@ pub mod tuf;
 
 mod format_hex;
 mod util;
+mod verify;
 
 pub use crate::error::*;
 pub use crate::tuf::*;

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -2,7 +2,6 @@
 
 use chrono::offset::Utc;
 use chrono::{DateTime, Duration};
-use log::{debug, warn};
 use serde::de::{Deserialize, DeserializeOwned, Deserializer, Error as DeserializeError};
 use serde::ser::{Error as SerializeError, Serialize, Serializer};
 use serde_derive::{Deserialize, Serialize};
@@ -497,111 +496,6 @@ where
     /// This operation is not safe to do with metadata obtained from an untrusted source.
     pub fn assume_valid(&self) -> Result<M> {
         D::deserialize(&self.metadata)
-    }
-
-    /// Verify this metadata.
-    ///
-    /// ```
-    /// # use chrono::prelude::*;
-    /// # use tuf::crypto::{PrivateKey, SignatureScheme, HashAlgorithm};
-    /// # use tuf::interchange::Json;
-    /// # use tuf::metadata::{SnapshotMetadataBuilder, SignedMetadata};
-    ///
-    /// # fn main() {
-    /// let key_1: &[u8] = include_bytes!("../tests/ed25519/ed25519-1.pk8.der");
-    /// let key_1 = PrivateKey::from_pkcs8(&key_1, SignatureScheme::Ed25519).unwrap();
-    ///
-    /// let key_2: &[u8] = include_bytes!("../tests/ed25519/ed25519-2.pk8.der");
-    /// let key_2 = PrivateKey::from_pkcs8(&key_2, SignatureScheme::Ed25519).unwrap();
-    ///
-    /// let snapshot = SnapshotMetadataBuilder::new().build().unwrap();
-    /// let snapshot = SignedMetadata::<Json, _>::new(&snapshot, &key_1).unwrap();
-    ///
-    /// assert!(snapshot.verify(
-    ///     1,
-    ///     vec![key_1.public()],
-    /// ).is_ok());
-    ///
-    /// // fail with increased threshold
-    /// assert!(snapshot.verify(
-    ///     2,
-    ///     vec![key_1.public()],
-    /// ).is_err());
-    ///
-    /// // fail when the keys aren't authorized
-    /// assert!(snapshot.verify(
-    ///     1,
-    ///     vec![key_2.public()],
-    /// ).is_err());
-    ///
-    /// // fail when the keys don't exist
-    /// assert!(snapshot.verify(
-    ///     1,
-    ///     &[],
-    /// ).is_err());
-    /// # }
-    pub fn verify<'a, I>(&self, threshold: u32, authorized_keys: I) -> Result<M>
-    where
-        I: IntoIterator<Item = &'a PublicKey>,
-    {
-        if self.signatures.is_empty() {
-            return Err(Error::VerificationFailure(
-                "The metadata was not signed with any authorized keys.".into(),
-            ));
-        }
-
-        if threshold < 1 {
-            return Err(Error::VerificationFailure(
-                "Threshold must be strictly greater than zero".into(),
-            ));
-        }
-
-        let authorized_keys = authorized_keys
-            .into_iter()
-            .map(|k| (k.key_id(), k))
-            .collect::<HashMap<&KeyId, &PublicKey>>();
-
-        let canonical_bytes = D::canonicalize(&self.metadata)?;
-
-        let mut signatures_needed = threshold;
-        // Create a key_id->signature map to deduplicate the key_ids.
-        let signatures = self
-            .signatures
-            .iter()
-            .map(|sig| (sig.key_id(), sig))
-            .collect::<HashMap<&KeyId, &Signature>>();
-        for (key_id, sig) in signatures {
-            match authorized_keys.get(key_id) {
-                Some(ref pub_key) => match pub_key.verify(&canonical_bytes, sig) {
-                    Ok(()) => {
-                        debug!("Good signature from key ID {:?}", pub_key.key_id());
-                        signatures_needed -= 1;
-                    }
-                    Err(e) => {
-                        warn!("Bad signature from key ID {:?}: {:?}", pub_key.key_id(), e);
-                    }
-                },
-                None => {
-                    warn!(
-                        "Key ID {:?} was not found in the set of authorized keys.",
-                        sig.key_id()
-                    );
-                }
-            }
-            if signatures_needed == 0 {
-                break;
-            }
-        }
-        if signatures_needed > 0 {
-            return Err(Error::VerificationFailure(format!(
-                "Signature threshold not met: {}/{}",
-                threshold - signatures_needed,
-                threshold
-            )));
-        }
-
-        // "assume" the metadata is valid because we just verified that it is.
-        self.assume_valid()
     }
 }
 
@@ -2099,6 +1993,7 @@ mod test {
     use super::*;
     use crate::crypto::SignatureScheme;
     use crate::interchange::Json;
+    use crate::verify::verify_signatures;
     use chrono::prelude::*;
     use maplit::{hashmap, hashset};
     use matches::assert_matches;
@@ -2432,7 +2327,12 @@ mod test {
 
         let signed: SignedMetadata<crate::interchange::cjson::Json, _> =
             SignedMetadata::new(&decoded, &root_key).unwrap();
-        signed.verify(1, &[root_key.public().clone()]).unwrap();
+        let raw_root = signed.to_raw().unwrap();
+
+        assert_matches!(
+            verify_signatures(&raw_root, 1, &[root_key.public().clone()]),
+            Ok(_)
+        );
     }
 
     #[test]
@@ -2447,8 +2347,12 @@ mod test {
         let root_key = PrivateKey::from_pkcs8(ED25519_1_PK8, SignatureScheme::Ed25519).unwrap();
         let decoded: SignedMetadata<crate::interchange::cjson::Json, RootMetadata> =
             serde_json::from_value(jsn).unwrap();
+        let raw_root = decoded.to_raw().unwrap();
 
-        decoded.verify(1, &[root_key.public().clone()]).unwrap();
+        assert_matches!(
+            verify_signatures(&raw_root, 1, &[root_key.public().clone()]),
+            Ok(_)
+        );
     }
 
     #[test]
@@ -2467,11 +2371,15 @@ mod test {
         let root_key = PrivateKey::from_pkcs8(ED25519_1_PK8, SignatureScheme::Ed25519).unwrap();
         let decoded: SignedMetadata<crate::interchange::cjson::Json, RootMetadata> =
             serde_json::from_value(jsn).unwrap();
+        let raw_root = decoded.to_raw().unwrap();
         assert_matches!(
-            decoded.verify(2, &[root_key.public().clone()]),
+            verify_signatures(&raw_root, 2, &[root_key.public().clone()]),
             Err(Error::VerificationFailure(_))
         );
-        decoded.verify(1, &[root_key.public().clone()]).unwrap();
+        assert_matches!(
+            verify_signatures(&raw_root, 1, &[root_key.public().clone()]),
+            Ok(_)
+        );
     }
 
     fn verify_signature_with_unknown_fields<M>(mut metadata: serde_json::Value)
@@ -2479,6 +2387,7 @@ mod test {
         M: Metadata,
     {
         let key = PrivateKey::from_pkcs8(ED25519_1_PK8, SignatureScheme::Ed25519).unwrap();
+        let public_keys = vec![key.public().clone()];
 
         let mut standard = SignedMetadataBuilder::<Json, M>::from_raw_metadata(metadata.clone())
             .unwrap()
@@ -2508,18 +2417,28 @@ mod test {
             .unwrap();
 
         // Ensure the signatures are valid as-is.
-        assert_matches!(standard.verify(1, std::iter::once(key.public())), Ok(_));
-        assert_matches!(custom.verify(1, std::iter::once(key.public())), Ok(_));
+        assert_matches!(
+            verify_signatures(&standard.to_raw().unwrap(), 1, &public_keys),
+            Ok(_)
+        );
+        assert_matches!(
+            verify_signatures(&custom.to_raw().unwrap(), 1, std::iter::once(key.public())),
+            Ok(_)
+        );
 
         // But not if the metadata was signed with custom fields and they are now missing or
         // unexpected new fields appear.
         std::mem::swap(&mut standard.metadata, &mut custom.metadata);
         assert_matches!(
-            standard.verify(1, std::iter::once(key.public())),
+            verify_signatures(
+                &standard.to_raw().unwrap(),
+                1,
+                std::iter::once(key.public())
+            ),
             Err(Error::VerificationFailure(_))
         );
         assert_matches!(
-            custom.verify(1, std::iter::once(key.public())),
+            verify_signatures(&custom.to_raw().unwrap(), 1, std::iter::once(key.public())),
             Err(Error::VerificationFailure(_))
         );
     }

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -265,7 +265,10 @@ where
     }
 
     /// Parse this metadata.
-    pub fn parse(&self) -> Result<SignedMetadata<D, M>> {
+    ///
+    /// **WARNING**: This does not verify signatures, so it exposes users to potential parser
+    /// exploits.
+    pub fn parse_untrusted(&self) -> Result<SignedMetadata<D, M>> {
         D::from_slice(&self.bytes)
     }
 }
@@ -2484,7 +2487,7 @@ mod test {
             .build()
             .to_raw()
             .unwrap()
-            .parse()
+            .parse_untrusted()
             .unwrap();
 
         metadata.as_object_mut().unwrap().insert(
@@ -2501,7 +2504,7 @@ mod test {
             .build()
             .to_raw()
             .unwrap()
-            .parse()
+            .parse_untrusted()
             .unwrap();
 
         // Ensure the signatures are valid as-is.

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -3,8 +3,7 @@
 use crate::crypto::{self, HashAlgorithm, HashValue};
 use crate::interchange::DataInterchange;
 use crate::metadata::{
-    Metadata, MetadataPath, MetadataVersion, RawSignedMetadata, SignedMetadata, TargetDescription,
-    TargetPath,
+    Metadata, MetadataPath, MetadataVersion, RawSignedMetadata, TargetDescription, TargetPath,
 };
 use crate::util::SafeAsyncRead;
 use crate::{Error, Result};
@@ -181,32 +180,6 @@ where
     R: RepositoryProvider<D>,
     D: DataInterchange + Sync,
 {
-    /// Fetch and parse metadata identified by `meta_path`, `version`, and
-    /// [`D::extension()`][extension].
-    ///
-    /// If `max_length` is provided, this method will return an error if the metadata exceeds
-    /// `max_length` bytes. If `hash_data` is provided, this method will return and error if the
-    /// hashed bytes of the metadata do not match `hash_data`.
-    ///
-    /// [extension]: crate::interchange::DataInterchange::extension
-    pub(crate) async fn fetch_metadata<'a, M>(
-        &'a self,
-        meta_path: &'a MetadataPath,
-        version: &'a MetadataVersion,
-        max_length: Option<usize>,
-        hash_data: Option<(&'static HashAlgorithm, HashValue)>,
-    ) -> Result<(RawSignedMetadata<D, M>, SignedMetadata<D, M>)>
-    where
-        M: Metadata,
-    {
-        let raw_signed_meta = self
-            .fetch_raw_metadata(meta_path, version, max_length, hash_data)
-            .await?;
-        let signed_meta = raw_signed_meta.parse()?;
-
-        Ok((raw_signed_meta, signed_meta))
-    }
-
     /// Fetch metadata identified by `meta_path`, `version`, and [`D::extension()`][extension].
     ///
     /// If `max_length` is provided, this method will return an error if the metadata exceeds
@@ -214,7 +187,7 @@ where
     /// hashed bytes of the metadata do not match `hash_data`.
     ///
     /// [extension]: crate::interchange::DataInterchange::extension
-    async fn fetch_raw_metadata<'a, M>(
+    pub(crate) async fn fetch_metadata<'a, M>(
         &'a self,
         meta_path: &'a MetadataPath,
         version: &'a MetadataVersion,
@@ -381,7 +354,7 @@ mod test {
 
             assert_matches!(
                 client
-                    .fetch_raw_metadata::<RootMetadata>(
+                    .fetch_metadata::<RootMetadata>(
                         &path,
                         &version,
                         None,
@@ -434,7 +407,7 @@ mod test {
 
             assert_matches!(
                 client
-                    .fetch_raw_metadata::<RootMetadata>(&path, &version, Some(100), None)
+                    .fetch_metadata::<RootMetadata>(&path, &version, Some(100), None)
                     .await,
                 Ok(_metadata)
             );

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -1,0 +1,160 @@
+use log::{debug, warn};
+use serde_derive::Deserialize;
+use std::collections::HashMap;
+
+use crate::crypto::{KeyId, PublicKey, Signature};
+use crate::error::Error;
+use crate::interchange::DataInterchange;
+use crate::metadata::{Metadata, RawSignedMetadata};
+use crate::Result;
+
+#[derive(Clone, Debug)]
+pub struct Verified<T> {
+    value: T,
+}
+
+impl<T> Verified<T> {
+    fn new(value: T) -> Self {
+        Verified { value }
+    }
+}
+
+impl<T> std::ops::Deref for Verified<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.value
+    }
+}
+
+/// Verify this metadata.
+///
+/// ```
+/// # use chrono::prelude::*;
+/// # use tuf::crypto::{PrivateKey, SignatureScheme, HashAlgorithm};
+/// # use tuf::interchange::Json;
+/// # use tuf::metadata::{SnapshotMetadataBuilder, SignedMetadata};
+///
+/// # fn main() {
+/// let key_1: &[u8] = include_bytes!("../tests/ed25519/ed25519-1.pk8.der");
+/// let key_1 = PrivateKey::from_pkcs8(&key_1, SignatureScheme::Ed25519).unwrap();
+///
+/// let key_2: &[u8] = include_bytes!("../tests/ed25519/ed25519-2.pk8.der");
+/// let key_2 = PrivateKey::from_pkcs8(&key_2, SignatureScheme::Ed25519).unwrap();
+///
+/// let snapshot = SnapshotMetadataBuilder::new().build().unwrap();
+/// let snapshot = SignedMetadata::<Json, _>::new(&snapshot, &key_1).unwrap();
+///
+/// assert!(snapshot.verify(
+///     1,
+///     vec![key_1.public()],
+/// ).is_ok());
+///
+/// // fail with increased threshold
+/// assert!(snapshot.verify(
+///     2,
+///     vec![key_1.public()],
+/// ).is_err());
+///
+/// // fail when the keys aren't authorized
+/// assert!(snapshot.verify(
+///     1,
+///     vec![key_2.public()],
+/// ).is_err());
+///
+/// // fail when the keys don't exist
+/// assert!(snapshot.verify(
+///     1,
+///     &[],
+/// ).is_err());
+/// # }
+pub(crate) fn verify_signatures<'a, D, M, I>(
+    raw_metadata: &RawSignedMetadata<D, M>,
+    threshold: u32,
+    authorized_keys: I,
+) -> Result<Verified<M>>
+where
+    D: DataInterchange,
+    M: Metadata,
+    I: IntoIterator<Item = &'a PublicKey>,
+{
+    if threshold < 1 {
+        return Err(Error::VerificationFailure(
+            "Threshold must be strictly greater than zero".into(),
+        ));
+    }
+
+    let authorized_keys = authorized_keys
+        .into_iter()
+        .map(|k| (k.key_id(), k))
+        .collect::<HashMap<&KeyId, &PublicKey>>();
+
+    // Extract the signatures and canonicalize the bytes.
+    let (signatures, canonical_bytes) = {
+        #[derive(Deserialize)]
+        pub struct SignedMetadata<D: DataInterchange> {
+            signatures: Vec<Signature>,
+            signed: D::RawData,
+        }
+
+        let unverified: SignedMetadata<D> = D::from_slice(raw_metadata.as_bytes())?;
+
+        if unverified.signatures.is_empty() {
+            return Err(Error::VerificationFailure(
+                "The metadata was not signed with any authorized keys.".into(),
+            ));
+        }
+
+        let canonical_bytes = D::canonicalize(&unverified.signed)?;
+        (unverified.signatures, canonical_bytes)
+    };
+
+    let mut signatures_needed = threshold;
+
+    // Create a key_id->signature map to deduplicate the key_ids.
+    let signatures = signatures
+        .iter()
+        .map(|sig| (sig.key_id(), sig))
+        .collect::<HashMap<&KeyId, &Signature>>();
+
+    for (key_id, sig) in signatures {
+        match authorized_keys.get(key_id) {
+            Some(ref pub_key) => match pub_key.verify(&canonical_bytes, sig) {
+                Ok(()) => {
+                    debug!("Good signature from key ID {:?}", pub_key.key_id());
+                    signatures_needed -= 1;
+                }
+                Err(e) => {
+                    warn!("Bad signature from key ID {:?}: {:?}", pub_key.key_id(), e);
+                }
+            },
+            None => {
+                warn!(
+                    "Key ID {:?} was not found in the set of authorized keys.",
+                    sig.key_id()
+                );
+            }
+        }
+        if signatures_needed == 0 {
+            break;
+        }
+    }
+
+    if signatures_needed > 0 {
+        return Err(Error::VerificationFailure(format!(
+            "Signature threshold not met: {}/{}",
+            threshold - signatures_needed,
+            threshold
+        )));
+    }
+
+    // Everything looks good so deserialize the metadata.
+    //
+    // Note: Canonicalization (or any other transformation of data) could modify or filter out
+    // information about the data. Therefore, while we've confirmed the canonical bytes are signed,
+    // we shouldn't interpret this as if the raw bytes were signed. So we deserialize from the
+    // `canonical_bytes`, rather than from `raw_meta.as_bytes()`.
+    let verified_metadata = D::from_slice(&canonical_bytes)?;
+
+    Ok(Verified::new(verified_metadata))
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -34,9 +34,10 @@ fn simple_delegation() {
         .timestamp_key(timestamp_key.public().clone())
         .signed::<Json>(&root_key)
         .unwrap();
+    let raw_root = root.to_raw().unwrap();
 
     let mut tuf =
-        Tuf::<Json>::from_root_with_trusted_keys(root, 1, once(root_key.public())).unwrap();
+        Tuf::<Json>::from_root_with_trusted_keys(&raw_root, 1, once(root_key.public())).unwrap();
 
     //// build the snapshot and timestamp ////
 
@@ -51,14 +52,16 @@ fn simple_delegation() {
         )
         .signed::<Json>(&snapshot_key)
         .unwrap();
+    let raw_snapshot = snapshot.to_raw().unwrap();
 
     let timestamp = TimestampMetadataBuilder::from_snapshot(&snapshot, &[HashAlgorithm::Sha256])
         .unwrap()
         .signed::<Json>(&timestamp_key)
         .unwrap();
+    let raw_timestamp = timestamp.to_raw().unwrap();
 
-    tuf.update_timestamp(timestamp).unwrap();
-    tuf.update_snapshot(snapshot).unwrap();
+    tuf.update_timestamp(&raw_timestamp).unwrap();
+    tuf.update_snapshot(&raw_snapshot).unwrap();
 
     //// build the targets ////
     let delegations = Delegations::new(
@@ -83,8 +86,9 @@ fn simple_delegation() {
         .delegations(delegations)
         .signed::<Json>(&targets_key)
         .unwrap();
+    let raw_targets = targets.to_raw().unwrap();
 
-    tuf.update_targets(targets).unwrap();
+    tuf.update_targets(&raw_targets).unwrap();
 
     //// build the delegation ////
     let target_file: &[u8] = b"bar";
@@ -97,11 +101,12 @@ fn simple_delegation() {
         .unwrap()
         .signed::<Json>(&delegation_key)
         .unwrap();
+    let raw_delegation = delegation.to_raw().unwrap();
 
     tuf.update_delegation(
         &MetadataPath::from_role(&Role::Targets),
         &MetadataPath::new("delegation").unwrap(),
-        delegation,
+        &raw_delegation,
     )
     .unwrap();
 
@@ -128,9 +133,10 @@ fn nested_delegation() {
         .timestamp_key(timestamp_key.public().clone())
         .signed::<Json>(&root_key)
         .unwrap();
+    let raw_root = root.to_raw().unwrap();
 
     let mut tuf =
-        Tuf::<Json>::from_root_with_trusted_keys(root, 1, once(root_key.public())).unwrap();
+        Tuf::<Json>::from_root_with_trusted_keys(&raw_root, 1, once(root_key.public())).unwrap();
 
     //// build the snapshot and timestamp ////
 
@@ -149,14 +155,16 @@ fn nested_delegation() {
         )
         .signed::<Json>(&snapshot_key)
         .unwrap();
+    let raw_snapshot = snapshot.to_raw().unwrap();
 
     let timestamp = TimestampMetadataBuilder::from_snapshot(&snapshot, &[HashAlgorithm::Sha256])
         .unwrap()
         .signed::<Json>(&timestamp_key)
         .unwrap();
+    let raw_timestamp = timestamp.to_raw().unwrap();
 
-    tuf.update_timestamp(timestamp).unwrap();
-    tuf.update_snapshot(snapshot).unwrap();
+    tuf.update_timestamp(&raw_timestamp).unwrap();
+    tuf.update_snapshot(&raw_snapshot).unwrap();
 
     //// build the targets ////
 
@@ -184,8 +192,9 @@ fn nested_delegation() {
         .delegations(delegations)
         .signed::<Json>(&targets_key)
         .unwrap();
+    let raw_targets = targets.to_raw().unwrap();
 
-    tuf.update_targets(targets).unwrap();
+    tuf.update_targets(&raw_targets).unwrap();
 
     //// build delegation A ////
 
@@ -206,11 +215,12 @@ fn nested_delegation() {
         .delegations(delegations)
         .signed::<Json>(&delegation_a_key)
         .unwrap();
+    let raw_delegation = delegation.to_raw().unwrap();
 
     tuf.update_delegation(
         &MetadataPath::from_role(&Role::Targets),
         &MetadataPath::new("delegation-a").unwrap(),
-        delegation,
+        &raw_delegation,
     )
     .unwrap();
 
@@ -227,11 +237,12 @@ fn nested_delegation() {
         .unwrap()
         .signed::<Json>(&delegation_b_key)
         .unwrap();
+    let raw_delegation = delegation.to_raw().unwrap();
 
     tuf.update_delegation(
         &MetadataPath::new("delegation-a").unwrap(),
         &MetadataPath::new("delegation-b").unwrap(),
-        delegation,
+        &raw_delegation,
     )
     .unwrap();
 
@@ -259,9 +270,10 @@ fn rejects_bad_delegation_signatures() {
         .timestamp_key(timestamp_key.public().clone())
         .signed::<Json>(&root_key)
         .unwrap();
+    let raw_root = root.to_raw().unwrap();
 
     let mut tuf =
-        Tuf::<Json>::from_root_with_trusted_keys(root, 1, once(root_key.public())).unwrap();
+        Tuf::<Json>::from_root_with_trusted_keys(&raw_root, 1, once(root_key.public())).unwrap();
 
     //// build the snapshot and timestamp ////
 
@@ -276,14 +288,16 @@ fn rejects_bad_delegation_signatures() {
         )
         .signed::<Json>(&snapshot_key)
         .unwrap();
+    let raw_snapshot = snapshot.to_raw().unwrap();
 
     let timestamp = TimestampMetadataBuilder::from_snapshot(&snapshot, &[HashAlgorithm::Sha256])
         .unwrap()
         .signed::<Json>(&timestamp_key)
         .unwrap();
+    let raw_timestamp = timestamp.to_raw().unwrap();
 
-    tuf.update_timestamp(timestamp).unwrap();
-    tuf.update_snapshot(snapshot).unwrap();
+    tuf.update_timestamp(&raw_timestamp).unwrap();
+    tuf.update_snapshot(&raw_snapshot).unwrap();
 
     //// build the targets ////
     let delegations = Delegations::new(
@@ -308,8 +322,9 @@ fn rejects_bad_delegation_signatures() {
         .delegations(delegations)
         .signed::<Json>(&targets_key)
         .unwrap();
+    let raw_targets = targets.to_raw().unwrap();
 
-    tuf.update_targets(targets).unwrap();
+    tuf.update_targets(&raw_targets).unwrap();
 
     //// build the delegation ////
     let target_file: &[u8] = b"bar";
@@ -322,12 +337,13 @@ fn rejects_bad_delegation_signatures() {
         .unwrap()
         .signed::<Json>(&bad_delegation_key)
         .unwrap();
+    let raw_delegation = delegation.to_raw().unwrap();
 
     assert_matches!(
         tuf.update_delegation(
             &MetadataPath::from_role(&Role::Targets),
             &MetadataPath::new("delegation").unwrap(),
-            delegation
+            &raw_delegation
         ),
         Err(Error::VerificationFailure(_))
     );
@@ -371,9 +387,10 @@ fn diamond_delegation() {
         .timestamp_key(etc_key.public().clone())
         .signed::<Json>(&etc_key)
         .unwrap();
+    let raw_root = root.to_raw().unwrap();
 
     let mut tuf =
-        Tuf::<Json>::from_root_with_trusted_keys(root, 1, once(etc_key.public())).unwrap();
+        Tuf::<Json>::from_root_with_trusted_keys(&raw_root, 1, once(etc_key.public())).unwrap();
 
     //// build the snapshot and timestamp ////
 
@@ -396,14 +413,16 @@ fn diamond_delegation() {
         )
         .signed::<Json>(&etc_key)
         .unwrap();
+    let raw_snapshot = snapshot.to_raw().unwrap();
 
     let timestamp = TimestampMetadataBuilder::from_snapshot(&snapshot, &[HashAlgorithm::Sha256])
         .unwrap()
         .signed::<Json>(&etc_key)
         .unwrap();
+    let raw_timestamp = timestamp.to_raw().unwrap();
 
-    tuf.update_timestamp(timestamp).unwrap();
-    tuf.update_snapshot(snapshot).unwrap();
+    tuf.update_timestamp(&raw_timestamp).unwrap();
+    tuf.update_snapshot(&raw_snapshot).unwrap();
 
     //// build the targets ////
 
@@ -448,8 +467,9 @@ fn diamond_delegation() {
         .delegations(delegations)
         .signed::<Json>(&targets_key)
         .unwrap();
+    let raw_targets = targets.to_raw().unwrap();
 
-    tuf.update_targets(targets).unwrap();
+    tuf.update_targets(&raw_targets).unwrap();
 
     //// build delegation A ////
 
@@ -470,11 +490,12 @@ fn diamond_delegation() {
         .delegations(delegations)
         .signed::<Json>(&delegation_a_key)
         .unwrap();
+    let raw_delegation = delegation.to_raw().unwrap();
 
     tuf.update_delegation(
         &MetadataPath::from_role(&Role::Targets),
         &MetadataPath::new("delegation-a").unwrap(),
-        delegation,
+        &raw_delegation,
     )
     .unwrap();
 
@@ -498,11 +519,12 @@ fn diamond_delegation() {
         .delegations(delegations)
         .signed::<Json>(&delegation_b_key)
         .unwrap();
+    let raw_delegation = delegation.to_raw().unwrap();
 
     tuf.update_delegation(
         &MetadataPath::from_role(&Role::Targets),
         &MetadataPath::new("delegation-b").unwrap(),
-        delegation,
+        &raw_delegation,
     )
     .unwrap();
 
@@ -526,13 +548,14 @@ fn diamond_delegation() {
         .unwrap()
         .signed::<Json>(&delegation_c_key)
         .unwrap();
+    let raw_delegation = delegation.to_raw().unwrap();
 
     //// Verify delegation-c is valid, but only when updated through delegation-a.
 
     tuf.update_delegation(
         &MetadataPath::new("delegation-a").unwrap(),
         &MetadataPath::new("delegation-c").unwrap(),
-        delegation.clone(),
+        &raw_delegation,
     )
     .unwrap();
 
@@ -540,7 +563,7 @@ fn diamond_delegation() {
         tuf.update_delegation(
             &MetadataPath::new("delegation-b").unwrap(),
             &MetadataPath::new("delegation-c").unwrap(),
-            delegation
+            &raw_delegation
         ),
         Err(Error::VerificationFailure(_))
     );

--- a/tests/interop/main.rs
+++ b/tests/interop/main.rs
@@ -216,7 +216,7 @@ async fn extract_keys(dir: &Path) -> Vec<PublicKey> {
         .unwrap();
     reader.read_to_end(&mut buf).await.unwrap();
     let metadata = RawSignedMetadata::<Json, RootMetadata>::new(buf)
-        .parse()
+        .parse_untrusted()
         .unwrap()
         .assume_valid()
         .unwrap();


### PR DESCRIPTION
This rewrites rust-tuf to be more strict on when metadata is deserialized. This is to start laying the groundwork to prevent rust-tuf from being vulnerable to parser exploits (like [CVE-2017-18349]). Almost all deserialization is moved into the new `verify.rs` module, which validates the metadata's signature before returning the deserialized metadata to the caller.

There are two remaining cases where metadata is parsed outside of `verify`:

* `Client::from_trusted_local`, where we don't have any keys to establish trust of the initial root metadata.
* `Client::update_root`, where we fetch the latest root metadata, and walk from the current trusted metadata version to the latest root metadata version.

These are explicitly called out with WARNING comments.

Also, this starts incorporating the TUF workflow spec into the `Tuf` functionality, in order to help reviewers understand which code is implementing which part of the spec, or make it obvious when we diverge from it.

Bug: #291

[CVE-2017-18349]: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-18349