### PR TITLE
HttpRepository::get only works with 200

### DIFF
--- a/src/repository/http.rs
+++ b/src/repository/http.rs
@@ -224,17 +224,15 @@ where
         let resp = self.client.request(req).await?;
         let status = resp.status();
 
-        if !status.is_success() {
-            if status == StatusCode::NOT_FOUND {
-                Err(Error::NotFound)
-            } else {
-                Err(Error::BadHttpStatus {
-                    code: status,
-                    uri: uri.to_string(),
-                })
-            }
-        } else {
+        if status == StatusCode::OK {
             Ok(resp)
+        } else if status == StatusCode::NOT_FOUND {
+            Err(Error::NotFound)
+        } else {
+            Err(Error::BadHttpStatus {
+                code: status,
+                uri: uri.to_string(),
+            })
         }
     }
 }


### PR DESCRIPTION
Some of the HTTP success status codes don't actually make sense with `HttpRepository`, like "204 No Content". As implemented, this would result in strange decoding errors further in the update workflow. Instead, this patch changes `HttpRepository::get` to only successfully return `Ok(resp)` if the status is 200.