### PR TITLE
Bump version to 0.3.0-beta1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tuf"
 edition = "2018"
-version = "0.3.0-alpha3"
+version = "0.3.0-beta1"
 authors = [ "heartsucker <heartsucker@autistici.org>" ]
 description = "Library for The Update Framework (TUF)"
 homepage = "https://github.com/heartsucker/rust-tuf"


### PR DESCRIPTION
rust-tuf has been pretty stable for some time, so I'm planning to cut a
release for HEAD. I'm keeping this as beta1 because before release I
want to factor out hyper into a subcrate before release in order to
allow users to select hyper 0.13.x or 0.14.x.