### PR TITLE
Remove MetadataVersion::Hash

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -874,8 +874,21 @@ where
                 Err(e) => return (delegation.terminating(), Err(e)),
             };
 
+            /////////////////////////////////////////
+            // TUF-1.0.9 §5.4:
+            //
+            //     Download the top-level targets metadata file, up to either the number of bytes
+            //     specified in the snapshot metadata file, or some Z number of bytes. The value
+            //     for Z is set by the authors of the application using TUF. For example, Z may be
+            //     tens of kilobytes. If consistent snapshots are not used (see Section 7), then
+            //     the filename used to download the targets metadata file is of the fixed form
+            //     FILENAME.EXT (e.g., targets.json). Otherwise, the filename is of the form
+            //     VERSION_NUMBER.FILENAME.EXT (e.g., 42.targets.json), where VERSION_NUMBER is the
+            //     version number of the targets metadata file listed in the snapshot metadata
+            //     file.
+
             let version = if self.tuf.trusted_root().consistent_snapshot() {
-                MetadataVersion::Hash(value.clone())
+                MetadataVersion::Number(role_meta.version())
             } else {
                 MetadataVersion::None
             };

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -211,8 +211,6 @@ pub enum MetadataVersion {
     None,
     /// The metadata is addressed by a specific version number.
     Number(u32),
-    /// The metadata is addressed by a hash prefix. Used with TUF's consistent snapshot feature.
-    Hash(HashValue),
 }
 
 impl MetadataVersion {
@@ -221,7 +219,6 @@ impl MetadataVersion {
         match *self {
             MetadataVersion::None => String::new(),
             MetadataVersion::Number(ref x) => format!("{}.", x),
-            MetadataVersion::Hash(ref v) => format!("{}.", v),
         }
     }
 }
@@ -943,9 +940,6 @@ impl MetadataPath {
     ///            ["foo".to_string(), "bar.json".to_string()]);
     /// assert_eq!(path.components::<Json>(&MetadataVersion::Number(1)),
     ///            ["foo".to_string(), "1.bar.json".to_string()]);
-    /// assert_eq!(path.components::<Json>(
-    ///                 &MetadataVersion::Hash(HashValue::new(vec![0x69, 0xb7, 0x1d]))),
-    ///            ["foo".to_string(), "69b71d.bar.json".to_string()]);
     /// ```
     pub fn components<D>(&self, version: &MetadataVersion) -> Vec<String>
     where


### PR DESCRIPTION
TUF no longer supports prefixing metadata paths by a hash, so this removes support for them.

Closes #254