### PR TITLE
Make RepositoryStorage object-safe

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -178,7 +178,7 @@ where
     /// local.store_metadata(
     ///     &root_path,
     ///     &root_version,
-    ///     root.to_raw().unwrap().as_bytes()
+    ///     &mut root.to_raw().unwrap().as_bytes()
     /// ).await?;
     ///
     /// let client = Client::with_trusted_local(
@@ -321,7 +321,7 @@ where
     /// remote.store_metadata(
     ///     &root_path,
     ///     &root_version,
-    ///     root.to_raw().unwrap().as_bytes()
+    ///     &mut root.to_raw().unwrap().as_bytes()
     /// ).await?;
     ///
     /// let client = Client::with_trusted_root_keys(
@@ -644,8 +644,8 @@ where
 
     /// Fetch a target from the remote repo and write it to the local repo.
     pub async fn fetch_target<'a>(&'a mut self, target: &'a TargetPath) -> Result<()> {
-        let read = self._fetch_target(target).await?;
-        self.local.store_target(read, target).await
+        let mut read = self._fetch_target(target).await?;
+        self.local.store_target(&mut read, target).await
     }
 
     /// Fetch a target from the remote repo and write it to the provided writer.

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -92,6 +92,13 @@ where
 {
 }
 
+impl<D, T> RepositoryStorageProvider<D> for T
+where
+    D: DataInterchange + Sync,
+    T: RepositoryStorage<D> + RepositoryProvider<D>,
+{
+}
+
 impl<T, D> RepositoryProvider<D> for &T
 where
     T: RepositoryProvider<D>,
@@ -139,12 +146,6 @@ where
     }
 }
 
-impl<T, D> RepositoryStorageProvider<D> for &T
-where
-    T: RepositoryStorage<D> + RepositoryProvider<D>,
-    D: DataInterchange + Sync,
-{
-}
 
 impl<T, D> RepositoryStorage<D> for Box<T>
 where
@@ -191,13 +192,6 @@ where
     ) -> BoxFuture<'a, Result<Box<dyn AsyncRead + Send + Unpin>>> {
         (**self).fetch_target(target_path, target_description)
     }
-}
-
-impl<T, D> RepositoryStorageProvider<D> for Box<T>
-where
-    T: RepositoryStorage<D> + RepositoryProvider<D> + ?Sized,
-    D: DataInterchange + Sync,
-{
 }
 
 /// A wrapper around an implementation of [`RepositoryProvider`] and/or [`RepositoryStorage`] tied

--- a/src/repository/ephemeral.rs
+++ b/src/repository/ephemeral.rs
@@ -12,7 +12,7 @@ use crate::crypto::{HashAlgorithm, HashValue};
 use crate::error::Error;
 use crate::interchange::DataInterchange;
 use crate::metadata::{MetadataPath, MetadataVersion, TargetDescription, TargetPath};
-use crate::repository::{RepositoryProvider, RepositoryStorage, RepositoryStorageProvider};
+use crate::repository::{RepositoryProvider, RepositoryStorage};
 use crate::Result;
 
 type ArcHashMap<K, V> = Arc<RwLock<HashMap<K, V>>>;
@@ -135,8 +135,6 @@ where
     }
 }
 
-impl<D> RepositoryStorageProvider<D> for EphemeralRepository<D> where D: DataInterchange + Sync {}
-
 #[cfg(test)]
 mod test {
     use super::*;
@@ -147,6 +145,7 @@ mod test {
     fn ephemeral_repo_targets() {
         block_on(async {
             let repo = EphemeralRepository::<Json>::new();
+
             let data: &[u8] = b"like tears in the rain";
             let target_description =
                 TargetDescription::from_reader(data, &[HashAlgorithm::Sha256]).unwrap();

--- a/src/repository/file_system.rs
+++ b/src/repository/file_system.rs
@@ -13,7 +13,7 @@ use crate::crypto::{HashAlgorithm, HashValue};
 use crate::error::Error;
 use crate::interchange::DataInterchange;
 use crate::metadata::{MetadataPath, MetadataVersion, TargetDescription, TargetPath};
-use crate::repository::{RepositoryProvider, RepositoryStorage, RepositoryStorageProvider};
+use crate::repository::{RepositoryProvider, RepositoryStorage};
 use crate::Result;
 
 /// A builder to create a repository contained on the local file system.
@@ -197,8 +197,6 @@ where
         .boxed()
     }
 }
-
-impl<D> RepositoryStorageProvider<D> for FileSystemRepository<D> where D: DataInterchange + Sync {}
 
 fn create_temp_file(path: &Path) -> Result<NamedTempFile> {
     // We want to atomically write the file to make sure clients can never see a partially written

--- a/tests/metadata/generate.rs
+++ b/tests/metadata/generate.rs
@@ -116,14 +116,14 @@ async fn update_root(
     repo.store_metadata(
         &root_path,
         &MetadataVersion::Number(version),
-        root.to_raw().unwrap().as_bytes(),
+        &mut root.to_raw().unwrap().as_bytes(),
     )
     .await
     .unwrap();
     repo.store_metadata(
         &root_path,
         &MetadataVersion::None,
-        root.to_raw().unwrap().as_bytes(),
+        &mut root.to_raw().unwrap().as_bytes(),
     )
     .await
     .unwrap();
@@ -178,7 +178,9 @@ async fn add_target(
         step.to_string()
     };
     let target_path = TargetPath::new(target_str.into()).unwrap();
-    repo.store_target(target_data, &target_path).await.unwrap();
+    repo.store_target(&mut &*target_data, &target_path)
+        .await
+        .unwrap();
 
     let version_prefix = if consistent_snapshot {
         MetadataVersion::Number(version)
@@ -189,7 +191,7 @@ async fn add_target(
     repo.store_metadata(
         &targets_path,
         &version_prefix,
-        signed_targets.to_raw().unwrap().as_bytes(),
+        &mut signed_targets.to_raw().unwrap().as_bytes(),
     )
     .await
     .unwrap();
@@ -206,7 +208,7 @@ async fn add_target(
     repo.store_metadata(
         &snapshot_path,
         &version_prefix,
-        snapshot.to_raw().unwrap().as_bytes(),
+        &mut snapshot.to_raw().unwrap().as_bytes(),
     )
     .await
     .unwrap();
@@ -223,7 +225,7 @@ async fn add_target(
     repo.store_metadata(
         &timestamp_path,
         &MetadataVersion::None,
-        timestamp.to_raw().unwrap().as_bytes(),
+        &mut timestamp.to_raw().unwrap().as_bytes(),
     )
     .await
     .unwrap();

--- a/tests/simple_example.rs
+++ b/tests/simple_example.rs
@@ -135,14 +135,14 @@ where
         .store_metadata(
             &root_path,
             &MetadataVersion::Number(1),
-            signed.to_raw().unwrap().as_bytes(),
+            &mut signed.to_raw().unwrap().as_bytes(),
         )
         .await?;
     remote
         .store_metadata(
             &root_path,
             &MetadataVersion::None,
-            signed.to_raw().unwrap().as_bytes(),
+            &mut signed.to_raw().unwrap().as_bytes(),
         )
         .await?;
 
@@ -158,9 +158,11 @@ where
     if consistent_snapshot {
         let (_, value) = crypto::hash_preference(target_description.hashes())?;
         let hash_prefixed_path = target_path.with_hash_prefix(&value)?;
-        let _ = remote.store_target(target_file, &hash_prefixed_path).await;
+        let _ = remote
+            .store_target(&mut &*target_file, &hash_prefixed_path)
+            .await;
     } else {
-        let _ = remote.store_target(target_file, &target_path).await;
+        let _ = remote.store_target(&mut &*target_file, &target_path).await;
     };
 
     let targets = TargetsMetadataBuilder::new()
@@ -175,14 +177,14 @@ where
         .store_metadata(
             &targets_path,
             &MetadataVersion::Number(1),
-            targets.to_raw().unwrap().as_bytes(),
+            &mut targets.to_raw().unwrap().as_bytes(),
         )
         .await?;
     remote
         .store_metadata(
             &targets_path,
             &MetadataVersion::None,
-            targets.to_raw().unwrap().as_bytes(),
+            &mut targets.to_raw().unwrap().as_bytes(),
         )
         .await?;
 
@@ -197,14 +199,14 @@ where
         .store_metadata(
             &snapshot_path,
             &MetadataVersion::Number(1),
-            snapshot.to_raw().unwrap().as_bytes(),
+            &mut snapshot.to_raw().unwrap().as_bytes(),
         )
         .await?;
     remote
         .store_metadata(
             &snapshot_path,
             &MetadataVersion::None,
-            snapshot.to_raw().unwrap().as_bytes(),
+            &mut snapshot.to_raw().unwrap().as_bytes(),
         )
         .await?;
 
@@ -218,14 +220,14 @@ where
         .store_metadata(
             &timestamp_path,
             &MetadataVersion::Number(1),
-            timestamp.to_raw().unwrap().as_bytes(),
+            &mut timestamp.to_raw().unwrap().as_bytes(),
         )
         .await?;
     remote
         .store_metadata(
             &timestamp_path,
             &MetadataVersion::None,
-            timestamp.to_raw().unwrap().as_bytes(),
+            &mut timestamp.to_raw().unwrap().as_bytes(),
         )
         .await?;
 


### PR DESCRIPTION
This changes the `RepositoryStorage` type to be object-safe by passing in the `AsyncRead` argument as a `&mut dyn AsyncRead`. Furthermore, Rust doesn't allow for a type like `Box<dyn A + B>`. So in order to make the `Repository` struct take a dyn boxed repository, this patch also adds a trait `RepositoryStorageProvider`, which has as a super trait `RepositoryStorage` and `RepositoryProvider`.

Test: Updated all the tests to work with this, and added a test to make sure these traits stay object-safe.