### PR TITLE
Remove tuf::client::PathTranslator

### DIFF
--- a/interop-tests/src/lib.rs
+++ b/interop-tests/src/lib.rs
@@ -8,7 +8,7 @@ use tuf::crypto::{Ed25519PrivateKey, HashAlgorithm, KeyType, PrivateKey, Signatu
 use tuf::interchange::JsonPretty;
 use tuf::metadata::{
     MetadataPath, MetadataVersion, Role, RootMetadataBuilder, SnapshotMetadataBuilder, TargetPath,
-    TargetsMetadataBuilder, TimestampMetadataBuilder, VirtualTargetPath,
+    TargetsMetadataBuilder, TimestampMetadataBuilder,
 };
 use tuf::repository::{FileSystemRepository, FileSystemRepositoryBuilder, RepositoryStorage};
 use walkdir::WalkDir;
@@ -174,7 +174,7 @@ async fn add_target(
         let target_data = step_str.as_bytes();
         targets_builder = targets_builder
             .insert_target_from_reader(
-                VirtualTargetPath::new(i.to_string()).unwrap(),
+                TargetPath::new(i.to_string()).unwrap(),
                 target_data,
                 &[HashAlgorithm::Sha256],
             )
@@ -190,7 +190,7 @@ async fn add_target(
 
     let hash = targets
         .targets()
-        .get(&VirtualTargetPath::new(step.to_string()).unwrap())
+        .get(&TargetPath::new(step.to_string()).unwrap())
         .unwrap()
         .hashes()
         .get(&HashAlgorithm::Sha256)

--- a/tuf/src/database.rs
+++ b/tuf/src/database.rs
@@ -10,7 +10,7 @@ use crate::error::Error;
 use crate::interchange::DataInterchange;
 use crate::metadata::{
     Delegations, Metadata, MetadataPath, RawSignedMetadata, Role, RootMetadata, SnapshotMetadata,
-    TargetDescription, TargetsMetadata, TimestampMetadata, VirtualTargetPath,
+    TargetDescription, TargetPath, TargetsMetadata, TimestampMetadata,
 };
 use crate::verify::{self, Verified};
 use crate::Result;
@@ -757,10 +757,10 @@ impl<D: DataInterchange> Database<D> {
     }
 
     /// Get a reference to the description needed to verify the target defined by the given
-    /// `VirtualTargetPath`. Returns an `Error` if the target is not defined in the trusted
+    /// `TargetPath`. Returns an `Error` if the target is not defined in the trusted
     /// metadata. This may mean the target exists somewhere in the metadata, but the chain of trust
     /// to that target may be invalid or incomplete.
-    pub fn target_description(&self, target_path: &VirtualTargetPath) -> Result<TargetDescription> {
+    pub fn target_description(&self, target_path: &TargetPath) -> Result<TargetDescription> {
         let _ = self.trusted_root_unexpired()?;
         let _ = self.trusted_snapshot_unexpired()?;
         let targets = self.trusted_targets_unexpired()?;
@@ -773,9 +773,9 @@ impl<D: DataInterchange> Database<D> {
             tuf: &Database<D>,
             default_terminate: bool,
             current_depth: u32,
-            target_path: &VirtualTargetPath,
+            target_path: &TargetPath,
             delegations: &Delegations,
-            parents: &[HashSet<VirtualTargetPath>],
+            parents: &[HashSet<TargetPath>],
             visited: &mut HashSet<MetadataPath>,
         ) -> (bool, Option<TargetDescription>) {
             for delegation in delegations.roles() {

--- a/tuf/src/interchange/cjson/shims.rs
+++ b/tuf/src/interchange/cjson/shims.rs
@@ -275,7 +275,7 @@ pub struct TargetsMetadata {
     spec_version: String,
     version: u32,
     expires: String,
-    targets: BTreeMap<metadata::VirtualTargetPath, metadata::TargetDescription>,
+    targets: BTreeMap<metadata::TargetPath, metadata::TargetDescription>,
     #[serde(skip_serializing_if = "Option::is_none")]
     delegations: Option<metadata::Delegations>,
 }
@@ -373,7 +373,7 @@ pub struct Delegation {
     threshold: u32,
     #[serde(rename = "keyids")]
     key_ids: Vec<crypto::KeyId>,
-    paths: Vec<metadata::VirtualTargetPath>,
+    paths: Vec<metadata::TargetPath>,
 }
 
 impl Delegation {
@@ -382,7 +382,7 @@ impl Delegation {
             .paths()
             .iter()
             .cloned()
-            .collect::<Vec<metadata::VirtualTargetPath>>();
+            .collect::<Vec<metadata::TargetPath>>();
         paths.sort();
         let mut key_ids = meta
             .key_ids()
@@ -405,7 +405,7 @@ impl Delegation {
             .paths
             .iter()
             .cloned()
-            .collect::<HashSet<metadata::VirtualTargetPath>>();
+            .collect::<HashSet<metadata::TargetPath>>();
         if paths.len() != self.paths.len() {
             return Err(Error::Encoding("Non-unique delegation paths.".into()));
         }

--- a/tuf/src/repository/file_system.rs
+++ b/tuf/src/repository/file_system.rs
@@ -96,8 +96,13 @@ impl<D> FileSystemRepository<D>
 where
     D: DataInterchange,
 {
+    /// Create a [FileSystemRepositoryBuilder].
+    pub fn builder<P: Into<PathBuf>>(local_path: P) -> FileSystemRepositoryBuilder<D> {
+        FileSystemRepositoryBuilder::new(local_path)
+    }
+
     /// Create a new repository on the local file system.
-    pub fn new(local_path: PathBuf) -> Result<Self> {
+    pub fn new<P: Into<PathBuf>>(local_path: P) -> Result<Self> {
         FileSystemRepositoryBuilder::new(local_path)
             .metadata_prefix("metadata")
             .targets_prefix("targets")

--- a/tuf/tests/integration.rs
+++ b/tuf/tests/integration.rs
@@ -5,7 +5,7 @@ use tuf::crypto::{Ed25519PrivateKey, HashAlgorithm, PrivateKey};
 use tuf::interchange::Json;
 use tuf::metadata::{
     Delegation, Delegations, MetadataDescription, MetadataPath, Role, RootMetadataBuilder,
-    SnapshotMetadataBuilder, TargetsMetadataBuilder, TimestampMetadataBuilder, VirtualTargetPath,
+    SnapshotMetadataBuilder, TargetPath, TargetsMetadataBuilder, TimestampMetadataBuilder,
 };
 use tuf::Database;
 use tuf::Error;
@@ -75,7 +75,7 @@ fn simple_delegation() {
                 .iter()
                 .cloned()
                 .collect(),
-            vec![VirtualTargetPath::new("foo".into()).unwrap()]
+            vec![TargetPath::new("foo".into()).unwrap()]
                 .iter()
                 .cloned()
                 .collect(),
@@ -95,7 +95,7 @@ fn simple_delegation() {
     let target_file: &[u8] = b"bar";
     let delegation = TargetsMetadataBuilder::new()
         .insert_target_from_reader(
-            VirtualTargetPath::new("foo".into()).unwrap(),
+            TargetPath::new("foo".into()).unwrap(),
             target_file,
             &[HashAlgorithm::Sha256],
         )
@@ -112,7 +112,7 @@ fn simple_delegation() {
     .unwrap();
 
     assert!(tuf
-        .target_description(&VirtualTargetPath::new("foo".into()).unwrap())
+        .target_description(&TargetPath::new("foo".into()).unwrap())
         .is_ok());
 }
 
@@ -182,7 +182,7 @@ fn nested_delegation() {
                 .iter()
                 .cloned()
                 .collect(),
-            vec![VirtualTargetPath::new("foo".into()).unwrap()]
+            vec![TargetPath::new("foo".into()).unwrap()]
                 .iter()
                 .cloned()
                 .collect(),
@@ -207,7 +207,7 @@ fn nested_delegation() {
             false,
             1,
             vec![delegation_b_key.public().key_id().clone()].iter().cloned().collect(),
-            vec![VirtualTargetPath::new("foo".into()).unwrap()].iter().cloned().collect(),
+            vec![TargetPath::new("foo".into()).unwrap()].iter().cloned().collect(),
         )
         .unwrap()],
     )
@@ -232,7 +232,7 @@ fn nested_delegation() {
 
     let delegation = TargetsMetadataBuilder::new()
         .insert_target_from_reader(
-            VirtualTargetPath::new("foo".into()).unwrap(),
+            TargetPath::new("foo".into()).unwrap(),
             target_file,
             &[HashAlgorithm::Sha256],
         )
@@ -249,7 +249,7 @@ fn nested_delegation() {
     .unwrap();
 
     assert!(tuf
-        .target_description(&VirtualTargetPath::new("foo".into()).unwrap())
+        .target_description(&TargetPath::new("foo".into()).unwrap())
         .is_ok());
 }
 
@@ -312,7 +312,7 @@ fn rejects_bad_delegation_signatures() {
                 .iter()
                 .cloned()
                 .collect(),
-            vec![VirtualTargetPath::new("foo".into()).unwrap()]
+            vec![TargetPath::new("foo".into()).unwrap()]
                 .iter()
                 .cloned()
                 .collect(),
@@ -332,7 +332,7 @@ fn rejects_bad_delegation_signatures() {
     let target_file: &[u8] = b"bar";
     let delegation = TargetsMetadataBuilder::new()
         .insert_target_from_reader(
-            VirtualTargetPath::new("foo".into()).unwrap(),
+            TargetPath::new("foo".into()).unwrap(),
             target_file,
             &[HashAlgorithm::Sha256],
         )
@@ -351,7 +351,7 @@ fn rejects_bad_delegation_signatures() {
     );
 
     assert_matches!(
-        tuf.target_description(&VirtualTargetPath::new("foo".into()).unwrap()),
+        tuf.target_description(&TargetPath::new("foo".into()).unwrap()),
         Err(Error::TargetUnavailable)
     );
 }
@@ -443,7 +443,7 @@ fn diamond_delegation() {
                     .iter()
                     .cloned()
                     .collect(),
-                vec![VirtualTargetPath::new("foo".into()).unwrap()]
+                vec![TargetPath::new("foo".into()).unwrap()]
                     .iter()
                     .cloned()
                     .collect(),
@@ -457,7 +457,7 @@ fn diamond_delegation() {
                     .iter()
                     .cloned()
                     .collect(),
-                vec![VirtualTargetPath::new("bar".into()).unwrap()]
+                vec![TargetPath::new("bar".into()).unwrap()]
                     .iter()
                     .cloned()
                     .collect(),
@@ -483,7 +483,7 @@ fn diamond_delegation() {
             false,
             1,
             vec![delegation_c_key.public().key_id().clone()].iter().cloned().collect(),
-            vec![VirtualTargetPath::new("foo".into()).unwrap()].iter().cloned().collect(),
+            vec![TargetPath::new("foo".into()).unwrap()].iter().cloned().collect(),
         )
         .unwrap()],
     )
@@ -512,7 +512,7 @@ fn diamond_delegation() {
             1,
             // oops, wrong key.
             vec![delegation_b_key.public().key_id().clone()].iter().cloned().collect(),
-            vec![VirtualTargetPath::new("bar".into()).unwrap()].iter().cloned().collect(),
+            vec![TargetPath::new("bar".into()).unwrap()].iter().cloned().collect(),
         )
         .unwrap()],
     )
@@ -538,13 +538,13 @@ fn diamond_delegation() {
 
     let delegation = TargetsMetadataBuilder::new()
         .insert_target_from_reader(
-            VirtualTargetPath::new("foo".into()).unwrap(),
+            TargetPath::new("foo".into()).unwrap(),
             foo_target_file,
             &[HashAlgorithm::Sha256],
         )
         .unwrap()
         .insert_target_from_reader(
-            VirtualTargetPath::new("bar".into()).unwrap(),
+            TargetPath::new("bar".into()).unwrap(),
             bar_target_file,
             &[HashAlgorithm::Sha256],
         )
@@ -572,11 +572,11 @@ fn diamond_delegation() {
     );
 
     assert!(tuf
-        .target_description(&VirtualTargetPath::new("foo".into()).unwrap())
+        .target_description(&TargetPath::new("foo".into()).unwrap())
         .is_ok());
 
     assert_matches!(
-        tuf.target_description(&VirtualTargetPath::new("bar".into()).unwrap()),
+        tuf.target_description(&TargetPath::new("bar".into()).unwrap()),
         Err(Error::TargetUnavailable)
     );
 }


### PR DESCRIPTION
This removes tuf::client::PathTranslator. I'm not sure if this is a holdover from pre TUF-1.0 era, but as of right now I'm not aware of any strong use cases for translating paths. The only one I can come up with is if some repository wants to escape OS-specific characters, but that could be done in a repository wrapper, or in the FileSystemRepository itself.

Note that this was written on top of #334, so we should land that first to avoid excess review churn.