### PR TITLE
Make `Client::update_root()` public

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -474,8 +474,10 @@ where
         self.tuf.trusted_delegations()
     }
 
+    /// Update TUF root metadata from the remote repository.
+    ///
     /// Returns `true` if an update occurred and `false` otherwise.
-    async fn update_root(&mut self) -> Result<bool> {
+    pub async fn update_root(&mut self) -> Result<bool> {
         Self::update_root_with_repos(&self.config, &mut self.tuf, Some(&self.local), &self.remote)
             .await
     }


### PR DESCRIPTION
Users of `Client::trusted_root()` might only care about the latest root
metadata, and none of the other metadata, but unfortunately the only way
to get get the latest root is to call `Client::update()`, which downloads
all the other metadata. This can be a problem because it's likely that the
root metadata has a long expiration, but the other metadata may have expired.

To address this, this exposes `Client::update_root()`, which allows these
users to just make sure the root metadata is up to date, and avoid the risk
of `Client::update()` failing with expired metadata.