### PR TITLE
Switch to hyper 0.14.x

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,9 +39,16 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
+          args: ${{ matrix.features }}
+
+      - name: Run Tests with Hyper 0.13
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: "--manifest-path tuf/Cargo.toml --no-default-features --features hyper_013/default"
 
       - name: Generate Docs
         uses: actions-rs/cargo@v1
         with:
           command: doc
-          args: --all-features --no-deps
+          args: --no-deps

--- a/tuf/Cargo.toml
+++ b/tuf/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tuf"
 edition = "2018"
-version = "0.3.0-beta2"
+version = "0.3.0-beta3"
 authors = [ "heartsucker <heartsucker@autistici.org>", "Erick Tryzelaar <etryzelaar@google.com>" ]
 description = "Library for The Update Framework (TUF)"
 homepage = "https://github.com/heartsucker/rust-tuf"
@@ -23,7 +23,8 @@ derp = "0.0.14"
 futures-io = "0.3.1"
 futures-util = { version = "0.3.1", features = [ "io" ] }
 http = "0.2.0"
-hyper = { version = "0.13.2", default-features = false, features = [ "stream" ] }
+hyper_013 = { package = "hyper", version = "0.13.2", default-features = false, features = [ "stream" ], optional = true }
+hyper_014 = { package = "hyper", version = "0.14.15", default-features = false, features = [ "stream", "client", "http1" ], optional = true }
 itoa = "0.4"
 log = "0.4"
 parking_lot = "0.11"
@@ -45,4 +46,4 @@ matches = "0.1.8"
 pretty_assertions = "1"
 
 [features]
-default = ["hyper/default"]
+default = ["hyper_014/tcp"]

--- a/tuf/src/client.rs
+++ b/tuf/src/client.rs
@@ -4,6 +4,10 @@
 //!
 //! ```no_run
 //! # use futures_executor::block_on;
+//! # #[cfg(feature = "hyper_013")]
+//! # use hyper_013 as hyper;
+//! # #[cfg(feature = "hyper_014")]
+//! # use hyper_014 as hyper;
 //! # use hyper::client::Client as HttpClient;
 //! # use std::path::PathBuf;
 //! # use std::str::FromStr;

--- a/tuf/src/error.rs
+++ b/tuf/src/error.rs
@@ -4,6 +4,10 @@ use data_encoding::DecodeError;
 use std::io;
 use std::path::Path;
 use thiserror::Error;
+#[cfg(feature = "hyper_013")]
+use hyper_013 as hyper;
+#[cfg(feature = "hyper_014")]
+use hyper_014 as hyper;
 
 use crate::metadata::Role;
 
@@ -42,6 +46,7 @@ pub enum Error {
     },
 
     /// Errors that can occur parsing HTTP streams.
+    #[cfg(any(feature = "hyper_013", feature = "hyper_014"))]
     #[error("hyper: {0}")]
     Hyper(#[from] hyper::Error),
 

--- a/tuf/src/repository.rs
+++ b/tuf/src/repository.rs
@@ -17,7 +17,10 @@ use std::sync::Arc;
 mod file_system;
 pub use self::file_system::{FileSystemRepository, FileSystemRepositoryBuilder};
 
+#[cfg(any(feature = "hyper_013", feature = "hyper_014"))]
 mod http;
+
+#[cfg(any(feature = "hyper_013", feature = "hyper_014"))]
 pub use self::http::{HttpRepository, HttpRepositoryBuilder};
 
 mod ephemeral;

--- a/tuf/src/repository/http.rs
+++ b/tuf/src/repository/http.rs
@@ -4,6 +4,10 @@ use futures_io::AsyncRead;
 use futures_util::future::{BoxFuture, FutureExt};
 use futures_util::stream::TryStreamExt;
 use http::{Response, StatusCode, Uri};
+#[cfg(feature = "hyper_013")]
+use hyper_013 as hyper;
+#[cfg(feature = "hyper_014")]
+use hyper_014 as hyper;
 use hyper::body::Body;
 use hyper::client::connect::Connect;
 use hyper::Client;


### PR DESCRIPTION
This switches rust-tuf to default to using hyper 0.14.x, but allows users to opt into using hyper 0.13.x by disabling the default features, and enabling the `hyper_013` feature.

Closes #321