### PR TITLE
Add a new repository builder

### DIFF
--- a/tuf/src/lib.rs
+++ b/tuf/src/lib.rs
@@ -116,14 +116,12 @@ pub mod database;
 pub mod error;
 pub mod interchange;
 pub mod metadata;
+pub mod repo_builder;
 pub mod repository;
 pub mod verify;
 
 mod format_hex;
 mod util;
-
-#[cfg(test)]
-mod repo_builder;
 
 pub use crate::database::*;
 pub use crate::error::*;

--- a/tuf/src/metadata.rs
+++ b/tuf/src/metadata.rs
@@ -205,7 +205,7 @@ impl Display for Role {
 }
 
 /// Enum used for addressing versioned TUF metadata.
-#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash)]
 pub enum MetadataVersion {
     /// The metadata is unversioned. This is the latest version of the metadata.
     None,
@@ -1062,13 +1062,12 @@ impl TimestampMetadataBuilder {
     ///
     /// * version: 1
     /// * expires: 1 day from the current time.
-    pub fn from_snapshot<D, M>(
-        snapshot: &SignedMetadata<D, M>,
+    pub fn from_snapshot<D>(
+        snapshot: &SignedMetadata<D, SnapshotMetadata>,
         hash_algs: &[HashAlgorithm],
     ) -> Result<Self>
     where
         D: DataInterchange,
-        M: Metadata,
     {
         let raw_snapshot = snapshot.to_raw()?;
         let description = MetadataDescription::from_slice(
@@ -1284,6 +1283,20 @@ impl SnapshotMetadataBuilder {
             expires: Utc::now() + Duration::days(7),
             meta: HashMap::new(),
         }
+    }
+
+    /// Create a new [SnapshotMetadataBuilder] from a given snapshot. It defaults to:
+    ///
+    /// * version: 1
+    /// * expires: 7 day from the current time.
+    pub fn from_targets<D>(
+        targets: &SignedMetadata<D, TargetsMetadata>,
+        hash_algs: &[HashAlgorithm],
+    ) -> Result<Self>
+    where
+        D: DataInterchange,
+    {
+        SnapshotMetadataBuilder::new().insert_metadata(targets, hash_algs)
     }
 
     /// Set the version number for this metadata.

--- a/tuf/src/repo_builder.rs
+++ b/tuf/src/repo_builder.rs
@@ -1,223 +1,2099 @@
-use crate::{
-    crypto::{HashAlgorithm, PrivateKey},
-    interchange::DataInterchange,
-    metadata::{
-        Metadata, MetadataPath, MetadataVersion, RawSignedMetadata, Role, RootMetadata,
-        RootMetadataBuilder, SignedMetadataBuilder, SnapshotMetadata, SnapshotMetadataBuilder,
-        TargetsMetadata, TargetsMetadataBuilder, TimestampMetadata, TimestampMetadataBuilder,
+//! Repository Builder
+
+use {
+    crate::{
+        crypto::{self, HashAlgorithm, PrivateKey},
+        database::Database,
+        interchange::DataInterchange,
+        metadata::{
+            Metadata, MetadataDescription, MetadataPath, MetadataVersion, RawSignedMetadata,
+            RawSignedMetadataSet, RawSignedMetadataSetBuilder, Role, RootMetadata,
+            RootMetadataBuilder, SignedMetadataBuilder, SnapshotMetadata, SnapshotMetadataBuilder,
+            TargetDescription, TargetPath, TargetsMetadata, TargetsMetadataBuilder,
+            TimestampMetadata, TimestampMetadataBuilder,
+        },
+        repository::RepositoryStorage,
+        Error, Result,
     },
-    repository::{Repository, RepositoryStorage},
-    Result,
+    chrono::Utc,
+    futures_io::{AsyncRead, AsyncSeek},
+    futures_util::AsyncSeekExt as _,
+    std::{collections::HashMap, io::SeekFrom, marker::PhantomData},
 };
 
-// This helper builder simplifies the process of creating new metadata.
-//
-// FIXME: This is not ready yet for public use, it is only intended for internal testing until the
-// design is complete.
-pub(crate) struct RepoBuilder<'a, R, D>
-where
-    R: RepositoryStorage<D> + Sync,
-    D: DataInterchange + Sync,
-{
-    repo: Repository<R, D>,
-    root_keys: Vec<&'a dyn PrivateKey>,
-    targets_keys: Vec<&'a dyn PrivateKey>,
-    snapshot_keys: Vec<&'a dyn PrivateKey>,
-    timestamp_keys: Vec<&'a dyn PrivateKey>,
-    snapshot_version: u32,
-    timestamp_version: u32,
-    root_builder: RootMetadataBuilder,
-    targets_builder: Option<TargetsMetadataBuilder>,
+mod private {
+    use super::*;
+
+    pub trait Sealed {}
+
+    impl Sealed for Root {}
+    impl<D: DataInterchange> Sealed for Targets<D> {}
+    impl<D: DataInterchange> Sealed for Snapshot<D> {}
+    impl<D: DataInterchange> Sealed for Timestamp<D> {}
+    impl<D: DataInterchange> Sealed for Done<D> {}
 }
 
-impl<'a, R, D> RepoBuilder<'a, R, D>
-where
-    R: RepositoryStorage<D> + Sync,
-    D: DataInterchange + Sync,
-{
-    pub(crate) fn new(repo: R) -> Self {
-        let repo = Repository::new(repo);
+/// Trait to track each of the repository building states.
+pub trait State: private::Sealed {}
 
+/// State to create a root metadata.
+#[doc(hidden)]
+pub struct Root {
+    builder: RootMetadataBuilder,
+}
+
+/// State to create a targets metadata.
+#[doc(hidden)]
+pub struct Targets<D: DataInterchange> {
+    staged_root: Option<Staged<D, RootMetadata>>,
+    builder: TargetsMetadataBuilder,
+    file_hash_algorithms: Vec<HashAlgorithm>,
+}
+
+impl<D: DataInterchange> Targets<D> {
+    fn new(staged_root: Option<Staged<D, RootMetadata>>) -> Self {
         Self {
-            repo,
-            root_keys: vec![],
-            targets_keys: vec![],
-            snapshot_keys: vec![],
-            timestamp_keys: vec![],
-            snapshot_version: 1,
-            timestamp_version: 1,
-            root_builder: RootMetadataBuilder::new(),
-            targets_builder: None,
+            staged_root,
+            builder: TargetsMetadataBuilder::new(),
+            file_hash_algorithms: vec![HashAlgorithm::Sha256],
+        }
+    }
+}
+
+/// State to create a snapshot metadata.
+#[doc(hidden)]
+pub struct Snapshot<D: DataInterchange> {
+    staged_root: Option<Staged<D, RootMetadata>>,
+    staged_targets: Option<Staged<D, TargetsMetadata>>,
+    include_targets_length: bool,
+    targets_hash_algorithms: Vec<HashAlgorithm>,
+    inherit_targets: bool,
+}
+
+impl<D: DataInterchange> Snapshot<D> {
+    fn new(
+        staged_root: Option<Staged<D, RootMetadata>>,
+        staged_targets: Option<Staged<D, TargetsMetadata>>,
+    ) -> Self {
+        Self {
+            staged_root,
+            staged_targets,
+            include_targets_length: false,
+            targets_hash_algorithms: vec![],
+            inherit_targets: true,
         }
     }
 
-    pub(crate) fn root_keys(mut self, keys: Vec<&'a dyn PrivateKey>) -> Self {
-        self.root_keys = keys;
+    fn targets_description(&self) -> Result<Option<MetadataDescription>> {
+        if let Some(ref targets) = self.staged_targets {
+            let length = if self.include_targets_length {
+                Some(targets.raw.as_bytes().len())
+            } else {
+                None
+            };
+
+            let hashes = if self.targets_hash_algorithms.is_empty() {
+                HashMap::new()
+            } else {
+                crypto::calculate_hashes_from_slice(
+                    targets.raw.as_bytes(),
+                    &self.targets_hash_algorithms,
+                )?
+            };
+
+            Ok(Some(MetadataDescription::new(
+                targets.metadata.version(),
+                length,
+                hashes,
+            )?))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+/// State to create a timestamp metadata.
+pub struct Timestamp<D: DataInterchange> {
+    staged_root: Option<Staged<D, RootMetadata>>,
+    staged_targets: Option<Staged<D, TargetsMetadata>>,
+    staged_snapshot: Option<Staged<D, SnapshotMetadata>>,
+    include_snapshot_length: bool,
+    snapshot_hash_algorithms: Vec<HashAlgorithm>,
+}
+
+impl<D: DataInterchange> Timestamp<D> {
+    fn new(state: Snapshot<D>, staged_snapshot: Option<Staged<D, SnapshotMetadata>>) -> Self {
+        Self {
+            staged_root: state.staged_root,
+            staged_targets: state.staged_targets,
+            staged_snapshot,
+            include_snapshot_length: false,
+            snapshot_hash_algorithms: vec![],
+        }
+    }
+
+    fn snapshot_description(&self) -> Result<Option<MetadataDescription>> {
+        if let Some(ref snapshot) = self.staged_snapshot {
+            let length = if self.include_snapshot_length {
+                Some(snapshot.raw.as_bytes().len())
+            } else {
+                None
+            };
+
+            let hashes = if self.snapshot_hash_algorithms.is_empty() {
+                HashMap::new()
+            } else {
+                crypto::calculate_hashes_from_slice(
+                    snapshot.raw.as_bytes(),
+                    &self.snapshot_hash_algorithms,
+                )?
+            };
+
+            Ok(Some(MetadataDescription::new(
+                snapshot.metadata.version(),
+                length,
+                hashes,
+            )?))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+/// The final state for building repository metadata.
+pub struct Done<D: DataInterchange> {
+    staged_root: Option<Staged<D, RootMetadata>>,
+    staged_targets: Option<Staged<D, TargetsMetadata>>,
+    staged_snapshot: Option<Staged<D, SnapshotMetadata>>,
+    staged_timestamp: Option<Staged<D, TimestampMetadata>>,
+}
+
+impl State for Root {}
+impl<D: DataInterchange> State for Targets<D> {}
+impl<D: DataInterchange> State for Snapshot<D> {}
+impl<D: DataInterchange> State for Timestamp<D> {}
+impl<D: DataInterchange> State for Done<D> {}
+
+struct Staged<D: DataInterchange, M: Metadata> {
+    metadata: M,
+    raw: RawSignedMetadata<D, M>,
+}
+
+struct RepoContext<'a, D, R>
+where
+    D: DataInterchange + Sync,
+    R: RepositoryStorage<D>,
+{
+    repo: R,
+    db: Option<&'a Database<D>>,
+    signing_root_keys: Vec<&'a dyn PrivateKey>,
+    signing_targets_keys: Vec<&'a dyn PrivateKey>,
+    signing_snapshot_keys: Vec<&'a dyn PrivateKey>,
+    signing_timestamp_keys: Vec<&'a dyn PrivateKey>,
+    trusted_root_keys: Vec<&'a dyn PrivateKey>,
+    trusted_targets_keys: Vec<&'a dyn PrivateKey>,
+    trusted_snapshot_keys: Vec<&'a dyn PrivateKey>,
+    trusted_timestamp_keys: Vec<&'a dyn PrivateKey>,
+    _interchange: PhantomData<D>,
+}
+
+fn sign<'a, D, I, M>(meta: &M, keys: I) -> Result<RawSignedMetadata<D, M>>
+where
+    D: DataInterchange,
+    M: Metadata,
+    I: IntoIterator<Item = &'a &'a dyn PrivateKey>,
+{
+    // Sign the root.
+    let mut signed_builder = SignedMetadataBuilder::<D, _>::from_metadata(meta)?;
+    for key in keys {
+        signed_builder = signed_builder.sign(*key)?;
+    }
+
+    signed_builder.build().to_raw()
+}
+
+/// This helper builder simplifies the process of creating new metadata.
+pub struct RepoBuilder<'a, D, R, S = Root>
+where
+    D: DataInterchange + Sync,
+    R: RepositoryStorage<D>,
+    S: State,
+{
+    ctx: RepoContext<'a, D, R>,
+    state: S,
+}
+
+impl<'a, D, R> RepoBuilder<'a, D, R, Root>
+where
+    D: DataInterchange + Sync,
+    R: RepositoryStorage<D>,
+{
+    /// Create a [RepoBuilder] for creating metadata for a new repository.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use {
+    /// #     futures_executor::block_on,
+    /// #     tuf::{
+    /// #         interchange::Json,
+    /// #         crypto::Ed25519PrivateKey,
+    /// #         repo_builder::RepoBuilder,
+    /// #         repository::EphemeralRepository,
+    /// #     },
+    /// # };
+    /// #
+    /// # let key = Ed25519PrivateKey::from_pkcs8(
+    /// #     include_bytes!("../tests/ed25519/ed25519-1.pk8.der")
+    /// # ).unwrap();
+    /// #
+    /// # block_on(async {
+    /// let mut repo = EphemeralRepository::<Json>::new();
+    /// let _metadata = RepoBuilder::create(&mut repo)
+    ///     .trusted_root_keys(&[&key])
+    ///     .trusted_targets_keys(&[&key])
+    ///     .trusted_snapshot_keys(&[&key])
+    ///     .trusted_timestamp_keys(&[&key])
+    ///     .commit()
+    ///     .await
+    ///     .unwrap();
+    /// # });
+    /// ```
+    pub fn create(repo: R) -> Self {
+        Self {
+            ctx: RepoContext {
+                repo,
+                db: None,
+                signing_root_keys: vec![],
+                signing_targets_keys: vec![],
+                signing_snapshot_keys: vec![],
+                signing_timestamp_keys: vec![],
+                trusted_root_keys: vec![],
+                trusted_targets_keys: vec![],
+                trusted_snapshot_keys: vec![],
+                trusted_timestamp_keys: vec![],
+                _interchange: PhantomData,
+            },
+            state: Root {
+                builder: RootMetadataBuilder::new(),
+            },
+        }
+    }
+
+    /// Create a [RepoBuilder] for creating metadata based off the latest
+    /// metadata in the [Database]. It will prepare to stage a new root metadata
+    /// based off the database's trusted root metadata:
+    ///
+    /// * root version to be 1 after the trusted root's version
+    /// * consistent snapshot to match the trusted root's consistent snapshot
+    /// * root threshold to match the trusted root's root threshold
+    /// * targets threshold to match the trusted root's targets threshold
+    /// * snapshot threshold to match the trusted root's snapshot threshold
+    /// * timestamp threshold to match the trusted root's timestamp threshold
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use {
+    /// #     futures_executor::block_on,
+    /// #     tuf::{
+    /// #         database::Database,
+    /// #         crypto::Ed25519PrivateKey,
+    /// #         interchange::Json,
+    /// #         repo_builder::RepoBuilder,
+    /// #         repository::EphemeralRepository,
+    /// #     },
+    /// # };
+    /// #
+    /// # let key = Ed25519PrivateKey::from_pkcs8(
+    /// #     include_bytes!("../tests/ed25519/ed25519-1.pk8.der")
+    /// # ).unwrap();
+    /// #
+    /// # block_on(async {
+    ///  let mut repo = EphemeralRepository::<Json>::new();
+    ///  let metadata1 = RepoBuilder::create(&mut repo)
+    ///     .trusted_root_keys(&[&key])
+    ///     .trusted_targets_keys(&[&key])
+    ///     .trusted_snapshot_keys(&[&key])
+    ///     .trusted_timestamp_keys(&[&key])
+    ///     .commit()
+    ///     .await
+    ///     .unwrap();
+    ///
+    /// let database = Database::from_trusted_metadata(&metadata1).unwrap();
+    ///
+    /// let _metadata2 = RepoBuilder::from_database(&mut repo, &database)
+    ///     .trusted_root_keys(&[&key])
+    ///     .trusted_targets_keys(&[&key])
+    ///     .trusted_snapshot_keys(&[&key])
+    ///     .trusted_timestamp_keys(&[&key])
+    ///     .create_root()
+    ///     .unwrap()
+    ///     .commit()
+    ///     .await
+    ///     .unwrap();
+    /// # });
+    /// ```
+    pub fn from_database(repo: R, db: &'a Database<D>) -> Self {
+        let builder = {
+            let trusted_root = db.trusted_root();
+
+            RootMetadataBuilder::new()
+                .consistent_snapshot(trusted_root.consistent_snapshot())
+                .root_threshold(trusted_root.root().threshold())
+                .targets_threshold(trusted_root.targets().threshold())
+                .snapshot_threshold(trusted_root.snapshot().threshold())
+                .timestamp_threshold(trusted_root.timestamp().threshold())
+        };
+
+        Self {
+            ctx: RepoContext {
+                repo,
+                db: Some(db),
+                signing_root_keys: vec![],
+                signing_targets_keys: vec![],
+                signing_snapshot_keys: vec![],
+                signing_timestamp_keys: vec![],
+                trusted_root_keys: vec![],
+                trusted_targets_keys: vec![],
+                trusted_snapshot_keys: vec![],
+                trusted_timestamp_keys: vec![],
+                _interchange: PhantomData,
+            },
+            state: Root { builder },
+        }
+    }
+
+    /// Sign the root metadata with `keys`, but do not include the keys as
+    /// trusted root keys in the root metadata. This is typically used to
+    /// support root key rotation.
+    pub fn signing_root_keys(mut self, keys: &[&'a dyn PrivateKey]) -> Self {
+        for key in keys {
+            self.ctx.signing_root_keys.push(*key);
+        }
         self
     }
 
-    pub(crate) fn targets_keys(mut self, keys: Vec<&'a dyn PrivateKey>) -> Self {
-        self.targets_keys = keys;
+    /// Sign the targets metadata with `keys`, but do not include the keys as
+    /// trusted targets keys in the root metadata. This is typically used to
+    /// support targets key rotation.
+    pub fn signing_targets_keys(mut self, keys: &[&'a dyn PrivateKey]) -> Self {
+        for key in keys {
+            self.ctx.signing_targets_keys.push(*key);
+        }
         self
     }
 
-    pub(crate) fn snapshot_keys(mut self, keys: Vec<&'a dyn PrivateKey>) -> Self {
-        self.snapshot_keys = keys;
+    /// Sign the snapshot metadata with `keys`, but do not include the keys as
+    /// trusted snapshot keys in the root metadata. This is typically used to
+    /// support snapshot key rotation.
+    pub fn signing_snapshot_keys(mut self, keys: &[&'a dyn PrivateKey]) -> Self {
+        for key in keys {
+            self.ctx.signing_snapshot_keys.push(*key);
+        }
         self
     }
 
-    pub(crate) fn timestamp_keys(mut self, keys: Vec<&'a dyn PrivateKey>) -> Self {
-        self.timestamp_keys = keys;
+    /// Sign the timestamp metadata with `keys`, but do not include the keys as
+    /// trusted timestamp keys in the root metadata. This is typically used to
+    /// support timestamp key rotation.
+    pub fn signing_timestamp_keys(mut self, keys: &[&'a dyn PrivateKey]) -> Self {
+        for key in keys {
+            self.ctx.signing_timestamp_keys.push(*key);
+        }
         self
     }
 
-    pub(crate) fn targets_version(self, version: u32) -> Self {
-        self.with_targets_builder(|bld| bld.version(version))
-    }
-
-    pub(crate) fn snapshot_version(mut self, version: u32) -> Self {
-        self.snapshot_version = version;
+    /// Sign the root metadata with `keys`, and include the keys as
+    /// trusted root keys in the root metadata.
+    pub fn trusted_root_keys(mut self, keys: &[&'a dyn PrivateKey]) -> Self {
+        for key in keys {
+            self.ctx.trusted_root_keys.push(*key);
+            self.state.builder = self.state.builder.root_key(key.public().clone());
+        }
         self
     }
 
-    pub(crate) fn timestamp_version(mut self, version: u32) -> Self {
-        self.timestamp_version = version;
+    /// Sign the targets metadata with `keys`, and include the keys as
+    /// trusted targets keys in the targets metadata.
+    pub fn trusted_targets_keys(mut self, keys: &[&'a dyn PrivateKey]) -> Self {
+        for key in keys {
+            self.ctx.trusted_targets_keys.push(*key);
+            self.state.builder = self.state.builder.targets_key(key.public().clone());
+        }
         self
     }
 
-    pub(crate) fn with_root_builder<F>(mut self, f: F) -> Self
+    /// Sign the snapshot metadata with `keys`, and include the keys as
+    /// trusted snapshot keys in the root metadata.
+    pub fn trusted_snapshot_keys(mut self, keys: &[&'a dyn PrivateKey]) -> Self {
+        for key in keys {
+            self.ctx.trusted_snapshot_keys.push(*key);
+            self.state.builder = self.state.builder.snapshot_key(key.public().clone());
+        }
+        self
+    }
+
+    /// Sign the timestamp metadata with `keys`, and include the keys as
+    /// trusted timestamp keys in the root metadata.
+    pub fn trusted_timestamp_keys(mut self, keys: &[&'a dyn PrivateKey]) -> Self {
+        for key in keys {
+            self.ctx.trusted_timestamp_keys.push(*key);
+            self.state.builder = self.state.builder.timestamp_key(key.public().clone());
+        }
+        self
+    }
+
+    /// Create a root metadata using the default settings.
+    pub fn create_root(self) -> Result<RepoBuilder<'a, D, R, Targets<D>>> {
+        self.with_root_builder(|builder| builder)
+    }
+
+    /// Create a targets metadata using the default settings.
+    ///
+    /// Note: This will also create a root metadata with the default settings if
+    /// necessary.
+    pub fn create_targets(self) -> Result<RepoBuilder<'a, D, R, Snapshot<D>>> {
+        self.create_root_if_necessary()?.create_targets()
+    }
+
+    /// Create a snapshot metadata using the default settings.
+    ///
+    /// Note: This will also:
+    /// * create a root metadata with the default settings if necessary.
+    /// * create a targets metadata if necessary.
+    pub fn create_snapshot(self) -> Result<RepoBuilder<'a, D, R, Timestamp<D>>> {
+        self.create_root_if_necessary()?.create_snapshot()
+    }
+
+    /// Create a timestamp metadata using the default settings.
+    ///
+    /// Note: This will also:
+    /// * create a root metadata with the default settings if necessary.
+    /// * create a targets metadata if necessary.
+    /// * create a snapshot metadata if necessary.
+    pub fn create_timestamp(self) -> Result<RepoBuilder<'a, D, R, Done<D>>> {
+        self.create_root_if_necessary()?.create_timestamp()
+    }
+
+    /// Create a new root using the default settings if one is required.
+    /// For example:
+    ///
+    /// * This is new metadata.
+    /// * The passed in keys are different than the keys in the trusted root.
+    /// * The metadata has expired.
+    pub fn create_root_if_necessary(self) -> Result<RepoBuilder<'a, D, R, Targets<D>>> {
+        if self.need_new_root() {
+            self.create_root()
+        } else {
+            Ok(self.skip_root())
+        }
+    }
+
+    /// Skip creating the root metadata.
+    pub fn skip_root(self) -> RepoBuilder<'a, D, R, Targets<D>> {
+        RepoBuilder {
+            ctx: self.ctx,
+            state: Targets::new(None),
+        }
+    }
+
+    /// Initialize a [RootMetadataBuilder] with the configured keys, and the
+    /// following defaults:
+    ///
+    /// * If the [RepoBuilder] was created for a new repository,  was created with a [Database], the version will be 1
+    ///
+    /// and pass it to the closure for further configuration. The builder then
+    /// will be used to generate a new root metadata and stage
+    ///
+    /// Generate a new metadata This function will generate a new root metadata,
+    /// which will automatically increment the version, and set the expiration
+    /// to the default expiration of one year.
+    pub fn with_root_builder<F>(self, f: F) -> Result<RepoBuilder<'a, D, R, Targets<D>>>
     where
         F: FnOnce(RootMetadataBuilder) -> RootMetadataBuilder,
     {
-        self.root_builder = f(self.root_builder);
-        self
+        let next_version = if let Some(db) = self.ctx.db {
+            db.trusted_root().version().checked_add(1).ok_or_else(|| {
+                Error::VerificationFailure("root version should be less than max u32".into())
+            })?
+        } else {
+            1
+        };
+
+        let root_builder = self.state.builder.version(next_version);
+        let root = f(root_builder).build()?;
+
+        let raw_root = sign(
+            &root,
+            self.ctx
+                .signing_root_keys
+                .iter()
+                .chain(&self.ctx.trusted_root_keys),
+        )?;
+
+        Ok(RepoBuilder {
+            ctx: self.ctx,
+            state: Targets::new(Some(Staged {
+                metadata: root,
+                raw: raw_root,
+            })),
+        })
     }
 
-    pub(crate) fn with_targets_builder<F>(mut self, f: F) -> Self
+    /// This function will generate a new targets metadata, which will
+    /// automatically increment the version, and set the expiration to the
+    /// default expiration of 3 months.
+    pub fn with_targets_builder<F>(self, f: F) -> Result<RepoBuilder<'a, D, R, Snapshot<D>>>
     where
         F: FnOnce(TargetsMetadataBuilder) -> TargetsMetadataBuilder,
     {
-        let targets_builder = self
-            .targets_builder
-            .unwrap_or_else(TargetsMetadataBuilder::new);
-        self.targets_builder = Some(f(targets_builder));
-        self
+        self.create_root_if_necessary()?.with_targets_builder(f)
     }
 
-    pub(crate) async fn commit(mut self) -> Result<CommittedMetadata<D>> {
-        let root = self.root_builder.build()?;
-        self.root_builder = RootMetadataBuilder::from(root.clone());
+    /// This function will generate a new snapshot metadata, which will
+    /// automatically increment the version, and set the expiration to the
+    /// default expiration of 3 months.
+    pub fn with_snapshot_builder<F>(self, f: F) -> Result<RepoBuilder<'a, D, R, Timestamp<D>>>
+    where
+        F: FnOnce(SnapshotMetadataBuilder) -> SnapshotMetadataBuilder,
+    {
+        self.create_root_if_necessary()?.with_snapshot_builder(f)
+    }
 
-        let mut signed_builder = SignedMetadataBuilder::from_metadata(&root)?;
-        for key in &self.root_keys {
-            signed_builder = signed_builder.sign(*key)?;
+    /// This function will generate a new timestamp metadata, which will
+    /// automatically increment the version, and set the expiration to the
+    /// default expiration of 3 months.
+    pub fn with_timestamp_builder<F>(self, f: F) -> Result<RepoBuilder<'a, D, R, Done<D>>>
+    where
+        F: FnOnce(TimestampMetadataBuilder) -> TimestampMetadataBuilder,
+    {
+        self.create_root_if_necessary()?.with_timestamp_builder(f)
+    }
+
+    /// If keys have changed, rewrite the root metadata. Otherwise do nothing.
+    pub async fn commit(self) -> Result<RawSignedMetadataSet<D>> {
+        self.create_root_if_necessary()?.commit().await
+    }
+
+    /// Check if we need a new root database.
+    fn need_new_root(&self) -> bool {
+        // If we don't have a database yet, we need to create the first root
+        // metadata.
+        let root = if let Some(db) = self.ctx.db {
+            db.trusted_root()
+        } else {
+            return true;
+        };
+
+        if root.expires() <= &Utc::now() {
+            return true;
         }
-        let raw_root = signed_builder.build().to_raw()?;
 
-        self.repo
-            .store_metadata(
-                &MetadataPath::from_role(&Role::Root),
-                &MetadataVersion::Number(root.version()),
-                &raw_root,
-            )
-            .await?;
+        // Sign the metadata if we passed in any old root keys.
+        if !self.ctx.signing_root_keys.is_empty() {
+            return true;
+        }
 
-        let (targets, snapshot, timestamp) =
-            if let Some(targets_builder) = self.targets_builder.take() {
-                let targets = targets_builder.build()?;
+        // Otherwise, see if any of the keys have changed.
+        let root_keys_count = root.root_keys().count();
+        if root_keys_count != self.ctx.trusted_root_keys.len() {
+            return true;
+        }
 
-                let mut signed_builder = SignedMetadataBuilder::from_metadata(&targets)?;
-                for key in &self.targets_keys {
-                    signed_builder = signed_builder.sign(*key)?;
-                }
-                let signed_targets = signed_builder.build();
-                let raw_targets = signed_targets.to_raw()?;
+        for &key in &self.ctx.trusted_root_keys {
+            if !root.root_keys().any(|x| x == key.public()) {
+                return true;
+            }
+        }
 
-                let snapshot = SnapshotMetadataBuilder::new()
-                    .version(self.snapshot_version)
-                    .insert_metadata(&signed_targets, &[HashAlgorithm::Sha256])?
-                    .build()?;
+        for &key in &self.ctx.trusted_targets_keys {
+            if !root.targets_keys().any(|x| x == key.public()) {
+                return true;
+            }
+        }
 
-                let mut signed_builder = SignedMetadataBuilder::from_metadata(&snapshot)?;
-                for key in &self.snapshot_keys {
-                    signed_builder = signed_builder.sign(*key)?;
-                }
-                let signed_snapshot = signed_builder.build();
-                let raw_snapshot = signed_snapshot.to_raw()?;
+        for &key in &self.ctx.trusted_snapshot_keys {
+            if !root.snapshot_keys().any(|x| x == key.public()) {
+                return true;
+            }
+        }
 
-                let timestamp = TimestampMetadataBuilder::from_snapshot(
-                    &signed_snapshot,
-                    &[HashAlgorithm::Sha256],
-                )?
-                .version(self.timestamp_version)
-                .build()?;
+        for &key in &self.ctx.trusted_timestamp_keys {
+            if !root.timestamp_keys().any(|x| x == key.public()) {
+                return true;
+            }
+        }
 
-                let mut signed_builder = SignedMetadataBuilder::from_metadata(&timestamp)?;
-                for key in &self.timestamp_keys {
-                    signed_builder = signed_builder.sign(*key)?;
-                }
-                let signed_timestamp = signed_builder.build();
-                let raw_timestamp = signed_timestamp.to_raw()?;
-
-                if root.consistent_snapshot() {
-                    self.repo
-                        .store_metadata(
-                            &MetadataPath::from_role(&Role::Targets),
-                            &MetadataVersion::Number(targets.version()),
-                            &raw_targets,
-                        )
-                        .await?;
-
-                    self.repo
-                        .store_metadata(
-                            &MetadataPath::from_role(&Role::Snapshot),
-                            &MetadataVersion::Number(snapshot.version()),
-                            &raw_snapshot,
-                        )
-                        .await?;
-                }
-
-                self.repo
-                    .store_metadata(
-                        &MetadataPath::from_role(&Role::Targets),
-                        &MetadataVersion::None,
-                        &raw_targets,
-                    )
-                    .await?;
-
-                self.repo
-                    .store_metadata(
-                        &MetadataPath::from_role(&Role::Snapshot),
-                        &MetadataVersion::None,
-                        &raw_snapshot,
-                    )
-                    .await?;
-
-                self.repo
-                    .store_metadata(
-                        &MetadataPath::from_role(&Role::Timestamp),
-                        &MetadataVersion::None,
-                        &raw_timestamp,
-                    )
-                    .await?;
-
-                (Some(raw_targets), Some(raw_snapshot), Some(raw_timestamp))
-            } else {
-                (None, None, None)
-            };
-
-        Ok(CommittedMetadata {
-            root: raw_root,
-            targets,
-            snapshot,
-            timestamp,
-        })
+        false
     }
 }
 
-pub(crate) struct CommittedMetadata<D> {
-    pub(crate) root: RawSignedMetadata<D, RootMetadata>,
-    pub(crate) targets: Option<RawSignedMetadata<D, TargetsMetadata>>,
-    pub(crate) snapshot: Option<RawSignedMetadata<D, SnapshotMetadata>>,
-    pub(crate) timestamp: Option<RawSignedMetadata<D, TimestampMetadata>>,
+impl<'a, D, R> RepoBuilder<'a, D, R, Targets<D>>
+where
+    D: DataInterchange + Sync,
+    R: RepositoryStorage<D>,
+{
+    /// Whether or not to include the length of the targets, and any delegated targets, in the
+    /// new snapshot.
+    pub fn file_hash_algorithms(mut self, algorithms: &[HashAlgorithm]) -> Self {
+        self.state.file_hash_algorithms = algorithms.to_vec();
+        self
+    }
+
+    /// Create a targets metadata using the default settings.
+    pub fn create_targets(self) -> Result<RepoBuilder<'a, D, R, Snapshot<D>>> {
+        self.with_targets_builder(|builder| builder)
+    }
+
+    /// Create a snapshot metadata using the default settings.
+    ///
+    /// Note: This will also:
+    /// * create a targets metadata if necessary.
+    pub fn create_snapshot(self) -> Result<RepoBuilder<'a, D, R, Timestamp<D>>> {
+        self.create_targets_if_necessary()?.create_snapshot()
+    }
+
+    /// Create a timestamp metadata using the default settings.
+    ///
+    /// Note: This will also:
+    /// * create a targets metadata if necessary.
+    /// * create a snapshot metadata if necessary.
+    pub fn create_timestamp(self) -> Result<RepoBuilder<'a, D, R, Done<D>>> {
+        self.create_targets_if_necessary()?.create_timestamp()
+    }
+
+    /// Create a new targets using the default settings if one is required.
+    /// For example:
+    ///
+    /// * This is new metadata.
+    /// * The metadata has expired.
+    pub fn create_targets_if_necessary(self) -> Result<RepoBuilder<'a, D, R, Snapshot<D>>> {
+        if self.need_new_targets() {
+            self.with_targets_builder(|builder| builder)
+        } else {
+            Ok(self.skip_targets())
+        }
+    }
+
+    /// Skip creating the targets metadata.
+    pub fn skip_targets(self) -> RepoBuilder<'a, D, R, Snapshot<D>> {
+        RepoBuilder {
+            ctx: self.ctx,
+            state: Snapshot::new(self.state.staged_root, None),
+        }
+    }
+
+    /// Add a target that's loaded in from the reader.
+    ///
+    /// Note: This will store the target in the repository.
+    pub async fn add_target<Rd>(
+        mut self,
+        target_path: TargetPath,
+        mut reader: Rd,
+    ) -> Result<RepoBuilder<'a, D, R, Targets<D>>>
+    where
+        Rd: AsyncRead + AsyncSeek + Unpin + Send,
+    {
+        let consistent_snapshot = if let Some(ref staged_root) = self.state.staged_root {
+            staged_root.metadata.consistent_snapshot()
+        } else if let Some(db) = self.ctx.db {
+            db.trusted_root().consistent_snapshot()
+        } else {
+            return Err(Error::MissingMetadata(Role::Root));
+        };
+
+        let target_description =
+            TargetDescription::from_reader(&mut reader, &self.state.file_hash_algorithms).await?;
+
+        // According to TUF section 5.5.2, when consistent snapshot is enabled, target files should be
+        // stored at `$HASH.FILENAME.EXT`. Otherwise it is stored at `FILENAME.EXT`.
+        if consistent_snapshot {
+            for digest in target_description.hashes().values() {
+                reader.seek(SeekFrom::Start(0)).await?;
+
+                let hash_prefixed_path = target_path.with_hash_prefix(digest)?;
+
+                self.ctx
+                    .repo
+                    .store_target(&hash_prefixed_path, &mut reader)
+                    .await?;
+            }
+        } else {
+            reader.seek(SeekFrom::Start(0)).await?;
+
+            self.ctx
+                .repo
+                .store_target(&target_path, &mut reader)
+                .await?;
+        }
+
+        self.state.builder = self
+            .state
+            .builder
+            .insert_target_description(target_path, target_description);
+
+        Ok(self)
+    }
+
+    /// This function will generate a new targets metadata, which will
+    /// automatically increment the version, and set the expiration to the
+    /// default expiration of 3 months.
+    pub fn with_targets_builder<F>(self, f: F) -> Result<RepoBuilder<'a, D, R, Snapshot<D>>>
+    where
+        F: FnOnce(TargetsMetadataBuilder) -> TargetsMetadataBuilder,
+    {
+        let next_version = if let Some(db) = self.ctx.db {
+            if let Some(trusted_targets) = db.trusted_targets() {
+                trusted_targets.version().checked_add(1).ok_or_else(|| {
+                    Error::VerificationFailure("targets version should be less than max u32".into())
+                })?
+            } else {
+                1
+            }
+        } else {
+            1
+        };
+
+        let targets_builder = self.state.builder.version(next_version);
+        let targets = f(targets_builder).build()?;
+
+        // Sign the targets metadata.
+        let raw_targets = sign(
+            &targets,
+            self.ctx
+                .signing_targets_keys
+                .iter()
+                .chain(&self.ctx.trusted_targets_keys),
+        )?;
+
+        Ok(RepoBuilder {
+            ctx: self.ctx,
+            state: Snapshot::new(
+                self.state.staged_root,
+                Some(Staged {
+                    metadata: targets,
+                    raw: raw_targets,
+                }),
+            ),
+        })
+    }
+
+    /// This function will generate a new snapshot metadata, which will
+    /// automatically increment the version, and set the expiration to the
+    /// default expiration of 3 months.
+    pub fn with_snapshot_builder<F>(self, f: F) -> Result<RepoBuilder<'a, D, R, Timestamp<D>>>
+    where
+        F: FnOnce(SnapshotMetadataBuilder) -> SnapshotMetadataBuilder,
+    {
+        self.create_targets_if_necessary()?.with_snapshot_builder(f)
+    }
+
+    /// This function will generate a new timestamp metadata, which will
+    /// automatically increment the version, and set the expiration to the
+    /// default expiration of 3 months.
+    pub fn with_timestamp_builder<F>(self, f: F) -> Result<RepoBuilder<'a, D, R, Done<D>>>
+    where
+        F: FnOnce(TimestampMetadataBuilder) -> TimestampMetadataBuilder,
+    {
+        self.create_targets_if_necessary()?
+            .with_timestamp_builder(f)
+    }
+
+    /// Write the metadata to the repository. Before writing the metadata to `repo`,
+    /// this will test that a client can update to this metadata to make sure it
+    /// is valid.
+    pub async fn commit(self) -> Result<RawSignedMetadataSet<D>> {
+        self.create_targets_if_necessary()?.commit().await
+    }
+
+    /// Commit the metadata for this repository without validating it.
+    ///
+    /// Warning: This can write invalid metadata to a repository without
+    /// validating that it is correct.
+    #[cfg(test)]
+    pub async fn commit_skip_validation(self) -> Result<RawSignedMetadataSet<D>> {
+        self.create_targets_if_necessary()?
+            .commit_skip_validation()
+            .await
+    }
+
+    fn need_new_targets(&self) -> bool {
+        let db = if let Some(ref db) = self.ctx.db {
+            db
+        } else {
+            return true;
+        };
+
+        if let Some(targets) = db.trusted_targets() {
+            if targets.expires() <= &Utc::now() {
+                return true;
+            }
+        } else {
+            return true;
+        }
+
+        false
+    }
+}
+
+impl<'a, D, R> RepoBuilder<'a, D, R, Snapshot<D>>
+where
+    D: DataInterchange + Sync,
+    R: RepositoryStorage<D>,
+{
+    /// Whether or not to include the length of the targets, and any delegated targets, in the
+    /// new snapshot.
+    pub fn snapshot_includes_length(mut self, include_targets_lengths: bool) -> Self {
+        self.state.include_targets_length = include_targets_lengths;
+        self
+    }
+
+    /// Whether or not to include the hashes of the targets, and any delegated targets, in the
+    /// new snapshot.
+    pub fn snapshot_includes_hashes(mut self, hashes: &[HashAlgorithm]) -> Self {
+        self.state.targets_hash_algorithms = hashes.to_vec();
+        self
+    }
+
+    /// Whether or not to inherit targets, and delegated targets, from the trusted snapshot in the
+    /// new snapshot.
+    pub fn inherit_targets(mut self, inherit_targets: bool) -> Self {
+        self.state.inherit_targets = inherit_targets;
+        self
+    }
+
+    /// Create a snapshot metadata using the default settings.
+    pub fn create_snapshot(self) -> Result<RepoBuilder<'a, D, R, Timestamp<D>>> {
+        self.with_snapshot_builder(|builder| builder)
+    }
+
+    /// Create a timestamp metadata using the default settings.
+    ///
+    /// Note: This will also:
+    /// * create a snapshot metadata if necessary.
+    pub fn create_timestamp(self) -> Result<RepoBuilder<'a, D, R, Done<D>>> {
+        self.create_snapshot_if_necessary()?.create_timestamp()
+    }
+
+    /// Create a new snapshot using the default settings if one is required.
+    /// For example:
+    ///
+    /// * This is new metadata.
+    /// * The metadata has expired.
+    pub fn create_snapshot_if_necessary(self) -> Result<RepoBuilder<'a, D, R, Timestamp<D>>> {
+        if self.need_new_snapshot() {
+            self.create_snapshot()
+        } else {
+            Ok(self.skip_snapshot())
+        }
+    }
+
+    /// Skip creating the snapshot metadata.
+    pub fn skip_snapshot(self) -> RepoBuilder<'a, D, R, Timestamp<D>> {
+        RepoBuilder {
+            ctx: self.ctx,
+            state: Timestamp::new(self.state, None),
+        }
+    }
+
+    /// This function will generate a new snapshot metadata, which will automatically
+    /// increment the version, and set the expiration to the default expiration of
+    /// 7 days.
+    pub fn with_snapshot_builder<F>(self, f: F) -> Result<RepoBuilder<'a, D, R, Timestamp<D>>>
+    where
+        F: FnOnce(SnapshotMetadataBuilder) -> SnapshotMetadataBuilder,
+    {
+        let next_version = if let Some(db) = self.ctx.db {
+            if let Some(trusted_snapshot) = db.trusted_snapshot() {
+                trusted_snapshot.version().checked_add(1).ok_or_else(|| {
+                    Error::VerificationFailure(
+                        "snapshot version should be less than max u32".into(),
+                    )
+                })?
+            } else {
+                1
+            }
+        } else {
+            1
+        };
+
+        let mut snapshot_builder = SnapshotMetadataBuilder::new().version(next_version);
+
+        // Insert all the metadata from the trusted snapshot.
+        if self.state.inherit_targets {
+            if let Some(db) = self.ctx.db {
+                if let Some(snapshot) = db.trusted_snapshot() {
+                    for (path, description) in snapshot.meta() {
+                        snapshot_builder = snapshot_builder
+                            .insert_metadata_description(path.clone(), description.clone());
+                    }
+                }
+            }
+        }
+
+        // Overwrite the targets entry if specified.
+        if let Some(targets_description) = self.state.targets_description()? {
+            snapshot_builder = snapshot_builder.insert_metadata_description(
+                MetadataPath::from_role(&Role::Targets),
+                targets_description,
+            );
+        };
+
+        let snapshot = f(snapshot_builder).build()?;
+        let raw_snapshot = sign(
+            &snapshot,
+            self.ctx
+                .signing_snapshot_keys
+                .iter()
+                .chain(&self.ctx.trusted_snapshot_keys),
+        )?;
+
+        Ok(RepoBuilder {
+            ctx: self.ctx,
+            state: Timestamp::new(
+                self.state,
+                Some(Staged {
+                    metadata: snapshot,
+                    raw: raw_snapshot,
+                }),
+            ),
+        })
+    }
+
+    /// This function will generate a new timestamp metadata, which will
+    /// automatically increment the version, and set the expiration to the
+    /// default expiration of 3 months.
+    pub fn with_timestamp_builder<F>(self, f: F) -> Result<RepoBuilder<'a, D, R, Done<D>>>
+    where
+        F: FnOnce(TimestampMetadataBuilder) -> TimestampMetadataBuilder,
+    {
+        self.create_snapshot_if_necessary()?
+            .with_timestamp_builder(f)
+    }
+
+    /// Write the metadata to the repository. Before writing the metadata to `repo`,
+    /// this will test that a client can update to this metadata to make sure it
+    /// is valid.
+    pub async fn commit(self) -> Result<RawSignedMetadataSet<D>> {
+        self.create_snapshot_if_necessary()?.commit().await
+    }
+
+    /// Commit the metadata for this repository without validating it.
+    ///
+    /// Warning: This can write invalid metadata to a repository without
+    /// validating that it is correct.
+    #[cfg(test)]
+    pub async fn commit_skip_validation(self) -> Result<RawSignedMetadataSet<D>> {
+        self.create_snapshot_if_necessary()?
+            .commit_skip_validation()
+            .await
+    }
+
+    fn need_new_snapshot(&self) -> bool {
+        let db = if let Some(ref db) = self.ctx.db {
+            db
+        } else {
+            return true;
+        };
+
+        if let Some(snapshot) = db.trusted_snapshot() {
+            if snapshot.expires() <= &Utc::now() {
+                return true;
+            }
+        } else {
+            return true;
+        }
+
+        false
+    }
+}
+
+impl<'a, D, R> RepoBuilder<'a, D, R, Timestamp<D>>
+where
+    D: DataInterchange + Sync,
+    R: RepositoryStorage<D>,
+{
+    /// Whether or not to include the length of the snapshot, and any delegated snapshot, in the
+    /// new snapshot.
+    pub fn timestamp_includes_length(mut self, include_snapshot_lengths: bool) -> Self {
+        self.state.include_snapshot_length = include_snapshot_lengths;
+        self
+    }
+
+    /// Whether or not to include the hashes of the snapshot in the
+    /// new timestamp.
+    pub fn timestamp_includes_hashes(mut self, hashes: &[HashAlgorithm]) -> Self {
+        self.state.snapshot_hash_algorithms = hashes.to_vec();
+        self
+    }
+
+    /// Create a timestamp metadata using the default settings.
+    ///
+    /// Note: This will also:
+    /// * create a root metadata with the default settings if necessary.
+    /// * create a targets metadata if necessary.
+    /// * create a snapshot metadata if necessary.
+    pub fn create_timestamp(self) -> Result<RepoBuilder<'a, D, R, Done<D>>> {
+        self.with_timestamp_builder(|builder| builder)
+    }
+
+    /// Create a new timestamp using the default settings if one is required.
+    /// For example:
+    ///
+    /// * This is new metadata.
+    /// * The metadata has expired.
+    pub fn create_timestamp_if_necessary(self) -> Result<RepoBuilder<'a, D, R, Done<D>>> {
+        if self.need_new_timestamp() {
+            self.create_timestamp()
+        } else {
+            Ok(self.skip_timestamp())
+        }
+    }
+
+    /// Skip creating the timestamp metadata.
+    pub fn skip_timestamp(self) -> RepoBuilder<'a, D, R, Done<D>> {
+        RepoBuilder {
+            ctx: self.ctx,
+            state: Done {
+                staged_root: self.state.staged_root,
+                staged_targets: self.state.staged_targets,
+                staged_snapshot: self.state.staged_snapshot,
+                staged_timestamp: None,
+            },
+        }
+    }
+
+    /// Build timestamp metadata for this repository, then write all metadata to
+    /// the repository. Before writing the metadata to `repo`, this will test
+    /// that a client can update to this metadata to make sure it is valid.
+    pub fn with_timestamp_builder<F>(self, f: F) -> Result<RepoBuilder<'a, D, R, Done<D>>>
+    where
+        F: FnOnce(TimestampMetadataBuilder) -> TimestampMetadataBuilder,
+    {
+        let next_version = if let Some(db) = self.ctx.db {
+            if let Some(trusted_timestamp) = db.trusted_timestamp() {
+                trusted_timestamp.version().checked_add(1).ok_or_else(|| {
+                    Error::VerificationFailure(
+                        "timestamp version should be less than max u32".into(),
+                    )
+                })?
+            } else {
+                1
+            }
+        } else {
+            1
+        };
+
+        let description = if let Some(description) = self.state.snapshot_description()? {
+            description
+        } else {
+            self.ctx
+                .db
+                .and_then(|db| db.trusted_timestamp())
+                .map(|timestamp| timestamp.snapshot().clone())
+                .ok_or(Error::MissingMetadata(Role::Timestamp))?
+        };
+
+        let timestamp_builder =
+            TimestampMetadataBuilder::from_metadata_description(description).version(next_version);
+
+        let timestamp = f(timestamp_builder).build()?;
+        let raw_timestamp = sign(
+            &timestamp,
+            self.ctx
+                .signing_timestamp_keys
+                .iter()
+                .chain(&self.ctx.trusted_timestamp_keys),
+        )?;
+
+        Ok(RepoBuilder {
+            ctx: self.ctx,
+            state: Done {
+                staged_root: self.state.staged_root,
+                staged_targets: self.state.staged_targets,
+                staged_snapshot: self.state.staged_snapshot,
+                staged_timestamp: Some(Staged {
+                    metadata: timestamp,
+                    raw: raw_timestamp,
+                }),
+            },
+        })
+    }
+
+    /// Write the metadata to the repository. Before writing the metadata to `repo`,
+    /// this will test that a client can update to this metadata to make sure it
+    /// is valid.
+    pub async fn commit(self) -> Result<RawSignedMetadataSet<D>> {
+        self.create_timestamp_if_necessary()?.commit().await
+    }
+
+    /// Commit the metadata for this repository without validating it.
+    ///
+    /// Warning: This can write invalid metadata to a repository without
+    /// validating that it is correct.
+    #[cfg(test)]
+    pub async fn commit_skip_validation(self) -> Result<RawSignedMetadataSet<D>> {
+        self.create_timestamp_if_necessary()?
+            .commit_skip_validation()
+            .await
+    }
+
+    fn need_new_timestamp(&self) -> bool {
+        let db = if let Some(ref db) = self.ctx.db {
+            db
+        } else {
+            return true;
+        };
+
+        if let Some(timestamp) = db.trusted_timestamp() {
+            if timestamp.expires() <= &Utc::now() {
+                return true;
+            }
+        } else {
+            return true;
+        }
+
+        false
+    }
+}
+
+impl<'a, D, R> RepoBuilder<'a, D, R, Done<D>>
+where
+    D: DataInterchange + Sync,
+    R: RepositoryStorage<D>,
+{
+    /// Commit the metadata for this repository, then write all metadata to the
+    /// repository. Before writing the metadata to `repo`, this will test that a
+    /// client can update to this metadata to make sure it is valid.
+    pub async fn commit(mut self) -> Result<RawSignedMetadataSet<D>> {
+        self.validate_built_metadata()?;
+        self.write_repo().await?;
+        Ok(self.build_skip_validation())
+    }
+
+    /// Commit the metadata for this repository without validating it.
+    ///
+    /// Warning: This can write invalid metadata to a repository without
+    /// validating that it is correct.
+    #[cfg(test)]
+    pub async fn commit_skip_validation(mut self) -> Result<RawSignedMetadataSet<D>> {
+        self.write_repo().await?;
+        Ok(self.build_skip_validation())
+    }
+
+    /// Build the metadata without validating it for correctness.
+    ///
+    /// Warning: This can produce invalid metadata.
+    fn build_skip_validation(self) -> RawSignedMetadataSet<D> {
+        let mut builder = RawSignedMetadataSetBuilder::new();
+
+        if let Some(root) = self.state.staged_root {
+            builder = builder.root(root.raw);
+        }
+
+        if let Some(targets) = self.state.staged_targets {
+            builder = builder.targets(targets.raw);
+        }
+
+        if let Some(snapshot) = self.state.staged_snapshot {
+            builder = builder.snapshot(snapshot.raw);
+        }
+
+        if let Some(timestamp) = self.state.staged_timestamp {
+            builder = builder.timestamp(timestamp.raw);
+        }
+
+        builder.build()
+    }
+
+    /// Before we commit any metadata, make sure that we can update from our
+    /// current TUF database to the latest version.
+    fn validate_built_metadata(&self) -> Result<()> {
+        // Use a TUF database to make sure we can update to the metadata we just
+        // produced. If we were constructed with a database, create a copy of it
+        // and make sure we can install the update.
+        let mut db = if let Some(db) = self.ctx.db {
+            let mut db = db.clone();
+
+            if let Some(ref root) = self.state.staged_root {
+                db.update_root(&root.raw)?;
+            }
+
+            db
+        } else if let Some(ref root) = self.state.staged_root {
+            Database::from_trusted_root(&root.raw)?
+        } else {
+            return Err(Error::MissingMetadata(Role::Root));
+        };
+
+        if let Some(ref timestamp) = self.state.staged_timestamp {
+            db.update_timestamp(&timestamp.raw)?;
+        }
+
+        if let Some(ref snapshot) = self.state.staged_snapshot {
+            db.update_snapshot(&snapshot.raw)?;
+        }
+
+        if let Some(ref targets) = self.state.staged_targets {
+            db.update_targets(&targets.raw)?;
+        }
+
+        Ok(())
+    }
+
+    async fn write_repo(&mut self) -> Result<()> {
+        let consistent_snapshot = if let Some(ref root) = self.state.staged_root {
+            self.ctx
+                .repo
+                .store_metadata(
+                    &MetadataPath::from_role(&Role::Root),
+                    &MetadataVersion::Number(root.metadata.version()),
+                    &mut root.raw.as_bytes(),
+                )
+                .await?;
+
+            self.ctx
+                .repo
+                .store_metadata(
+                    &MetadataPath::from_role(&Role::Root),
+                    &MetadataVersion::None,
+                    &mut root.raw.as_bytes(),
+                )
+                .await?;
+
+            root.metadata.consistent_snapshot()
+        } else if let Some(db) = self.ctx.db {
+            db.trusted_root().consistent_snapshot()
+        } else {
+            return Err(Error::MissingMetadata(Role::Root));
+        };
+
+        if let Some(ref targets) = self.state.staged_targets {
+            let path = MetadataPath::from_role(&Role::Targets);
+            self.ctx
+                .repo
+                .store_metadata(&path, &MetadataVersion::None, &mut targets.raw.as_bytes())
+                .await?;
+
+            if consistent_snapshot {
+                self.ctx
+                    .repo
+                    .store_metadata(
+                        &path,
+                        &MetadataVersion::Number(targets.metadata.version()),
+                        &mut targets.raw.as_bytes(),
+                    )
+                    .await?;
+            }
+        }
+
+        if let Some(ref snapshot) = self.state.staged_snapshot {
+            let path = MetadataPath::from_role(&Role::Snapshot);
+            self.ctx
+                .repo
+                .store_metadata(&path, &MetadataVersion::None, &mut snapshot.raw.as_bytes())
+                .await?;
+
+            if consistent_snapshot {
+                self.ctx
+                    .repo
+                    .store_metadata(
+                        &path,
+                        &MetadataVersion::Number(snapshot.metadata.version()),
+                        &mut snapshot.raw.as_bytes(),
+                    )
+                    .await?;
+            }
+        }
+
+        if let Some(ref timestamp) = self.state.staged_timestamp {
+            self.ctx
+                .repo
+                .store_metadata(
+                    &MetadataPath::from_role(&Role::Timestamp),
+                    &MetadataVersion::None,
+                    &mut timestamp.raw.as_bytes(),
+                )
+                .await?;
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::repository::RepositoryProvider;
+
+    use {
+        super::*,
+        crate::{
+            client::{Client, Config},
+            crypto::Ed25519PrivateKey,
+            interchange::Json,
+            metadata::SignedMetadata,
+            repository::EphemeralRepository,
+        },
+        chrono::{
+            offset::{TimeZone as _, Utc},
+            DateTime,
+        },
+        futures_executor::block_on,
+        futures_util::io::{AsyncReadExt, Cursor},
+        lazy_static::lazy_static,
+        matches::assert_matches,
+        pretty_assertions::assert_eq,
+        std::collections::BTreeMap,
+    };
+
+    lazy_static! {
+        static ref KEYS: Vec<Ed25519PrivateKey> = {
+            let keys: &[&[u8]] = &[
+                include_bytes!("../tests/ed25519/ed25519-1.pk8.der"),
+                include_bytes!("../tests/ed25519/ed25519-2.pk8.der"),
+                include_bytes!("../tests/ed25519/ed25519-3.pk8.der"),
+                include_bytes!("../tests/ed25519/ed25519-4.pk8.der"),
+                include_bytes!("../tests/ed25519/ed25519-5.pk8.der"),
+                include_bytes!("../tests/ed25519/ed25519-6.pk8.der"),
+            ];
+            keys.iter()
+                .map(|b| Ed25519PrivateKey::from_pkcs8(b).unwrap())
+                .collect()
+        };
+    }
+
+    fn create_root(
+        version: u32,
+        consistent_snapshot: bool,
+        expires: DateTime<Utc>,
+    ) -> SignedMetadata<Json, RootMetadata> {
+        let root = RootMetadataBuilder::new()
+            .version(version)
+            .consistent_snapshot(consistent_snapshot)
+            .expires(expires)
+            .root_threshold(2)
+            .root_key(KEYS[0].public().clone())
+            .root_key(KEYS[1].public().clone())
+            .root_key(KEYS[2].public().clone())
+            .targets_threshold(2)
+            .targets_key(KEYS[1].public().clone())
+            .targets_key(KEYS[2].public().clone())
+            .targets_key(KEYS[3].public().clone())
+            .snapshot_threshold(2)
+            .snapshot_key(KEYS[2].public().clone())
+            .snapshot_key(KEYS[3].public().clone())
+            .snapshot_key(KEYS[4].public().clone())
+            .timestamp_threshold(2)
+            .timestamp_key(KEYS[3].public().clone())
+            .timestamp_key(KEYS[4].public().clone())
+            .timestamp_key(KEYS[5].public().clone())
+            .build()
+            .unwrap();
+
+        SignedMetadataBuilder::from_metadata(&root)
+            .unwrap()
+            .sign(&KEYS[0])
+            .unwrap()
+            .sign(&KEYS[1])
+            .unwrap()
+            .sign(&KEYS[2])
+            .unwrap()
+            .build()
+    }
+
+    fn create_targets(
+        version: u32,
+        expires: DateTime<Utc>,
+    ) -> SignedMetadata<Json, TargetsMetadata> {
+        let targets = TargetsMetadataBuilder::new()
+            .version(version)
+            .expires(expires)
+            .build()
+            .unwrap();
+        SignedMetadataBuilder::<Json, _>::from_metadata(&targets)
+            .unwrap()
+            .sign(&KEYS[1])
+            .unwrap()
+            .sign(&KEYS[2])
+            .unwrap()
+            .sign(&KEYS[3])
+            .unwrap()
+            .build()
+    }
+
+    fn create_snapshot(
+        version: u32,
+        expires: DateTime<Utc>,
+        targets: &SignedMetadata<Json, TargetsMetadata>,
+        include_length_and_hashes: bool,
+    ) -> SignedMetadata<Json, SnapshotMetadata> {
+        let description = if include_length_and_hashes {
+            let raw_targets = targets.to_raw().unwrap();
+            let hashes = crypto::calculate_hashes_from_slice(
+                raw_targets.as_bytes(),
+                &[HashAlgorithm::Sha256],
+            )
+            .unwrap();
+
+            MetadataDescription::new(version, Some(raw_targets.as_bytes().len()), hashes).unwrap()
+        } else {
+            MetadataDescription::new(version, None, HashMap::new()).unwrap()
+        };
+
+        let snapshot = SnapshotMetadataBuilder::new()
+            .insert_metadata_description(MetadataPath::from_role(&Role::Targets), description)
+            .version(version)
+            .expires(expires)
+            .build()
+            .unwrap();
+        SignedMetadataBuilder::<Json, _>::from_metadata(&snapshot)
+            .unwrap()
+            .sign(&KEYS[2])
+            .unwrap()
+            .sign(&KEYS[3])
+            .unwrap()
+            .sign(&KEYS[4])
+            .unwrap()
+            .build()
+    }
+
+    fn create_timestamp(
+        version: u32,
+        expires: DateTime<Utc>,
+        snapshot: &SignedMetadata<Json, SnapshotMetadata>,
+        include_length_and_hashes: bool,
+    ) -> SignedMetadata<Json, TimestampMetadata> {
+        let description = if include_length_and_hashes {
+            let raw_snapshot = snapshot.to_raw().unwrap();
+            let hashes = crypto::calculate_hashes_from_slice(
+                raw_snapshot.as_bytes(),
+                &[HashAlgorithm::Sha256],
+            )
+            .unwrap();
+
+            MetadataDescription::new(version, Some(raw_snapshot.as_bytes().len()), hashes).unwrap()
+        } else {
+            MetadataDescription::new(version, None, HashMap::new()).unwrap()
+        };
+
+        let timestamp = TimestampMetadataBuilder::from_metadata_description(description)
+            .version(version)
+            .expires(expires)
+            .build()
+            .unwrap();
+        SignedMetadataBuilder::<Json, _>::from_metadata(&timestamp)
+            .unwrap()
+            .sign(&KEYS[3])
+            .unwrap()
+            .sign(&KEYS[4])
+            .unwrap()
+            .sign(&KEYS[5])
+            .unwrap()
+            .build()
+    }
+
+    fn assert_metadata(
+        metadata: &RawSignedMetadataSet<Json>,
+        expected_root: Option<&RawSignedMetadata<Json, RootMetadata>>,
+        expected_targets: Option<&RawSignedMetadata<Json, TargetsMetadata>>,
+        expected_snapshot: Option<&RawSignedMetadata<Json, SnapshotMetadata>>,
+        expected_timestamp: Option<&RawSignedMetadata<Json, TimestampMetadata>>,
+    ) {
+        assert_eq!(
+            metadata.root().map(|m| m.parse_untrusted().unwrap()),
+            expected_root.map(|m| m.parse_untrusted().unwrap())
+        );
+        assert_eq!(
+            metadata.targets().map(|m| m.parse_untrusted().unwrap()),
+            expected_targets.map(|m| m.parse_untrusted().unwrap())
+        );
+        assert_eq!(
+            metadata.snapshot().map(|m| m.parse_untrusted().unwrap()),
+            expected_snapshot.map(|m| m.parse_untrusted().unwrap())
+        );
+        assert_eq!(
+            metadata.timestamp().map(|m| m.parse_untrusted().unwrap()),
+            expected_timestamp.map(|m| m.parse_untrusted().unwrap())
+        );
+    }
+
+    fn assert_repo(
+        repo: &EphemeralRepository<Json>,
+        expected_metadata: &BTreeMap<(MetadataPath, MetadataVersion), &[u8]>,
+    ) {
+        let actual_metadata = repo
+            .metadata()
+            .iter()
+            .map(|(k, v)| (k.clone(), String::from_utf8_lossy(v).to_string()))
+            .collect::<BTreeMap<_, _>>();
+
+        let expected_metadata = expected_metadata
+            .iter()
+            .map(|(k, v)| (k.clone(), String::from_utf8_lossy(v).to_string()))
+            .collect::<BTreeMap<_, _>>();
+
+        assert_eq!(
+            actual_metadata.keys().collect::<Vec<_>>(),
+            expected_metadata.keys().collect::<Vec<_>>()
+        );
+        assert_eq!(actual_metadata, expected_metadata);
+    }
+
+    #[test]
+    fn test_create_and_update_repo_not_consistent_snapshot() {
+        block_on(check_create_and_update_repo(false));
+    }
+
+    #[test]
+    fn test_create_and_update_repo_consistent_snapshot() {
+        block_on(check_create_and_update_repo(true));
+    }
+
+    async fn check_create_and_update_repo(consistent_snapshot: bool) {
+        // We'll write all the metadata to this remote repository.
+        let mut remote = EphemeralRepository::<Json>::new();
+
+        // First, create the metadata.
+        let expires1 = Utc.ymd(2038, 1, 1).and_hms(0, 0, 0);
+        let metadata1 = RepoBuilder::create(&mut remote)
+            .trusted_root_keys(&[&KEYS[0], &KEYS[1], &KEYS[2]])
+            .trusted_targets_keys(&[&KEYS[1], &KEYS[2], &KEYS[3]])
+            .trusted_snapshot_keys(&[&KEYS[2], &KEYS[3], &KEYS[4]])
+            .trusted_timestamp_keys(&[&KEYS[3], &KEYS[4], &KEYS[5]])
+            .with_root_builder(|builder| {
+                builder
+                    .expires(expires1)
+                    .consistent_snapshot(consistent_snapshot)
+                    .root_threshold(2)
+                    .targets_threshold(2)
+                    .snapshot_threshold(2)
+                    .timestamp_threshold(2)
+            })
+            .unwrap()
+            .with_targets_builder(|builder| builder.expires(expires1))
+            .unwrap()
+            .snapshot_includes_length(true)
+            .snapshot_includes_hashes(&[HashAlgorithm::Sha256])
+            .with_snapshot_builder(|builder| builder.expires(expires1))
+            .unwrap()
+            .timestamp_includes_length(true)
+            .timestamp_includes_hashes(&[HashAlgorithm::Sha256])
+            .with_timestamp_builder(|builder| builder.expires(expires1))
+            .unwrap()
+            .commit()
+            .await
+            .unwrap();
+
+        // Generate the expected metadata by hand, and make sure we produced
+        // what we expected.
+        let signed_root1 = create_root(1, consistent_snapshot, expires1);
+        let signed_targets1 = create_targets(1, expires1);
+        let signed_snapshot1 = create_snapshot(1, expires1, &signed_targets1, true);
+        let signed_timestamp1 = create_timestamp(1, expires1, &signed_snapshot1, true);
+
+        let raw_root1 = signed_root1.to_raw().unwrap();
+        let raw_targets1 = signed_targets1.to_raw().unwrap();
+        let raw_snapshot1 = signed_snapshot1.to_raw().unwrap();
+        let raw_timestamp1 = signed_timestamp1.to_raw().unwrap();
+
+        assert_metadata(
+            &metadata1,
+            Some(&raw_root1),
+            Some(&raw_targets1),
+            Some(&raw_snapshot1),
+            Some(&raw_timestamp1),
+        );
+
+        // Make sure we stored the metadata correctly.
+        let mut expected_metadata: BTreeMap<_, _> = vec![
+            (
+                (
+                    MetadataPath::from_role(&Role::Root),
+                    MetadataVersion::Number(1),
+                ),
+                raw_root1.as_bytes(),
+            ),
+            (
+                (MetadataPath::from_role(&Role::Root), MetadataVersion::None),
+                raw_root1.as_bytes(),
+            ),
+            (
+                (
+                    MetadataPath::from_role(&Role::Targets),
+                    MetadataVersion::None,
+                ),
+                raw_targets1.as_bytes(),
+            ),
+            (
+                (
+                    MetadataPath::from_role(&Role::Snapshot),
+                    MetadataVersion::None,
+                ),
+                raw_snapshot1.as_bytes(),
+            ),
+            (
+                (
+                    MetadataPath::from_role(&Role::Timestamp),
+                    MetadataVersion::None,
+                ),
+                raw_timestamp1.as_bytes(),
+            ),
+        ]
+        .into_iter()
+        .collect();
+
+        if consistent_snapshot {
+            expected_metadata.extend(vec![
+                (
+                    (
+                        MetadataPath::from_role(&Role::Targets),
+                        MetadataVersion::Number(1),
+                    ),
+                    raw_targets1.as_bytes(),
+                ),
+                (
+                    (
+                        MetadataPath::from_role(&Role::Snapshot),
+                        MetadataVersion::Number(1),
+                    ),
+                    raw_snapshot1.as_bytes(),
+                ),
+            ]);
+        }
+
+        assert_repo(&remote, &expected_metadata);
+
+        // Create a client, and make sure we can update to the version we
+        // just made.
+        let mut client = Client::with_trusted_root(
+            Config::default(),
+            metadata1.root().unwrap(),
+            EphemeralRepository::new(),
+            remote,
+        )
+        .await
+        .unwrap();
+        client.update().await.unwrap();
+        assert_eq!(client.trusted_root().version(), 1);
+        assert_eq!(client.trusted_targets().map(|m| m.version()), Some(1));
+        assert_eq!(client.trusted_snapshot().map(|m| m.version()), Some(1));
+        assert_eq!(client.trusted_timestamp().map(|m| m.version()), Some(1));
+
+        // Create a new metadata, derived from the tuf database we created
+        // with the client.
+        let expires2 = Utc.ymd(2038, 1, 2).and_hms(0, 0, 0);
+        let mut parts = client.into_parts();
+        let metadata2 = RepoBuilder::from_database(&mut parts.remote, &parts.database)
+            .trusted_root_keys(&[&KEYS[0], &KEYS[1], &KEYS[2]])
+            .trusted_targets_keys(&[&KEYS[1], &KEYS[2], &KEYS[3]])
+            .trusted_snapshot_keys(&[&KEYS[2], &KEYS[3], &KEYS[4]])
+            .trusted_timestamp_keys(&[&KEYS[3], &KEYS[4], &KEYS[5]])
+            .with_root_builder(|builder| builder.expires(expires2))
+            .unwrap()
+            .with_targets_builder(|builder| builder.expires(expires2))
+            .unwrap()
+            .snapshot_includes_length(false)
+            .snapshot_includes_hashes(&[])
+            .with_snapshot_builder(|builder| builder.expires(expires2))
+            .unwrap()
+            .timestamp_includes_length(false)
+            .timestamp_includes_hashes(&[])
+            .with_timestamp_builder(|builder| builder.expires(expires2))
+            .unwrap()
+            .commit()
+            .await
+            .unwrap();
+
+        // Make sure the new metadata was generated as expected.
+        let signed_root2 = create_root(2, consistent_snapshot, expires2);
+        let signed_targets2 = create_targets(2, expires2);
+        let signed_snapshot2 = create_snapshot(2, expires2, &signed_targets2, false);
+        let signed_timestamp2 = create_timestamp(2, expires2, &signed_snapshot2, false);
+
+        let raw_root2 = signed_root2.to_raw().unwrap();
+        let raw_targets2 = signed_targets2.to_raw().unwrap();
+        let raw_snapshot2 = signed_snapshot2.to_raw().unwrap();
+        let raw_timestamp2 = signed_timestamp2.to_raw().unwrap();
+
+        assert_metadata(
+            &metadata2,
+            Some(&raw_root2),
+            Some(&raw_targets2),
+            Some(&raw_snapshot2),
+            Some(&raw_timestamp2),
+        );
+
+        // Check that the new metadata was written.
+        expected_metadata.extend(vec![
+            (
+                (
+                    MetadataPath::from_role(&Role::Root),
+                    MetadataVersion::Number(2),
+                ),
+                raw_root2.as_bytes(),
+            ),
+            (
+                (MetadataPath::from_role(&Role::Root), MetadataVersion::None),
+                raw_root2.as_bytes(),
+            ),
+            (
+                (
+                    MetadataPath::from_role(&Role::Targets),
+                    MetadataVersion::None,
+                ),
+                raw_targets2.as_bytes(),
+            ),
+            (
+                (
+                    MetadataPath::from_role(&Role::Snapshot),
+                    MetadataVersion::None,
+                ),
+                raw_snapshot2.as_bytes(),
+            ),
+            (
+                (
+                    MetadataPath::from_role(&Role::Timestamp),
+                    MetadataVersion::None,
+                ),
+                raw_timestamp2.as_bytes(),
+            ),
+        ]);
+
+        if consistent_snapshot {
+            expected_metadata.extend(vec![
+                (
+                    (
+                        MetadataPath::from_role(&Role::Targets),
+                        MetadataVersion::Number(2),
+                    ),
+                    raw_targets2.as_bytes(),
+                ),
+                (
+                    (
+                        MetadataPath::from_role(&Role::Snapshot),
+                        MetadataVersion::Number(2),
+                    ),
+                    raw_snapshot2.as_bytes(),
+                ),
+            ]);
+        }
+
+        assert_repo(&parts.remote, &expected_metadata);
+
+        // And make sure the client can update to the latest metadata.
+        let mut client = Client::from_parts(parts);
+        client.update().await.unwrap();
+        assert_eq!(client.trusted_root().version(), 2);
+        assert_eq!(client.trusted_targets().map(|m| m.version()), Some(2));
+        assert_eq!(client.trusted_snapshot().map(|m| m.version()), Some(2));
+        assert_eq!(client.trusted_timestamp().map(|m| m.version()), Some(2));
+    }
+
+    #[test]
+    fn commit_does_nothing_if_nothing_changed_not_consistent_snapshot() {
+        block_on(commit_does_nothing_if_nothing_changed(false))
+    }
+
+    #[test]
+    fn commit_does_nothing_if_nothing_changed_consistent_snapshot() {
+        block_on(commit_does_nothing_if_nothing_changed(true))
+    }
+
+    async fn commit_does_nothing_if_nothing_changed(consistent_snapshot: bool) {
+        let mut repo = EphemeralRepository::<Json>::new();
+        let metadata1 = RepoBuilder::create(&mut repo)
+            .trusted_root_keys(&[&KEYS[0]])
+            .trusted_targets_keys(&[&KEYS[0]])
+            .trusted_snapshot_keys(&[&KEYS[0]])
+            .trusted_timestamp_keys(&[&KEYS[0]])
+            .with_root_builder(|builder| builder.consistent_snapshot(consistent_snapshot))
+            .unwrap()
+            .commit()
+            .await
+            .unwrap();
+
+        let client_repo = EphemeralRepository::new();
+        let mut client = Client::with_trusted_root(
+            Config::default(),
+            metadata1.root().unwrap(),
+            client_repo,
+            repo,
+        )
+        .await
+        .unwrap();
+
+        assert!(client.update().await.unwrap());
+        assert_eq!(client.trusted_root().version(), 1);
+
+        // Make sure doing another commit makes no changes.
+        let mut parts = client.into_parts();
+        let metadata2 = RepoBuilder::from_database(&mut parts.remote, &parts.database)
+            .trusted_root_keys(&[&KEYS[0]])
+            .trusted_targets_keys(&[&KEYS[0]])
+            .trusted_snapshot_keys(&[&KEYS[0]])
+            .trusted_timestamp_keys(&[&KEYS[0]])
+            .commit()
+            .await
+            .unwrap();
+
+        assert_metadata(&metadata2, None, None, None, None);
+
+        let mut client = Client::from_parts(parts);
+        assert!(!client.update().await.unwrap());
+        assert_eq!(client.trusted_root().version(), 1);
+    }
+
+    #[test]
+    fn root_chain_update_not_consistent() {
+        block_on(check_root_chain_update(false));
+    }
+
+    #[test]
+    fn root_chain_update_consistent() {
+        block_on(check_root_chain_update(true));
+    }
+
+    async fn check_root_chain_update(consistent_snapshot: bool) {
+        let mut repo = EphemeralRepository::<Json>::new();
+
+        // First, create the initial metadata. We initially sign the root
+        // metadata with key 1.
+        let metadata1 = RepoBuilder::create(&mut repo)
+            .trusted_root_keys(&[&KEYS[1]])
+            .trusted_targets_keys(&[&KEYS[0]])
+            .trusted_snapshot_keys(&[&KEYS[0]])
+            .trusted_timestamp_keys(&[&KEYS[0]])
+            .with_root_builder(|builder| builder.consistent_snapshot(consistent_snapshot))
+            .unwrap()
+            .commit()
+            .await
+            .unwrap();
+
+        let client_repo = EphemeralRepository::new();
+        let mut client = Client::with_trusted_root(
+            Config::default(),
+            metadata1.root().unwrap(),
+            client_repo,
+            repo,
+        )
+        .await
+        .unwrap();
+
+        assert!(client.update().await.unwrap());
+        assert_eq!(client.trusted_root().version(), 1);
+        assert_eq!(
+            client.trusted_root().root_keys().collect::<Vec<_>>(),
+            vec![KEYS[1].public()],
+        );
+
+        // Another update should not fetch anything.
+        assert!(!client.update().await.unwrap());
+        assert_eq!(client.trusted_root().version(), 1);
+
+        // Now bump the root to version 2. We sign the root metadata with both
+        // key 1 and 2, but the builder should only trust key 2.
+        let mut parts = client.into_parts();
+        let _metadata2 = RepoBuilder::from_database(&mut parts.remote, &parts.database)
+            .signing_root_keys(&[&KEYS[1]])
+            .trusted_root_keys(&[&KEYS[2]])
+            .trusted_targets_keys(&[&KEYS[0]])
+            .trusted_snapshot_keys(&[&KEYS[0]])
+            .trusted_timestamp_keys(&[&KEYS[0]])
+            .commit()
+            .await
+            .unwrap();
+
+        let mut client = Client::from_parts(parts);
+        assert!(client.update().await.unwrap());
+        assert_eq!(client.trusted_root().version(), 2);
+        assert_eq!(
+            client.trusted_root().consistent_snapshot(),
+            consistent_snapshot
+        );
+        assert_eq!(
+            client.trusted_root().root_keys().collect::<Vec<_>>(),
+            vec![KEYS[2].public()],
+        );
+
+        // Another update should not fetch anything.
+        assert!(!client.update().await.unwrap());
+        assert_eq!(client.trusted_root().version(), 2);
+
+        // Now bump the root to version 3. The metadata will only be signed with
+        // key 2, and trusted by key 2.
+        let mut parts = client.into_parts();
+        let _metadata3 = RepoBuilder::from_database(&mut parts.remote, &parts.database)
+            .trusted_root_keys(&[&KEYS[2]])
+            .trusted_targets_keys(&[&KEYS[0]])
+            .trusted_snapshot_keys(&[&KEYS[0]])
+            .trusted_timestamp_keys(&[&KEYS[0]])
+            .create_root()
+            .unwrap()
+            .commit()
+            .await
+            .unwrap();
+
+        let mut client = Client::from_parts(parts);
+        assert!(client.update().await.unwrap());
+        assert_eq!(client.trusted_root().version(), 3);
+        assert_eq!(
+            client.trusted_root().root_keys().collect::<Vec<_>>(),
+            vec![KEYS[2].public()],
+        );
+
+        // Another update should not fetch anything.
+        assert!(!client.update().await.unwrap());
+        assert_eq!(client.trusted_root().version(), 3);
+    }
+
+    #[test]
+    fn test_from_database_root_must_be_one_after_the_last() {
+        block_on(async {
+            let mut repo = EphemeralRepository::<Json>::new();
+            let metadata = RepoBuilder::create(&mut repo)
+                .trusted_root_keys(&[&KEYS[0]])
+                .trusted_targets_keys(&[&KEYS[0]])
+                .trusted_snapshot_keys(&[&KEYS[0]])
+                .trusted_timestamp_keys(&[&KEYS[0]])
+                .commit()
+                .await
+                .unwrap();
+
+            let db = Database::from_trusted_metadata(&metadata).unwrap();
+
+            assert_matches!(
+                RepoBuilder::from_database(&mut repo, &db)
+                    .trusted_root_keys(&[&KEYS[0]])
+                    .trusted_targets_keys(&[&KEYS[0]])
+                    .trusted_snapshot_keys(&[&KEYS[0]])
+                    .trusted_timestamp_keys(&[&KEYS[0]])
+                    .with_root_builder(|builder| builder.version(3))
+                    .unwrap()
+                    .commit().await,
+                Err(Error::VerificationFailure(s))
+                if &s == "Attempted to roll back root metadata at version 1 to 3."
+            );
+        })
+    }
+
+    #[test]
+    fn test_add_target_not_consistent_snapshot() {
+        block_on(async move {
+            let mut repo = EphemeralRepository::<Json>::new();
+
+            let hash_algs = &[HashAlgorithm::Sha256, HashAlgorithm::Sha512];
+
+            let target_path = TargetPath::new("foo/bar").unwrap();
+            let target_file: &[u8] = b"things fade, alternatives exclude";
+
+            let metadata = RepoBuilder::create(&mut repo)
+                .trusted_root_keys(&[&KEYS[0]])
+                .trusted_targets_keys(&[&KEYS[0]])
+                .trusted_snapshot_keys(&[&KEYS[0]])
+                .trusted_timestamp_keys(&[&KEYS[0]])
+                .with_root_builder(|builder| builder.consistent_snapshot(false))
+                .unwrap()
+                .file_hash_algorithms(hash_algs)
+                .add_target(target_path.clone(), Cursor::new(target_file))
+                .await
+                .unwrap()
+                .commit()
+                .await
+                .unwrap();
+
+            // Make sure the target was written correctly.
+            let mut rdr = repo.fetch_target(&target_path).await.unwrap();
+            let mut buf = vec![];
+            rdr.read_to_end(&mut buf).await.unwrap();
+            drop(rdr);
+
+            assert_eq!(&buf, target_file);
+
+            let mut client = Client::with_trusted_root(
+                Config::default(),
+                metadata.root().unwrap(),
+                EphemeralRepository::new(),
+                repo,
+            )
+            .await
+            .unwrap();
+
+            client.update().await.unwrap();
+
+            // Make sure the target description is correct.
+            assert_eq!(
+                client.fetch_target_description(&target_path).await.unwrap(),
+                TargetDescription::from_slice(target_file, hash_algs).unwrap(),
+            );
+
+            // Make sure we can fetch the target.
+            let mut rdr = client.fetch_target(&target_path).await.unwrap();
+            let mut buf = vec![];
+            rdr.read_to_end(&mut buf).await.unwrap();
+            assert_eq!(&buf, target_file);
+        })
+    }
+
+    #[test]
+    fn test_add_target_consistent_snapshot() {
+        block_on(async move {
+            let mut repo = EphemeralRepository::<Json>::new();
+
+            let hash_algs = &[HashAlgorithm::Sha256, HashAlgorithm::Sha512];
+
+            let target_path = TargetPath::new("foo/bar").unwrap();
+            let target_file: &[u8] = b"things fade, alternatives exclude";
+
+            let metadata = RepoBuilder::create(&mut repo)
+                .trusted_root_keys(&[&KEYS[0]])
+                .trusted_targets_keys(&[&KEYS[0]])
+                .trusted_snapshot_keys(&[&KEYS[0]])
+                .trusted_timestamp_keys(&[&KEYS[0]])
+                .with_root_builder(|builder| builder.consistent_snapshot(true))
+                .unwrap()
+                .file_hash_algorithms(hash_algs)
+                .add_target(target_path.clone(), Cursor::new(target_file))
+                .await
+                .unwrap()
+                .commit()
+                .await
+                .unwrap();
+
+            // Make sure the target was written correctly with hash prefixes.
+            for hash_alg in hash_algs {
+                let hash = crypto::calculate_hash(target_file, hash_alg);
+                let target_path = target_path.with_hash_prefix(&hash).unwrap();
+
+                let mut rdr = repo.fetch_target(&target_path).await.unwrap();
+                let mut buf = vec![];
+                rdr.read_to_end(&mut buf).await.unwrap();
+
+                assert_eq!(&buf, target_file);
+            }
+
+            let mut client = Client::with_trusted_root(
+                Config::default(),
+                metadata.root().unwrap(),
+                EphemeralRepository::new(),
+                repo,
+            )
+            .await
+            .unwrap();
+
+            client.update().await.unwrap();
+
+            // Make sure the target description is correct.
+            assert_eq!(
+                client.fetch_target_description(&target_path).await.unwrap(),
+                TargetDescription::from_slice(target_file, hash_algs).unwrap(),
+            );
+
+            // Make sure we can fetch the target.
+            let mut rdr = client.fetch_target(&target_path).await.unwrap();
+            let mut buf = vec![];
+            rdr.read_to_end(&mut buf).await.unwrap();
+            assert_eq!(&buf, target_file);
+        })
+    }
 }

--- a/tuf/src/repo_builder.rs
+++ b/tuf/src/repo_builder.rs
@@ -510,17 +510,8 @@ where
         }
     }
 
-    /// Initialize a [RootMetadataBuilder] with the configured keys, and the
-    /// following defaults:
-    ///
-    /// * If the [RepoBuilder] was created for a new repository,  was created with a [Database], the version will be 1
-    ///
-    /// and pass it to the closure for further configuration. The builder then
-    /// will be used to generate a new root metadata and stage
-    ///
-    /// Generate a new metadata This function will generate a new root metadata,
-    /// which will automatically increment the version, and set the expiration
-    /// to the default expiration of one year.
+    /// This function will generate a new root metadata, which will automatically increment the
+    /// version, and set the expiration to the default expiration of 1 year.
     pub fn with_root_builder<F>(self, f: F) -> Result<RepoBuilder<'a, D, R, Targets<D>>>
     where
         F: FnOnce(RootMetadataBuilder) -> RootMetadataBuilder,
@@ -553,9 +544,8 @@ where
         })
     }
 
-    /// This function will generate a new targets metadata, which will
-    /// automatically increment the version, and set the expiration to the
-    /// default expiration of 3 months.
+    /// This function will generate a new targets metadata, which will automatically increment the
+    /// version, and set the expiration to the default expiration of 3 months.
     pub fn with_targets_builder<F>(self, f: F) -> Result<RepoBuilder<'a, D, R, Snapshot<D>>>
     where
         F: FnOnce(TargetsMetadataBuilder) -> TargetsMetadataBuilder,
@@ -563,9 +553,8 @@ where
         self.create_root_if_necessary()?.with_targets_builder(f)
     }
 
-    /// This function will generate a new snapshot metadata, which will
-    /// automatically increment the version, and set the expiration to the
-    /// default expiration of 3 months.
+    /// This function will generate a new snapshot metadata, which will automatically increment the
+    /// version, and set the expiration to the default expiration of 7 days.
     pub fn with_snapshot_builder<F>(self, f: F) -> Result<RepoBuilder<'a, D, R, Timestamp<D>>>
     where
         F: FnOnce(SnapshotMetadataBuilder) -> SnapshotMetadataBuilder,
@@ -573,9 +562,8 @@ where
         self.create_root_if_necessary()?.with_snapshot_builder(f)
     }
 
-    /// This function will generate a new timestamp metadata, which will
-    /// automatically increment the version, and set the expiration to the
-    /// default expiration of 3 months.
+    /// This function will generate a new timestamp metadata, which will automatically increment
+    /// the version, and set the expiration to the default expiration of 1 day.
     pub fn with_timestamp_builder<F>(self, f: F) -> Result<RepoBuilder<'a, D, R, Done<D>>>
     where
         F: FnOnce(TimestampMetadataBuilder) -> TimestampMetadataBuilder,
@@ -748,9 +736,8 @@ where
         Ok(self)
     }
 
-    /// This function will generate a new targets metadata, which will
-    /// automatically increment the version, and set the expiration to the
-    /// default expiration of 3 months.
+    /// This function will generate a new targets metadata, which will automatically increment the
+    /// version, and set the expiration to the default expiration of 3 months.
     pub fn with_targets_builder<F>(self, f: F) -> Result<RepoBuilder<'a, D, R, Snapshot<D>>>
     where
         F: FnOnce(TargetsMetadataBuilder) -> TargetsMetadataBuilder,
@@ -791,9 +778,8 @@ where
         })
     }
 
-    /// This function will generate a new snapshot metadata, which will
-    /// automatically increment the version, and set the expiration to the
-    /// default expiration of 3 months.
+    /// This function will generate a new snapshot metadata, which will automatically increment the
+    /// version, and set the expiration to the default expiration of 7 days.
     pub fn with_snapshot_builder<F>(self, f: F) -> Result<RepoBuilder<'a, D, R, Timestamp<D>>>
     where
         F: FnOnce(SnapshotMetadataBuilder) -> SnapshotMetadataBuilder,
@@ -801,9 +787,8 @@ where
         self.create_targets_if_necessary()?.with_snapshot_builder(f)
     }
 
-    /// This function will generate a new timestamp metadata, which will
-    /// automatically increment the version, and set the expiration to the
-    /// default expiration of 3 months.
+    /// This function will generate a new timestamp metadata, which will automatically increment
+    /// the version, and set the expiration to the default expiration of 1 day.
     pub fn with_timestamp_builder<F>(self, f: F) -> Result<RepoBuilder<'a, D, R, Done<D>>>
     where
         F: FnOnce(TimestampMetadataBuilder) -> TimestampMetadataBuilder,
@@ -909,9 +894,8 @@ where
         }
     }
 
-    /// This function will generate a new snapshot metadata, which will automatically
-    /// increment the version, and set the expiration to the default expiration of
-    /// 7 days.
+    /// This function will generate a new snapshot metadata, which will automatically increment the
+    /// version, and set the expiration to the default expiration of 7 days.
     pub fn with_snapshot_builder<F>(self, f: F) -> Result<RepoBuilder<'a, D, R, Timestamp<D>>>
     where
         F: FnOnce(SnapshotMetadataBuilder) -> SnapshotMetadataBuilder,
@@ -973,9 +957,8 @@ where
         })
     }
 
-    /// This function will generate a new timestamp metadata, which will
-    /// automatically increment the version, and set the expiration to the
-    /// default expiration of 3 months.
+    /// This function will generate a new timestamp metadata, which will automatically increment
+    /// the version, and set the expiration to the default expiration of 1 day.
     pub fn with_timestamp_builder<F>(self, f: F) -> Result<RepoBuilder<'a, D, R, Done<D>>>
     where
         F: FnOnce(TimestampMetadataBuilder) -> TimestampMetadataBuilder,
@@ -1076,9 +1059,8 @@ where
         }
     }
 
-    /// Build timestamp metadata for this repository, then write all metadata to
-    /// the repository. Before writing the metadata to `repo`, this will test
-    /// that a client can update to this metadata to make sure it is valid.
+    /// This function will generate a new timestamp metadata, which will automatically increment
+    /// the version, and set the expiration to the default expiration of 1 day.
     pub fn with_timestamp_builder<F>(self, f: F) -> Result<RepoBuilder<'a, D, R, Done<D>>>
     where
         F: FnOnce(TimestampMetadataBuilder) -> TimestampMetadataBuilder,

--- a/tuf/src/repository/ephemeral.rs
+++ b/tuf/src/repository/ephemeral.rs
@@ -32,6 +32,11 @@ where
             _interchange: PhantomData,
         }
     }
+
+    #[cfg(test)]
+    pub(crate) fn metadata(&self) -> &HashMap<(MetadataPath, MetadataVersion), Box<[u8]>> {
+        &self.metadata
+    }
 }
 
 impl<D> Default for EphemeralRepository<D>

--- a/tuf/tests/integration.rs
+++ b/tuf/tests/integration.rs
@@ -1,12 +1,14 @@
+use futures_executor::block_on;
 use maplit::hashmap;
 use matches::assert_matches;
-use std::iter::once;
 use tuf::crypto::{Ed25519PrivateKey, HashAlgorithm, PrivateKey};
 use tuf::interchange::Json;
 use tuf::metadata::{
-    Delegation, Delegations, MetadataDescription, MetadataPath, Role, RootMetadataBuilder,
-    SnapshotMetadataBuilder, TargetPath, TargetsMetadataBuilder, TimestampMetadataBuilder,
+    Delegation, Delegations, MetadataDescription, MetadataPath, Role, TargetPath,
+    TargetsMetadataBuilder,
 };
+use tuf::repo_builder::RepoBuilder;
+use tuf::repository::EphemeralRepository;
 use tuf::Database;
 use tuf::Error;
 
@@ -19,423 +21,95 @@ const ED25519_6_PK8: &[u8] = include_bytes!("./ed25519/ed25519-6.pk8.der");
 
 #[test]
 fn simple_delegation() {
-    let root_key = Ed25519PrivateKey::from_pkcs8(ED25519_1_PK8).unwrap();
-    let snapshot_key = Ed25519PrivateKey::from_pkcs8(ED25519_2_PK8).unwrap();
-    let targets_key = Ed25519PrivateKey::from_pkcs8(ED25519_3_PK8).unwrap();
-    let timestamp_key = Ed25519PrivateKey::from_pkcs8(ED25519_4_PK8).unwrap();
-    let delegation_key = Ed25519PrivateKey::from_pkcs8(ED25519_5_PK8).unwrap();
+    block_on(async {
+        let root_key = Ed25519PrivateKey::from_pkcs8(ED25519_1_PK8).unwrap();
+        let snapshot_key = Ed25519PrivateKey::from_pkcs8(ED25519_2_PK8).unwrap();
+        let targets_key = Ed25519PrivateKey::from_pkcs8(ED25519_3_PK8).unwrap();
+        let timestamp_key = Ed25519PrivateKey::from_pkcs8(ED25519_4_PK8).unwrap();
+        let delegation_key = Ed25519PrivateKey::from_pkcs8(ED25519_5_PK8).unwrap();
 
-    //// build the root ////
-
-    let root = RootMetadataBuilder::new()
-        .root_key(root_key.public().clone())
-        .snapshot_key(snapshot_key.public().clone())
-        .targets_key(targets_key.public().clone())
-        .timestamp_key(timestamp_key.public().clone())
-        .signed::<Json>(&root_key)
+        let delegations = Delegations::new(
+            hashmap! { delegation_key.public().key_id().clone() => delegation_key.public().clone() },
+            vec![Delegation::new(
+                MetadataPath::new("delegation").unwrap(),
+                false,
+                1,
+                vec![delegation_key.public().key_id().clone()]
+                    .iter()
+                    .cloned()
+                    .collect(),
+                vec![TargetPath::new("foo").unwrap()]
+                    .iter()
+                    .cloned()
+                    .collect(),
+            )
+            .unwrap()],
+        )
         .unwrap();
-    let raw_root = root.to_raw().unwrap();
 
-    let mut tuf =
-        Database::<Json>::from_root_with_trusted_keys(&raw_root, 1, once(root_key.public()))
+        let mut repo = EphemeralRepository::new();
+        let metadata = RepoBuilder::create(&mut repo)
+            .trusted_root_keys(&[&root_key])
+            .trusted_snapshot_keys(&[&snapshot_key])
+            .trusted_targets_keys(&[&targets_key])
+            .trusted_timestamp_keys(&[&timestamp_key])
+            .with_targets_builder(|builder| builder.delegations(delegations))
+            .unwrap()
+            .with_snapshot_builder(|builder| {
+                builder.insert_metadata_description(
+                    MetadataPath::new("delegation").unwrap(),
+                    MetadataDescription::from_slice(&[0u8], 1, &[HashAlgorithm::Sha256]).unwrap(),
+                )
+            })
+            .unwrap()
+            .commit()
+            .await
             .unwrap();
 
-    //// build the snapshot and timestamp ////
+        let mut tuf = Database::<Json>::from_trusted_metadata(&metadata).unwrap();
 
-    let snapshot = SnapshotMetadataBuilder::new()
-        .insert_metadata_description(
-            MetadataPath::new("targets").unwrap(),
-            MetadataDescription::from_slice(&[0u8], 1, &[HashAlgorithm::Sha256]).unwrap(),
+        //// build the targets ////
+        //// build the delegation ////
+        let target_file: &[u8] = b"bar";
+        let delegation = TargetsMetadataBuilder::new()
+            .insert_target_from_slice(
+                TargetPath::new("foo").unwrap(),
+                target_file,
+                &[HashAlgorithm::Sha256],
+            )
+            .unwrap()
+            .signed::<Json>(&delegation_key)
+            .unwrap();
+        let raw_delegation = delegation.to_raw().unwrap();
+
+        tuf.update_delegation(
+            &MetadataPath::from_role(&Role::Targets),
+            &MetadataPath::new("delegation").unwrap(),
+            &raw_delegation,
         )
-        .insert_metadata_description(
-            MetadataPath::new("delegation").unwrap(),
-            MetadataDescription::from_slice(&[0u8], 1, &[HashAlgorithm::Sha256]).unwrap(),
-        )
-        .signed::<Json>(&snapshot_key)
         .unwrap();
-    let raw_snapshot = snapshot.to_raw().unwrap();
 
-    let timestamp = TimestampMetadataBuilder::from_snapshot(&snapshot, &[HashAlgorithm::Sha256])
-        .unwrap()
-        .signed::<Json>(&timestamp_key)
-        .unwrap();
-    let raw_timestamp = timestamp.to_raw().unwrap();
-
-    tuf.update_timestamp(&raw_timestamp).unwrap();
-    tuf.update_snapshot(&raw_snapshot).unwrap();
-
-    //// build the targets ////
-    let delegations = Delegations::new(
-        hashmap! { delegation_key.public().key_id().clone() => delegation_key.public().clone() },
-        vec![Delegation::new(
-            MetadataPath::new("delegation").unwrap(),
-            false,
-            1,
-            vec![delegation_key.public().key_id().clone()]
-                .iter()
-                .cloned()
-                .collect(),
-            vec![TargetPath::new("foo").unwrap()]
-                .iter()
-                .cloned()
-                .collect(),
-        )
-        .unwrap()],
-    )
-    .unwrap();
-    let targets = TargetsMetadataBuilder::new()
-        .delegations(delegations)
-        .signed::<Json>(&targets_key)
-        .unwrap();
-    let raw_targets = targets.to_raw().unwrap();
-
-    tuf.update_targets(&raw_targets).unwrap();
-
-    //// build the delegation ////
-    let target_file: &[u8] = b"bar";
-    let delegation = TargetsMetadataBuilder::new()
-        .insert_target_from_slice(
-            TargetPath::new("foo").unwrap(),
-            target_file,
-            &[HashAlgorithm::Sha256],
-        )
-        .unwrap()
-        .signed::<Json>(&delegation_key)
-        .unwrap();
-    let raw_delegation = delegation.to_raw().unwrap();
-
-    tuf.update_delegation(
-        &MetadataPath::from_role(&Role::Targets),
-        &MetadataPath::new("delegation").unwrap(),
-        &raw_delegation,
-    )
-    .unwrap();
-
-    assert!(tuf
-        .target_description(&TargetPath::new("foo").unwrap())
-        .is_ok());
+        assert!(tuf
+            .target_description(&TargetPath::new("foo").unwrap())
+            .is_ok());
+    })
 }
 
 #[test]
 fn nested_delegation() {
-    let root_key = Ed25519PrivateKey::from_pkcs8(ED25519_1_PK8).unwrap();
-    let snapshot_key = Ed25519PrivateKey::from_pkcs8(ED25519_2_PK8).unwrap();
-    let targets_key = Ed25519PrivateKey::from_pkcs8(ED25519_3_PK8).unwrap();
-    let timestamp_key = Ed25519PrivateKey::from_pkcs8(ED25519_4_PK8).unwrap();
-    let delegation_a_key = Ed25519PrivateKey::from_pkcs8(ED25519_5_PK8).unwrap();
-    let delegation_b_key = Ed25519PrivateKey::from_pkcs8(ED25519_6_PK8).unwrap();
+    block_on(async {
+        let root_key = Ed25519PrivateKey::from_pkcs8(ED25519_1_PK8).unwrap();
+        let snapshot_key = Ed25519PrivateKey::from_pkcs8(ED25519_2_PK8).unwrap();
+        let targets_key = Ed25519PrivateKey::from_pkcs8(ED25519_3_PK8).unwrap();
+        let timestamp_key = Ed25519PrivateKey::from_pkcs8(ED25519_4_PK8).unwrap();
+        let delegation_a_key = Ed25519PrivateKey::from_pkcs8(ED25519_5_PK8).unwrap();
+        let delegation_b_key = Ed25519PrivateKey::from_pkcs8(ED25519_6_PK8).unwrap();
 
-    //// build the root ////
-
-    let root = RootMetadataBuilder::new()
-        .root_key(root_key.public().clone())
-        .snapshot_key(snapshot_key.public().clone())
-        .targets_key(targets_key.public().clone())
-        .timestamp_key(timestamp_key.public().clone())
-        .signed::<Json>(&root_key)
-        .unwrap();
-    let raw_root = root.to_raw().unwrap();
-
-    let mut tuf =
-        Database::<Json>::from_root_with_trusted_keys(&raw_root, 1, once(root_key.public()))
-            .unwrap();
-
-    //// build the snapshot and timestamp ////
-
-    let snapshot = SnapshotMetadataBuilder::new()
-        .insert_metadata_description(
-            MetadataPath::new("targets").unwrap(),
-            MetadataDescription::from_slice(&[0u8], 1, &[HashAlgorithm::Sha256]).unwrap(),
-        )
-        .insert_metadata_description(
-            MetadataPath::new("delegation-a").unwrap(),
-            MetadataDescription::from_slice(&[0u8], 1, &[HashAlgorithm::Sha256]).unwrap(),
-        )
-        .insert_metadata_description(
-            MetadataPath::new("delegation-b").unwrap(),
-            MetadataDescription::from_slice(&[0u8], 1, &[HashAlgorithm::Sha256]).unwrap(),
-        )
-        .signed::<Json>(&snapshot_key)
-        .unwrap();
-    let raw_snapshot = snapshot.to_raw().unwrap();
-
-    let timestamp = TimestampMetadataBuilder::from_snapshot(&snapshot, &[HashAlgorithm::Sha256])
-        .unwrap()
-        .signed::<Json>(&timestamp_key)
-        .unwrap();
-    let raw_timestamp = timestamp.to_raw().unwrap();
-
-    tuf.update_timestamp(&raw_timestamp).unwrap();
-    tuf.update_snapshot(&raw_snapshot).unwrap();
-
-    //// build the targets ////
-
-    let delegations = Delegations::new(
-        hashmap! {
-            delegation_a_key.public().key_id().clone() => delegation_a_key.public().clone(),
-        },
-        vec![Delegation::new(
-            MetadataPath::new("delegation-a").unwrap(),
-            false,
-            1,
-            vec![delegation_a_key.public().key_id().clone()]
-                .iter()
-                .cloned()
-                .collect(),
-            vec![TargetPath::new("foo").unwrap()]
-                .iter()
-                .cloned()
-                .collect(),
-        )
-        .unwrap()],
-    )
-    .unwrap();
-    let targets = TargetsMetadataBuilder::new()
-        .delegations(delegations)
-        .signed::<Json>(&targets_key)
-        .unwrap();
-    let raw_targets = targets.to_raw().unwrap();
-
-    tuf.update_targets(&raw_targets).unwrap();
-
-    //// build delegation A ////
-
-    let delegations = Delegations::new(
-        hashmap! { delegation_b_key.public().key_id().clone() => delegation_b_key.public().clone() },
-        vec![Delegation::new(
-            MetadataPath::new("delegation-b").unwrap(),
-            false,
-            1,
-            vec![delegation_b_key.public().key_id().clone()].iter().cloned().collect(),
-            vec![TargetPath::new("foo").unwrap()].iter().cloned().collect(),
-        )
-        .unwrap()],
-    )
-    .unwrap();
-
-    let delegation = TargetsMetadataBuilder::new()
-        .delegations(delegations)
-        .signed::<Json>(&delegation_a_key)
-        .unwrap();
-    let raw_delegation = delegation.to_raw().unwrap();
-
-    tuf.update_delegation(
-        &MetadataPath::from_role(&Role::Targets),
-        &MetadataPath::new("delegation-a").unwrap(),
-        &raw_delegation,
-    )
-    .unwrap();
-
-    //// build delegation B ////
-
-    let target_file: &[u8] = b"bar";
-
-    let delegation = TargetsMetadataBuilder::new()
-        .insert_target_from_slice(
-            TargetPath::new("foo").unwrap(),
-            target_file,
-            &[HashAlgorithm::Sha256],
-        )
-        .unwrap()
-        .signed::<Json>(&delegation_b_key)
-        .unwrap();
-    let raw_delegation = delegation.to_raw().unwrap();
-
-    tuf.update_delegation(
-        &MetadataPath::new("delegation-a").unwrap(),
-        &MetadataPath::new("delegation-b").unwrap(),
-        &raw_delegation,
-    )
-    .unwrap();
-
-    assert!(tuf
-        .target_description(&TargetPath::new("foo").unwrap())
-        .is_ok());
-}
-
-#[test]
-fn rejects_bad_delegation_signatures() {
-    let root_key = Ed25519PrivateKey::from_pkcs8(ED25519_1_PK8).unwrap();
-    let snapshot_key = Ed25519PrivateKey::from_pkcs8(ED25519_2_PK8).unwrap();
-    let targets_key = Ed25519PrivateKey::from_pkcs8(ED25519_3_PK8).unwrap();
-    let timestamp_key = Ed25519PrivateKey::from_pkcs8(ED25519_4_PK8).unwrap();
-    let delegation_key = Ed25519PrivateKey::from_pkcs8(ED25519_5_PK8).unwrap();
-    let bad_delegation_key = Ed25519PrivateKey::from_pkcs8(ED25519_6_PK8).unwrap();
-
-    //// build the root ////
-
-    let root = RootMetadataBuilder::new()
-        .root_key(root_key.public().clone())
-        .snapshot_key(snapshot_key.public().clone())
-        .targets_key(targets_key.public().clone())
-        .timestamp_key(timestamp_key.public().clone())
-        .signed::<Json>(&root_key)
-        .unwrap();
-    let raw_root = root.to_raw().unwrap();
-
-    let mut tuf =
-        Database::<Json>::from_root_with_trusted_keys(&raw_root, 1, once(root_key.public()))
-            .unwrap();
-
-    //// build the snapshot and timestamp ////
-
-    let snapshot = SnapshotMetadataBuilder::new()
-        .insert_metadata_description(
-            MetadataPath::new("targets").unwrap(),
-            MetadataDescription::from_slice(&*vec![0u8], 1, &[HashAlgorithm::Sha256]).unwrap(),
-        )
-        .insert_metadata_description(
-            MetadataPath::new("delegation").unwrap(),
-            MetadataDescription::from_slice(&*vec![0u8], 1, &[HashAlgorithm::Sha256]).unwrap(),
-        )
-        .signed::<Json>(&snapshot_key)
-        .unwrap();
-    let raw_snapshot = snapshot.to_raw().unwrap();
-
-    let timestamp = TimestampMetadataBuilder::from_snapshot(&snapshot, &[HashAlgorithm::Sha256])
-        .unwrap()
-        .signed::<Json>(&timestamp_key)
-        .unwrap();
-    let raw_timestamp = timestamp.to_raw().unwrap();
-
-    tuf.update_timestamp(&raw_timestamp).unwrap();
-    tuf.update_snapshot(&raw_snapshot).unwrap();
-
-    //// build the targets ////
-    let delegations = Delegations::new(
-        hashmap! { delegation_key.public().key_id().clone() => delegation_key.public().clone() },
-        vec![Delegation::new(
-            MetadataPath::new("delegation").unwrap(),
-            false,
-            1,
-            vec![delegation_key.public().key_id().clone()]
-                .iter()
-                .cloned()
-                .collect(),
-            vec![TargetPath::new("foo").unwrap()]
-                .iter()
-                .cloned()
-                .collect(),
-        )
-        .unwrap()],
-    )
-    .unwrap();
-    let targets = TargetsMetadataBuilder::new()
-        .delegations(delegations)
-        .signed::<Json>(&targets_key)
-        .unwrap();
-    let raw_targets = targets.to_raw().unwrap();
-
-    tuf.update_targets(&raw_targets).unwrap();
-
-    //// build the delegation ////
-    let target_file: &[u8] = b"bar";
-    let delegation = TargetsMetadataBuilder::new()
-        .insert_target_from_slice(
-            TargetPath::new("foo").unwrap(),
-            target_file,
-            &[HashAlgorithm::Sha256],
-        )
-        .unwrap()
-        .signed::<Json>(&bad_delegation_key)
-        .unwrap();
-    let raw_delegation = delegation.to_raw().unwrap();
-
-    assert_matches!(
-        tuf.update_delegation(
-            &MetadataPath::from_role(&Role::Targets),
-            &MetadataPath::new("delegation").unwrap(),
-            &raw_delegation
-        ),
-        Err(Error::VerificationFailure(_))
-    );
-
-    assert_matches!(
-        tuf.target_description(&TargetPath::new("foo").unwrap()),
-        Err(Error::TargetUnavailable)
-    );
-}
-
-#[test]
-fn diamond_delegation() {
-    let etc_key = Ed25519PrivateKey::from_pkcs8(ED25519_1_PK8).unwrap();
-    let targets_key = Ed25519PrivateKey::from_pkcs8(ED25519_2_PK8).unwrap();
-    let delegation_a_key = Ed25519PrivateKey::from_pkcs8(ED25519_3_PK8).unwrap();
-    let delegation_b_key = Ed25519PrivateKey::from_pkcs8(ED25519_4_PK8).unwrap();
-    let delegation_c_key = Ed25519PrivateKey::from_pkcs8(ED25519_5_PK8).unwrap();
-
-    // Given delegations a, b, and c, targets delegates "foo" to delegation-a and "bar" to
-    // delegation-b.
-    //
-    //             targets
-    //              /  \
-    //   delegation-a  delegation-b
-    //              \  /
-    //          delegation-c
-    //
-    // if delegation-a delegates "foo" to delegation-c, and
-    //    delegation-b delegates "bar" to delegation-c, but
-    //    delegation-b's signature is invalid, then delegation-c
-    // can contain target "bar" which is unaccessible and target "foo" which is.
-    //
-    // Verify tuf::Database handles this situation correctly.
-
-    //// build the root ////
-
-    let root = RootMetadataBuilder::new()
-        .root_key(etc_key.public().clone())
-        .snapshot_key(etc_key.public().clone())
-        .targets_key(targets_key.public().clone())
-        .timestamp_key(etc_key.public().clone())
-        .signed::<Json>(&etc_key)
-        .unwrap();
-    let raw_root = root.to_raw().unwrap();
-
-    let mut tuf =
-        Database::<Json>::from_root_with_trusted_keys(&raw_root, 1, once(etc_key.public()))
-            .unwrap();
-
-    //// build the snapshot and timestamp ////
-
-    let snapshot = SnapshotMetadataBuilder::new()
-        .insert_metadata_description(
-            MetadataPath::new("targets").unwrap(),
-            MetadataDescription::from_slice(&*vec![0u8], 1, &[HashAlgorithm::Sha256]).unwrap(),
-        )
-        .insert_metadata_description(
-            MetadataPath::new("delegation-a").unwrap(),
-            MetadataDescription::from_slice(&*vec![0u8], 1, &[HashAlgorithm::Sha256]).unwrap(),
-        )
-        .insert_metadata_description(
-            MetadataPath::new("delegation-b").unwrap(),
-            MetadataDescription::from_slice(&*vec![0u8], 1, &[HashAlgorithm::Sha256]).unwrap(),
-        )
-        .insert_metadata_description(
-            MetadataPath::new("delegation-c").unwrap(),
-            MetadataDescription::from_slice(&*vec![0u8], 1, &[HashAlgorithm::Sha256]).unwrap(),
-        )
-        .signed::<Json>(&etc_key)
-        .unwrap();
-    let raw_snapshot = snapshot.to_raw().unwrap();
-
-    let timestamp = TimestampMetadataBuilder::from_snapshot(&snapshot, &[HashAlgorithm::Sha256])
-        .unwrap()
-        .signed::<Json>(&etc_key)
-        .unwrap();
-    let raw_timestamp = timestamp.to_raw().unwrap();
-
-    tuf.update_timestamp(&raw_timestamp).unwrap();
-    tuf.update_snapshot(&raw_snapshot).unwrap();
-
-    //// build the targets ////
-
-    let delegations = Delegations::new(
-        hashmap! {
-            delegation_a_key.public().key_id().clone() => delegation_a_key.public().clone(),
-            delegation_b_key.public().key_id().clone() => delegation_b_key.public().clone(),
-        },
-        vec![
-            Delegation::new(
+        let delegations = Delegations::new(
+            hashmap! {
+                delegation_a_key.public().key_id().clone() => delegation_a_key.public().clone(),
+            },
+            vec![Delegation::new(
                 MetadataPath::new("delegation-a").unwrap(),
                 false,
                 1,
@@ -448,35 +122,272 @@ fn diamond_delegation() {
                     .cloned()
                     .collect(),
             )
-            .unwrap(),
-            Delegation::new(
-                MetadataPath::new("delegation-b").unwrap(),
+            .unwrap()],
+        )
+        .unwrap();
+
+        let mut repo = EphemeralRepository::new();
+        let metadata = RepoBuilder::create(&mut repo)
+            .trusted_root_keys(&[&root_key])
+            .trusted_snapshot_keys(&[&snapshot_key])
+            .trusted_targets_keys(&[&targets_key])
+            .trusted_timestamp_keys(&[&timestamp_key])
+            .with_targets_builder(|builder| builder.delegations(delegations))
+            .unwrap()
+            .with_snapshot_builder(|builder| {
+                builder
+                    .insert_metadata_description(
+                        MetadataPath::new("delegation-a").unwrap(),
+                        MetadataDescription::from_slice(&[0u8], 1, &[HashAlgorithm::Sha256])
+                            .unwrap(),
+                    )
+                    .insert_metadata_description(
+                        MetadataPath::new("delegation-b").unwrap(),
+                        MetadataDescription::from_slice(&[0u8], 1, &[HashAlgorithm::Sha256])
+                            .unwrap(),
+                    )
+            })
+            .unwrap()
+            .commit()
+            .await
+            .unwrap();
+
+        let mut tuf = Database::<Json>::from_trusted_metadata(&metadata).unwrap();
+
+        //// build delegation A ////
+
+        let delegations = Delegations::new(
+        hashmap! { delegation_b_key.public().key_id().clone() => delegation_b_key.public().clone() },
+        vec![Delegation::new(
+            MetadataPath::new("delegation-b").unwrap(),
+            false,
+            1,
+            vec![delegation_b_key.public().key_id().clone()].iter().cloned().collect(),
+            vec![TargetPath::new("foo").unwrap()].iter().cloned().collect(),
+        )
+        .unwrap()],
+    )
+    .unwrap();
+
+        let delegation = TargetsMetadataBuilder::new()
+            .delegations(delegations)
+            .signed::<Json>(&delegation_a_key)
+            .unwrap();
+        let raw_delegation = delegation.to_raw().unwrap();
+
+        tuf.update_delegation(
+            &MetadataPath::from_role(&Role::Targets),
+            &MetadataPath::new("delegation-a").unwrap(),
+            &raw_delegation,
+        )
+        .unwrap();
+
+        //// build delegation B ////
+
+        let target_file: &[u8] = b"bar";
+
+        let delegation = TargetsMetadataBuilder::new()
+            .insert_target_from_slice(
+                TargetPath::new("foo").unwrap(),
+                target_file,
+                &[HashAlgorithm::Sha256],
+            )
+            .unwrap()
+            .signed::<Json>(&delegation_b_key)
+            .unwrap();
+        let raw_delegation = delegation.to_raw().unwrap();
+
+        tuf.update_delegation(
+            &MetadataPath::new("delegation-a").unwrap(),
+            &MetadataPath::new("delegation-b").unwrap(),
+            &raw_delegation,
+        )
+        .unwrap();
+
+        assert!(tuf
+            .target_description(&TargetPath::new("foo").unwrap())
+            .is_ok());
+    })
+}
+
+#[test]
+fn rejects_bad_delegation_signatures() {
+    block_on(async {
+        let root_key = Ed25519PrivateKey::from_pkcs8(ED25519_1_PK8).unwrap();
+        let snapshot_key = Ed25519PrivateKey::from_pkcs8(ED25519_2_PK8).unwrap();
+        let targets_key = Ed25519PrivateKey::from_pkcs8(ED25519_3_PK8).unwrap();
+        let timestamp_key = Ed25519PrivateKey::from_pkcs8(ED25519_4_PK8).unwrap();
+        let delegation_key = Ed25519PrivateKey::from_pkcs8(ED25519_5_PK8).unwrap();
+        let bad_delegation_key = Ed25519PrivateKey::from_pkcs8(ED25519_6_PK8).unwrap();
+
+        let delegations = Delegations::new(
+            hashmap! { delegation_key.public().key_id().clone() => delegation_key.public().clone() },
+            vec![Delegation::new(
+                MetadataPath::new("delegation").unwrap(),
                 false,
                 1,
-                vec![delegation_b_key.public().key_id().clone()]
+                vec![delegation_key.public().key_id().clone()]
                     .iter()
                     .cloned()
                     .collect(),
-                vec![TargetPath::new("bar").unwrap()]
+                vec![TargetPath::new("foo").unwrap()]
                     .iter()
                     .cloned()
                     .collect(),
             )
-            .unwrap(),
-        ],
-    )
-    .unwrap();
-    let targets = TargetsMetadataBuilder::new()
-        .delegations(delegations)
-        .signed::<Json>(&targets_key)
+            .unwrap()],
+        )
         .unwrap();
-    let raw_targets = targets.to_raw().unwrap();
 
-    tuf.update_targets(&raw_targets).unwrap();
+        let mut repo = EphemeralRepository::new();
+        let metadata = RepoBuilder::create(&mut repo)
+            .trusted_root_keys(&[&root_key])
+            .trusted_snapshot_keys(&[&snapshot_key])
+            .trusted_targets_keys(&[&targets_key])
+            .trusted_timestamp_keys(&[&timestamp_key])
+            .with_targets_builder(|builder| builder.delegations(delegations))
+            .unwrap()
+            .with_snapshot_builder(|builder| {
+                builder.insert_metadata_description(
+                    MetadataPath::new("delegation").unwrap(),
+                    MetadataDescription::from_slice(&[0u8], 1, &[HashAlgorithm::Sha256]).unwrap(),
+                )
+            })
+            .unwrap()
+            .commit()
+            .await
+            .unwrap();
 
-    //// build delegation A ////
+        let mut tuf = Database::<Json>::from_trusted_metadata(&metadata).unwrap();
 
-    let delegations = Delegations::new(
+        //// build the delegation ////
+        let target_file: &[u8] = b"bar";
+        let delegation = TargetsMetadataBuilder::new()
+            .insert_target_from_slice(
+                TargetPath::new("foo").unwrap(),
+                target_file,
+                &[HashAlgorithm::Sha256],
+            )
+            .unwrap()
+            .signed::<Json>(&bad_delegation_key)
+            .unwrap();
+        let raw_delegation = delegation.to_raw().unwrap();
+
+        assert_matches!(
+            tuf.update_delegation(
+                &MetadataPath::from_role(&Role::Targets),
+                &MetadataPath::new("delegation").unwrap(),
+                &raw_delegation
+            ),
+            Err(Error::VerificationFailure(_))
+        );
+
+        assert_matches!(
+            tuf.target_description(&TargetPath::new("foo").unwrap()),
+            Err(Error::TargetUnavailable)
+        );
+    })
+}
+
+#[test]
+fn diamond_delegation() {
+    block_on(async {
+        let etc_key = Ed25519PrivateKey::from_pkcs8(ED25519_1_PK8).unwrap();
+        let targets_key = Ed25519PrivateKey::from_pkcs8(ED25519_2_PK8).unwrap();
+        let delegation_a_key = Ed25519PrivateKey::from_pkcs8(ED25519_3_PK8).unwrap();
+        let delegation_b_key = Ed25519PrivateKey::from_pkcs8(ED25519_4_PK8).unwrap();
+        let delegation_c_key = Ed25519PrivateKey::from_pkcs8(ED25519_5_PK8).unwrap();
+
+        // Given delegations a, b, and c, targets delegates "foo" to delegation-a and "bar" to
+        // delegation-b.
+        //
+        //             targets
+        //              /  \
+        //   delegation-a  delegation-b
+        //              \  /
+        //          delegation-c
+        //
+        // if delegation-a delegates "foo" to delegation-c, and
+        //    delegation-b delegates "bar" to delegation-c, but
+        //    delegation-b's signature is invalid, then delegation-c
+        // can contain target "bar" which is unaccessible and target "foo" which is.
+        //
+        // Verify tuf::Database handles this situation correctly.
+
+        let delegations = Delegations::new(
+            hashmap! {
+                delegation_a_key.public().key_id().clone() => delegation_a_key.public().clone(),
+                delegation_b_key.public().key_id().clone() => delegation_b_key.public().clone(),
+            },
+            vec![
+                Delegation::new(
+                    MetadataPath::new("delegation-a").unwrap(),
+                    false,
+                    1,
+                    vec![delegation_a_key.public().key_id().clone()]
+                        .iter()
+                        .cloned()
+                        .collect(),
+                    vec![TargetPath::new("foo").unwrap()]
+                        .iter()
+                        .cloned()
+                        .collect(),
+                )
+                .unwrap(),
+                Delegation::new(
+                    MetadataPath::new("delegation-b").unwrap(),
+                    false,
+                    1,
+                    vec![delegation_b_key.public().key_id().clone()]
+                        .iter()
+                        .cloned()
+                        .collect(),
+                    vec![TargetPath::new("bar").unwrap()]
+                        .iter()
+                        .cloned()
+                        .collect(),
+                )
+                .unwrap(),
+            ],
+        )
+        .unwrap();
+
+        let mut repo = EphemeralRepository::new();
+        let metadata = RepoBuilder::create(&mut repo)
+            .trusted_root_keys(&[&etc_key])
+            .trusted_snapshot_keys(&[&etc_key])
+            .trusted_targets_keys(&[&targets_key])
+            .trusted_timestamp_keys(&[&etc_key])
+            .with_targets_builder(|builder| builder.delegations(delegations))
+            .unwrap()
+            .with_snapshot_builder(|builder| {
+                builder
+                    .insert_metadata_description(
+                        MetadataPath::new("delegation-a").unwrap(),
+                        MetadataDescription::from_slice(&[0u8], 1, &[HashAlgorithm::Sha256])
+                            .unwrap(),
+                    )
+                    .insert_metadata_description(
+                        MetadataPath::new("delegation-b").unwrap(),
+                        MetadataDescription::from_slice(&[0u8], 1, &[HashAlgorithm::Sha256])
+                            .unwrap(),
+                    )
+                    .insert_metadata_description(
+                        MetadataPath::new("delegation-c").unwrap(),
+                        MetadataDescription::from_slice(&[0u8], 1, &[HashAlgorithm::Sha256])
+                            .unwrap(),
+                    )
+            })
+            .unwrap()
+            .commit()
+            .await
+            .unwrap();
+
+        let mut tuf = Database::<Json>::from_trusted_metadata(&metadata).unwrap();
+
+        //// build delegation A ////
+
+        let delegations = Delegations::new(
         hashmap! { delegation_c_key.public().key_id().clone() => delegation_c_key.public().clone() },
         vec![Delegation::new(
             MetadataPath::new("delegation-c").unwrap(),
@@ -489,22 +400,22 @@ fn diamond_delegation() {
     )
     .unwrap();
 
-    let delegation = TargetsMetadataBuilder::new()
-        .delegations(delegations)
-        .signed::<Json>(&delegation_a_key)
+        let delegation = TargetsMetadataBuilder::new()
+            .delegations(delegations)
+            .signed::<Json>(&delegation_a_key)
+            .unwrap();
+        let raw_delegation = delegation.to_raw().unwrap();
+
+        tuf.update_delegation(
+            &MetadataPath::from_role(&Role::Targets),
+            &MetadataPath::new("delegation-a").unwrap(),
+            &raw_delegation,
+        )
         .unwrap();
-    let raw_delegation = delegation.to_raw().unwrap();
 
-    tuf.update_delegation(
-        &MetadataPath::from_role(&Role::Targets),
-        &MetadataPath::new("delegation-a").unwrap(),
-        &raw_delegation,
-    )
-    .unwrap();
+        //// build delegation B ////
 
-    //// build delegation B ////
-
-    let delegations = Delegations::new(
+        let delegations = Delegations::new(
         hashmap! { delegation_c_key.public().key_id().clone() => delegation_c_key.public().clone() },
         vec![Delegation::new(
             MetadataPath::new("delegation-c").unwrap(),
@@ -518,65 +429,66 @@ fn diamond_delegation() {
     )
     .unwrap();
 
-    let delegation = TargetsMetadataBuilder::new()
-        .delegations(delegations)
-        .signed::<Json>(&delegation_b_key)
-        .unwrap();
-    let raw_delegation = delegation.to_raw().unwrap();
+        let delegation = TargetsMetadataBuilder::new()
+            .delegations(delegations)
+            .signed::<Json>(&delegation_b_key)
+            .unwrap();
+        let raw_delegation = delegation.to_raw().unwrap();
 
-    tuf.update_delegation(
-        &MetadataPath::from_role(&Role::Targets),
-        &MetadataPath::new("delegation-b").unwrap(),
-        &raw_delegation,
-    )
-    .unwrap();
-
-    //// build delegation C ////
-
-    let foo_target_file: &[u8] = b"foo contents";
-    let bar_target_file: &[u8] = b"bar contents";
-
-    let delegation = TargetsMetadataBuilder::new()
-        .insert_target_from_slice(
-            TargetPath::new("foo").unwrap(),
-            foo_target_file,
-            &[HashAlgorithm::Sha256],
-        )
-        .unwrap()
-        .insert_target_from_slice(
-            TargetPath::new("bar").unwrap(),
-            bar_target_file,
-            &[HashAlgorithm::Sha256],
-        )
-        .unwrap()
-        .signed::<Json>(&delegation_c_key)
-        .unwrap();
-    let raw_delegation = delegation.to_raw().unwrap();
-
-    //// Verify delegation-c is valid, but only when updated through delegation-a.
-
-    tuf.update_delegation(
-        &MetadataPath::new("delegation-a").unwrap(),
-        &MetadataPath::new("delegation-c").unwrap(),
-        &raw_delegation,
-    )
-    .unwrap();
-
-    assert_matches!(
         tuf.update_delegation(
+            &MetadataPath::from_role(&Role::Targets),
             &MetadataPath::new("delegation-b").unwrap(),
+            &raw_delegation,
+        )
+        .unwrap();
+
+        //// build delegation C ////
+
+        let foo_target_file: &[u8] = b"foo contents";
+        let bar_target_file: &[u8] = b"bar contents";
+
+        let delegation = TargetsMetadataBuilder::new()
+            .insert_target_from_slice(
+                TargetPath::new("foo").unwrap(),
+                foo_target_file,
+                &[HashAlgorithm::Sha256],
+            )
+            .unwrap()
+            .insert_target_from_slice(
+                TargetPath::new("bar").unwrap(),
+                bar_target_file,
+                &[HashAlgorithm::Sha256],
+            )
+            .unwrap()
+            .signed::<Json>(&delegation_c_key)
+            .unwrap();
+        let raw_delegation = delegation.to_raw().unwrap();
+
+        //// Verify delegation-c is valid, but only when updated through delegation-a.
+
+        tuf.update_delegation(
+            &MetadataPath::new("delegation-a").unwrap(),
             &MetadataPath::new("delegation-c").unwrap(),
-            &raw_delegation
-        ),
-        Err(Error::VerificationFailure(_))
-    );
+            &raw_delegation,
+        )
+        .unwrap();
 
-    assert!(tuf
-        .target_description(&TargetPath::new("foo").unwrap())
-        .is_ok());
+        assert_matches!(
+            tuf.update_delegation(
+                &MetadataPath::new("delegation-b").unwrap(),
+                &MetadataPath::new("delegation-c").unwrap(),
+                &raw_delegation
+            ),
+            Err(Error::VerificationFailure(_))
+        );
 
-    assert_matches!(
-        tuf.target_description(&TargetPath::new("bar").unwrap()),
-        Err(Error::TargetUnavailable)
-    );
+        assert!(tuf
+            .target_description(&TargetPath::new("foo").unwrap())
+            .is_ok());
+
+        assert_matches!(
+            tuf.target_description(&TargetPath::new("bar").unwrap()),
+            Err(Error::TargetUnavailable)
+        );
+    })
 }


### PR DESCRIPTION
This introduces a new repository builder. It greatly simplifies creating metadata for a repository. Here's a simple example that creates a repository, with a file, and commiting it to a repository.

```rust
let key = Ed25519PrivateKey::from_pkcs8("...").unwrap();
let mut repo = EphemeralRepository::new();
let _metadata = RepoBuilder::<Json>::create(&mut repo)
    .trusted_root_keys(&[&key])
    .trusted_targets_keys(&[&key])
    .trusted_snapshot_keys(&[&key])
    .trusted_timestamp_keys(&[&key])
    .add_target("foo/bar", Cursor::new(b"some file"))
    .commit()
    .await
    .unwrap();
```

It also supports generating new metadata derived off of a TUF database:

```rust
let mut client: tuf::Client = ...;
client.update().await().unwrap();

let _metadata2 = RepoBuilder::from_database(&mut repo, client.database())
    .trusted_root_key(&[&key])
    .trusted_targets_key(&[&key])
    .trusted_snapshot_key(&[&key])
    .trusted_timestamp_key(&[&key])
    .create_root()
    .unwrap()
    .commit()
    .await
    .unwrap();
```

Unfortunately RepoBuilder does not yet take care of generating target delegations. That will come in a future patch.
