### PR TITLE
Initialize clients with local metadata

### DIFF
--- a/src/repo_builder.rs
+++ b/src/repo_builder.rs
@@ -159,20 +159,28 @@ where
                 let signed_timestamp = signed_builder.build();
                 let raw_timestamp = signed_timestamp.to_raw()?;
 
-                let targets_version;
-                let snapshot_version;
                 if root.consistent_snapshot() {
-                    targets_version = MetadataVersion::Number(targets.version());
-                    snapshot_version = MetadataVersion::Number(snapshot.version());
-                } else {
-                    targets_version = MetadataVersion::None;
-                    snapshot_version = MetadataVersion::None;
+                    self.repo
+                        .store_metadata(
+                            &MetadataPath::from_role(&Role::Targets),
+                            &MetadataVersion::Number(targets.version()),
+                            &raw_targets,
+                        )
+                        .await?;
+
+                    self.repo
+                        .store_metadata(
+                            &MetadataPath::from_role(&Role::Snapshot),
+                            &MetadataVersion::Number(snapshot.version()),
+                            &raw_snapshot,
+                        )
+                        .await?;
                 }
 
                 self.repo
                     .store_metadata(
                         &MetadataPath::from_role(&Role::Targets),
-                        &targets_version,
+                        &MetadataVersion::None,
                         &raw_targets,
                     )
                     .await?;
@@ -180,7 +188,7 @@ where
                 self.repo
                     .store_metadata(
                         &MetadataPath::from_role(&Role::Snapshot),
-                        &snapshot_version,
+                        &MetadataVersion::None,
                         &raw_snapshot,
                     )
                     .await?;

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -311,7 +311,7 @@ where
     ///
     /// [extension]: crate::interchange::DataInterchange::extension
     pub async fn store_metadata<'a, M>(
-        &'a mut self,
+        &'a self,
         path: &'a MetadataPath,
         version: &'a MetadataVersion,
         metadata: &'a RawSignedMetadata<D, M>,
@@ -328,7 +328,7 @@ where
 
     /// Store the provided `target` in a location identified by `target_path`.
     pub async fn store_target<'a>(
-        &'a mut self,
+        &'a self,
         target: &'a mut (dyn AsyncRead + Send + Unpin + 'a),
         target_path: &'a TargetPath,
     ) -> Result<()> {
@@ -366,7 +366,7 @@ mod test {
     #[test]
     fn repository_rejects_mismatched_path() {
         block_on(async {
-            let mut repo = Repository::<_, Json>::new(EphemeralRepository::new());
+            let repo = Repository::<_, Json>::new(EphemeralRepository::new());
             let fake_metadata = RawSignedMetadata::<Json, RootMetadata>::new(vec![]);
 
             repo.store_metadata(
@@ -509,7 +509,7 @@ mod test {
     fn repository_rejects_corrupt_targets() {
         block_on(async {
             let repo = EphemeralRepository::new();
-            let mut client = Repository::<_, Json>::new(repo);
+            let client = Repository::<_, Json>::new(repo);
 
             let data: &[u8] = b"like tears in the rain";
             let target_description =
@@ -540,7 +540,7 @@ mod test {
         block_on(async {
             let repo: Box<dyn RepositoryStorageProvider<Json>> =
                 Box::new(EphemeralRepository::new());
-            let mut client = Repository::<_, Json>::new(Box::new(repo));
+            let client = Repository::<_, Json>::new(Box::new(repo));
 
             let data: &[u8] = b"like tears in the rain";
             let target_description =


### PR DESCRIPTION
This updates the `tuf::Client` constructors to load the initial metadata from the local repository. It does this by refactoring `Client` to support updating from arbitrary repositories, and optionally writing the metadata back to the local repository (since during initialization we don't want to write back what we just read). One thing to note is that all but the root metadata is stored unversioned, so during initialization we are treating things as if consistent_snapshots is false.

In order to do this, this also changes `tuf::Repository::store_{metadata,targets` to take `&self`.

Test: This adds a few tests to check this behavior.
* Check that using all client constructors will load metadata during initialization.
* Check that we ignore errors if local metadata is missing, expired, or malformed.
* Check that we won't try to load metadata from the local repository after client initialization.

Closes #301