### PR TITLE
Add accessor methods for trusted metadata to Client

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -2184,6 +2184,7 @@ mod test {
             assert_matches!(client.update().await, Ok(false));
         });
     }
+    
     #[test]
     fn with_trusted_methods_return_correct_metadata() {
         block_on(async {


### PR DESCRIPTION
This adds some accessor methods to Client that provide access to the `Tuf::trusted_*` fields.

We currently need access to the TUF metadata and we do this now by reading the JSON directly. This is problematic because we can't be certain the metadata is valid when reading it. 

Here's the example flow of where we do this now (soon to be rewritten in Rust): https://cs.opensource.google/fuchsia/fuchsia/+/master:src/sys/pkg/bin/pm/pmhttp/config.go;l=96.