### PR TITLE
Add Error::BadHttpStatus to expose http status codes

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -31,7 +31,7 @@ pub enum Error {
     #[error("http: {0}")]
     Http(http::Error),
 
-    /// Unexpected error
+    /// Unexpected HTTP response status.
     #[error("error getting {uri}: request failed with status code {code}")]
     BadHttpStatus {
         /// HTTP status code.

--- a/src/error.rs
+++ b/src/error.rs
@@ -31,6 +31,16 @@ pub enum Error {
     #[error("http: {0}")]
     Http(http::Error),
 
+    /// Unexpected error
+    #[error("error getting {uri}: request failed with status code {code}")]
+    BadHttpStatus {
+        /// HTTP status code.
+        code: http::StatusCode,
+
+        /// URI Resource that resulted in the error.
+        uri: String,
+    },
+
     /// Errors that can occur parsing HTTP streams.
     #[error("hyper: {0}")]
     Hyper(hyper::Error),

--- a/src/repository/http.rs
+++ b/src/repository/http.rs
@@ -217,7 +217,7 @@ where
         let uri = extend_uri(base_uri, prefix, components)?;
 
         let req = Request::builder()
-            .uri(uri)
+            .uri(&uri)
             .header("User-Agent", &*self.user_agent)
             .body(Body::default())?;
 
@@ -230,7 +230,7 @@ where
             } else {
                 Err(Error::BadHttpStatus {
                     code: status,
-                    uri: self.uri.to_string(),
+                    uri: uri.to_string(),
                 })
             }
         } else {

--- a/src/repository/http.rs
+++ b/src/repository/http.rs
@@ -228,10 +228,10 @@ where
             if status == StatusCode::NOT_FOUND {
                 Err(Error::NotFound)
             } else {
-                Err(Error::Opaque(format!(
-                    "Error getting {:?}: {:?}",
-                    self.uri, resp
-                )))
+                Err(Error::BadHttpStatus {
+                    code: status,
+                    uri: self.uri.to_string(),
+                })
             }
         } else {
             Ok(resp)


### PR DESCRIPTION
This switches the http repository from returning an `Opaque` error into returning BadHttpStatus, which allows clients to perform structured logging when a remote server returns a variety of HTTP status codes.