### PR TITLE
Change update_root to follow TUF-1.0.9 section 5.1

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -478,6 +478,11 @@ where
             //     exact number is as yet unknown), then go to step 5.1.9. The value for Y is set
             //     by the authors of the application using TUF. For example, Y may be 2^10.
 
+            // FIXME(#306) We do not have an upper bound on the number of root metadata we'll
+            // fetch. This means that an attacker that's stolen the root keys could cause a client
+            // to fall into an infinite loop (but if an attacker has stolen the root keys, the
+            // client probably has worse problems to worry about).
+
             let next_version = MetadataVersion::Number(self.tuf.trusted_root().version() + 1);
             let res = self
                 .remote

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -22,6 +22,11 @@ pub use self::http::{HttpRepository, HttpRepositoryBuilder};
 mod ephemeral;
 pub use self::ephemeral::EphemeralRepository;
 
+#[cfg(test)]
+mod track_repo;
+#[cfg(test)]
+pub(crate) use self::track_repo::{Track, TrackRepository};
+
 /// A readable TUF repository.
 pub trait RepositoryProvider<D>
 where

--- a/src/repository/track_repo.rs
+++ b/src/repository/track_repo.rs
@@ -1,0 +1,165 @@
+use {
+    crate::{
+        crypto::{HashAlgorithm, HashValue},
+        interchange::DataInterchange,
+        metadata::{MetadataPath, MetadataVersion, TargetDescription, TargetPath},
+        repository::{RepositoryProvider, RepositoryStorage},
+        Result,
+    },
+    futures_io::AsyncRead,
+    futures_util::{
+        future::{BoxFuture, FutureExt},
+        io::{AsyncReadExt, Cursor},
+    },
+    parking_lot::Mutex,
+    std::sync::Arc,
+};
+
+#[derive(Debug, PartialEq)]
+pub(crate) enum Track {
+    Store {
+        path: MetadataPath,
+        version: MetadataVersion,
+        metadata: String,
+    },
+    FetchFound {
+        path: MetadataPath,
+        version: MetadataVersion,
+        metadata: String,
+    },
+    FetchErr(MetadataPath, MetadataVersion),
+}
+
+impl Track {
+    pub(crate) fn store<T>(meta_path: &MetadataPath, version: &MetadataVersion, metadata: T) -> Self
+    where
+        T: Into<Vec<u8>>,
+    {
+        Track::Store {
+            path: meta_path.clone(),
+            version: version.clone(),
+            metadata: String::from_utf8(metadata.into()).unwrap(),
+        }
+    }
+
+    pub(crate) fn fetch_found<T>(
+        meta_path: &MetadataPath,
+        version: &MetadataVersion,
+        metadata: T,
+    ) -> Self
+    where
+        T: Into<Vec<u8>>,
+    {
+        Track::FetchFound {
+            path: meta_path.clone(),
+            version: version.clone(),
+            metadata: String::from_utf8(metadata.into()).unwrap(),
+        }
+    }
+}
+
+/// Helper Repository wrapper that tracks all the fetches and stores for testing purposes.
+pub(crate) struct TrackRepository<R> {
+    repo: R,
+    tracks: Arc<Mutex<Vec<Track>>>,
+}
+
+impl<R> TrackRepository<R> {
+    pub(crate) fn new(repo: R) -> Self {
+        Self {
+            repo,
+            tracks: Arc::new(Mutex::new(vec![])),
+        }
+    }
+
+    pub(crate) fn take_tracks(&self) -> Vec<Track> {
+        self.tracks.lock().drain(..).collect()
+    }
+}
+
+impl<D, R> RepositoryStorage<D> for TrackRepository<R>
+where
+    R: RepositoryStorage<D> + Sync + Send,
+    D: DataInterchange + Sync,
+{
+    fn store_metadata<'a>(
+        &'a self,
+        meta_path: &'a MetadataPath,
+        version: &'a MetadataVersion,
+        metadata: &'a mut (dyn AsyncRead + Send + Unpin + 'a),
+    ) -> BoxFuture<'a, Result<()>> {
+        async move {
+            let mut buf = Vec::new();
+            metadata.read_to_end(&mut buf).await?;
+
+            let () = self
+                .repo
+                .store_metadata(meta_path, version, &mut buf.as_slice())
+                .await?;
+
+            self.tracks
+                .lock()
+                .push(Track::store(meta_path, version, buf));
+
+            Ok(())
+        }
+        .boxed()
+    }
+
+    fn store_target<'a>(
+        &'a self,
+        target: &'a mut (dyn AsyncRead + Send + Unpin + 'a),
+        target_path: &'a TargetPath,
+    ) -> BoxFuture<'a, Result<()>> {
+        self.repo.store_target(target, target_path)
+    }
+}
+
+impl<D, R> RepositoryProvider<D> for TrackRepository<R>
+where
+    D: DataInterchange + Sync,
+    R: RepositoryProvider<D> + Sync,
+{
+    fn fetch_metadata<'a>(
+        &'a self,
+        meta_path: &'a MetadataPath,
+        version: &'a MetadataVersion,
+        max_length: Option<usize>,
+        hash_data: Option<(&'static HashAlgorithm, HashValue)>,
+    ) -> BoxFuture<'a, Result<Box<dyn AsyncRead + Send + Unpin>>> {
+        async move {
+            let fut = self
+                .repo
+                .fetch_metadata(meta_path, version, max_length, hash_data);
+            match fut.await {
+                Ok(mut rdr) => {
+                    let mut buf = Vec::new();
+                    rdr.read_to_end(&mut buf).await?;
+
+                    self.tracks
+                        .lock()
+                        .push(Track::fetch_found(meta_path, version, buf.clone()));
+
+                    let rdr: Box<dyn AsyncRead + Send + Unpin> = Box::new(Cursor::new(buf));
+
+                    Ok(rdr)
+                }
+                Err(err) => {
+                    self.tracks
+                        .lock()
+                        .push(Track::FetchErr(meta_path.clone(), version.clone()));
+                    Err(err)
+                }
+            }
+        }
+        .boxed()
+    }
+
+    fn fetch_target<'a>(
+        &'a self,
+        target_path: &'a TargetPath,
+        target_description: &'a TargetDescription,
+    ) -> BoxFuture<'a, Result<Box<dyn AsyncRead + Send + Unpin>>> {
+        self.repo.fetch_target(target_path, target_description)
+    }
+}

--- a/src/repository/track_repo.rs
+++ b/src/repository/track_repo.rs
@@ -58,7 +58,7 @@ impl Track {
     }
 }
 
-/// Helper Repository wrapper that tracks all the fetches and stores for testing purposes.
+/// Helper Repository wrapper that tracks all the metadata fetches and stores for testing purposes.
 pub(crate) struct TrackRepository<R> {
     repo: R,
     tracks: Arc<Mutex<Vec<Track>>>,

--- a/src/tuf.rs
+++ b/src/tuf.rs
@@ -189,10 +189,9 @@ impl<D: DataInterchange> Tuf<D> {
             //     discard it, abort the update cycle, and report the rollback attack. On the next
             //     update cycle, begin at step 0 and version N of the root metadata file.
 
-            let next_root_version = trusted_root
-                .version()
-                .checked_add(1)
-                .expect("root version should be less than max u32");
+            let next_root_version = trusted_root.version().checked_add(1).ok_or_else(|| {
+                Error::VerificationFailure(format!("root version should be less than max u32"))
+            })?;
 
             if new_root.version() != next_root_version {
                 return Err(Error::VerificationFailure(format!(


### PR DESCRIPTION
This switches Client::update_root to follow TUF-1.0.9 section 5.1 to update the root metadata. It now will fetch root N+1 until it receives a not-found error.

Test: This behavior is checked by the current tests. We could add a new test that makes sure we don't fetch `root.json`, but I'm not sure we get much value from a test like that.