### PR TITLE
Clean up Repository{Storage,Provider} arguments

### DIFF
--- a/interop-tests/src/lib.rs
+++ b/interop-tests/src/lib.rs
@@ -202,7 +202,7 @@ async fn add_target(
         step.to_string()
     };
     let target_path = TargetPath::new(target_str).unwrap();
-    repo.store_target(&mut &*target_data, &target_path)
+    repo.store_target(&target_path, &mut &*target_data)
         .await
         .unwrap();
 

--- a/interop-tests/tests/test.rs
+++ b/interop-tests/tests/test.rs
@@ -220,7 +220,7 @@ where
 
     let mut buf = Vec::new();
     let mut reader = remote
-        .fetch_metadata(&root_path, &MetadataVersion::Number(1), None, None)
+        .fetch_metadata(&root_path, &MetadataVersion::Number(1))
         .await
         .unwrap();
     reader.read_to_end(&mut buf).await.unwrap();

--- a/tuf/src/client.rs
+++ b/tuf/src/client.rs
@@ -755,7 +755,7 @@ where
     /// Fetch a target from the remote repo and write it to the local repo.
     pub async fn fetch_target<'a>(&'a mut self, target: &'a TargetPath) -> Result<()> {
         let mut read = self._fetch_target(target).await?;
-        self.local.store_target(&mut read, target).await
+        self.local.store_target(target, &mut read).await
     }
 
     /// Fetch a target from the remote repo and write it to the provided writer.

--- a/tuf/src/repository.rs
+++ b/tuf/src/repository.rs
@@ -55,8 +55,6 @@ where
         &'a self,
         meta_path: &'a MetadataPath,
         version: &'a MetadataVersion,
-        max_length: Option<usize>,
-        hash_data: Option<(&'static HashAlgorithm, HashValue)>,
     ) -> BoxFuture<'a, Result<Box<dyn AsyncRead + Send + Unpin>>>;
 
     /// Fetch the given target.
@@ -70,7 +68,6 @@ where
     fn fetch_target<'a>(
         &'a self,
         target_path: &'a TargetPath,
-        target_description: &'a TargetDescription,
     ) -> BoxFuture<'a, Result<Box<dyn AsyncRead + Send + Unpin>>>;
 }
 
@@ -95,8 +92,8 @@ where
     /// existing target at that location.
     fn store_target<'a>(
         &'a self,
-        target: &'a mut (dyn AsyncRead + Send + Unpin + 'a),
         target_path: &'a TargetPath,
+        target: &'a mut (dyn AsyncRead + Send + Unpin + 'a),
     ) -> BoxFuture<'a, Result<()>>;
 }
 
@@ -124,18 +121,15 @@ where
         &'a self,
         meta_path: &'a MetadataPath,
         version: &'a MetadataVersion,
-        max_length: Option<usize>,
-        hash_data: Option<(&'static HashAlgorithm, HashValue)>,
     ) -> BoxFuture<'a, Result<Box<dyn AsyncRead + Send + Unpin>>> {
-        (**self).fetch_metadata(meta_path, version, max_length, hash_data)
+        (**self).fetch_metadata(meta_path, version)
     }
 
     fn fetch_target<'a>(
         &'a self,
         target_path: &'a TargetPath,
-        target_description: &'a TargetDescription,
     ) -> BoxFuture<'a, Result<Box<dyn AsyncRead + Send + Unpin>>> {
-        (**self).fetch_target(target_path, target_description)
+        (**self).fetch_target(target_path)
     }
 }
 
@@ -155,10 +149,10 @@ where
 
     fn store_target<'a>(
         &'a self,
-        target: &'a mut (dyn AsyncRead + Send + Unpin + 'a),
         target_path: &'a TargetPath,
+        target: &'a mut (dyn AsyncRead + Send + Unpin + 'a),
     ) -> BoxFuture<'a, Result<()>> {
-        (**self).store_target(target, target_path)
+        (**self).store_target(target_path, target)
     }
 }
 
@@ -178,10 +172,10 @@ where
 
     fn store_target<'a>(
         &'a self,
-        target: &'a mut (dyn AsyncRead + Send + Unpin + 'a),
         target_path: &'a TargetPath,
+        target: &'a mut (dyn AsyncRead + Send + Unpin + 'a),
     ) -> BoxFuture<'a, Result<()>> {
-        (**self).store_target(target, target_path)
+        (**self).store_target(target_path, target)
     }
 }
 
@@ -194,18 +188,15 @@ where
         &'a self,
         meta_path: &'a MetadataPath,
         version: &'a MetadataVersion,
-        max_length: Option<usize>,
-        hash_data: Option<(&'static HashAlgorithm, HashValue)>,
     ) -> BoxFuture<'a, Result<Box<dyn AsyncRead + Send + Unpin>>> {
-        (**self).fetch_metadata(meta_path, version, max_length, hash_data)
+        (**self).fetch_metadata(meta_path, version)
     }
 
     fn fetch_target<'a>(
         &'a self,
         target_path: &'a TargetPath,
-        target_description: &'a TargetDescription,
     ) -> BoxFuture<'a, Result<Box<dyn AsyncRead + Send + Unpin>>> {
-        (**self).fetch_target(target_path, target_description)
+        (**self).fetch_target(target_path)
     }
 }
 
@@ -218,18 +209,15 @@ where
         &'a self,
         meta_path: &'a MetadataPath,
         version: &'a MetadataVersion,
-        max_length: Option<usize>,
-        hash_data: Option<(&'static HashAlgorithm, HashValue)>,
     ) -> BoxFuture<'a, Result<Box<dyn AsyncRead + Send + Unpin>>> {
-        (**self).fetch_metadata(meta_path, version, max_length, hash_data)
+        (**self).fetch_metadata(meta_path, version)
     }
 
     fn fetch_target<'a>(
         &'a self,
         target_path: &'a TargetPath,
-        target_description: &'a TargetDescription,
     ) -> BoxFuture<'a, Result<Box<dyn AsyncRead + Send + Unpin>>> {
-        (**self).fetch_target(target_path, target_description)
+        (**self).fetch_target(target_path)
     }
 }
 
@@ -249,10 +237,10 @@ where
 
     fn store_target<'a>(
         &'a self,
-        target: &'a mut (dyn AsyncRead + Send + Unpin + 'a),
         target_path: &'a TargetPath,
+        target: &'a mut (dyn AsyncRead + Send + Unpin + 'a),
     ) -> BoxFuture<'a, Result<()>> {
-        (**self).store_target(target, target_path)
+        (**self).store_target(target_path, target)
     }
 }
 
@@ -319,7 +307,7 @@ where
         // implementation should only be trusted to use those as hints to fail early.
         let mut reader = self
             .repository
-            .fetch_metadata(meta_path, version, max_length, hash_data.clone())
+            .fetch_metadata(meta_path, version)
             .await?
             .check_length_and_hash(max_length.unwrap_or(::std::usize::MAX) as u64, hash_data)?;
 
@@ -346,7 +334,7 @@ where
         let (hash_alg, value) = crypto::hash_preference(target_description.hashes())?;
 
         self.repository
-            .fetch_target(target_path, target_description)
+            .fetch_target(target_path)
             .await?
             .check_length_and_hash(target_description.length(), Some((hash_alg, value.clone())))
     }
@@ -380,10 +368,10 @@ where
     /// Store the provided `target` in a location identified by `target_path`.
     pub async fn store_target<'a>(
         &'a self,
-        target: &'a mut (dyn AsyncRead + Send + Unpin + 'a),
         target_path: &'a TargetPath,
+        target: &'a mut (dyn AsyncRead + Send + Unpin + 'a),
     ) -> Result<()> {
-        self.repository.store_target(target, target_path).await
+        self.repository.store_target(target_path, target).await
     }
 }
 
@@ -566,7 +554,7 @@ mod test {
             let target_description =
                 TargetDescription::from_reader(data, &[HashAlgorithm::Sha256]).unwrap();
             let path = TargetPath::new("batty".into()).unwrap();
-            client.store_target(&mut &*data, &path).await.unwrap();
+            client.store_target(&path, &mut &*data).await.unwrap();
 
             let mut read = client
                 .fetch_target(&path, &target_description)
@@ -577,7 +565,7 @@ mod test {
             assert_eq!(buf.as_slice(), data);
 
             let bad_data: &[u8] = b"you're in a desert";
-            client.store_target(&mut &*bad_data, &path).await.unwrap();
+            client.store_target(&path, &mut &*bad_data).await.unwrap();
             let mut read = client
                 .fetch_target(&path, &target_description)
                 .await
@@ -597,7 +585,7 @@ mod test {
             let target_description =
                 TargetDescription::from_reader(data, &[HashAlgorithm::Sha256]).unwrap();
             let path = TargetPath::new("batty".into()).unwrap();
-            client.store_target(&mut &*data, &path).await.unwrap();
+            client.store_target(&path, &mut &*data).await.unwrap();
 
             let mut read = client
                 .fetch_target(&path, &target_description)
@@ -620,7 +608,7 @@ mod test {
             let target_description =
                 TargetDescription::from_reader(data, &[HashAlgorithm::Sha256]).unwrap();
             let path = TargetPath::new("batty".into()).unwrap();
-            client.store_target(&mut &*data, &path).await.unwrap();
+            client.store_target(&path, &mut &*data).await.unwrap();
 
             let mut read = client
                 .fetch_target(&path, &target_description)

--- a/tuf/src/repository/error_repo.rs
+++ b/tuf/src/repository/error_repo.rs
@@ -1,8 +1,7 @@
 use {
     crate::{
-        crypto::{HashAlgorithm, HashValue},
         interchange::DataInterchange,
-        metadata::{MetadataPath, MetadataVersion, TargetDescription, TargetPath},
+        metadata::{MetadataPath, MetadataVersion, TargetPath},
         repository::{RepositoryProvider, RepositoryStorage},
         Error, Result,
     },
@@ -39,19 +38,15 @@ where
         &'a self,
         meta_path: &'a MetadataPath,
         version: &'a MetadataVersion,
-        max_length: Option<usize>,
-        hash_data: Option<(&'static HashAlgorithm, HashValue)>,
     ) -> BoxFuture<'a, Result<Box<dyn AsyncRead + Send + Unpin>>> {
-        self.repo
-            .fetch_metadata(meta_path, version, max_length, hash_data)
+        self.repo.fetch_metadata(meta_path, version)
     }
 
     fn fetch_target<'a>(
         &'a self,
         target_path: &'a TargetPath,
-        target_description: &'a TargetDescription,
     ) -> BoxFuture<'a, Result<Box<dyn AsyncRead + Send + Unpin>>> {
-        self.repo.fetch_target(target_path, target_description)
+        self.repo.fetch_target(target_path)
     }
 }
 
@@ -75,9 +70,9 @@ where
 
     fn store_target<'a>(
         &'a self,
-        target: &'a mut (dyn AsyncRead + Send + Unpin + 'a),
         target_path: &'a TargetPath,
+        target: &'a mut (dyn AsyncRead + Send + Unpin + 'a),
     ) -> BoxFuture<'a, Result<()>> {
-        self.repo.store_target(target, target_path)
+        self.repo.store_target(target_path, target)
     }
 }

--- a/tuf/src/repository/http.rs
+++ b/tuf/src/repository/http.rs
@@ -17,10 +17,9 @@ use std::io;
 use std::marker::PhantomData;
 use url::Url;
 
-use crate::crypto::{HashAlgorithm, HashValue};
 use crate::error::Error;
 use crate::interchange::DataInterchange;
-use crate::metadata::{MetadataPath, MetadataVersion, TargetDescription, TargetPath};
+use crate::metadata::{MetadataPath, MetadataVersion, TargetPath};
 use crate::repository::RepositoryProvider;
 use crate::util::SafeAsyncRead;
 use crate::Result;
@@ -250,8 +249,6 @@ where
         &'a self,
         meta_path: &'a MetadataPath,
         version: &'a MetadataVersion,
-        _max_length: Option<usize>,
-        _hash_data: Option<(&'static HashAlgorithm, HashValue)>,
     ) -> BoxFuture<'a, Result<Box<dyn AsyncRead + Send + Unpin>>> {
         let components = meta_path.components::<D>(version);
         async move {
@@ -274,7 +271,6 @@ where
     fn fetch_target<'a>(
         &'a self,
         target_path: &'a TargetPath,
-        _target_description: &'a TargetDescription,
     ) -> BoxFuture<'a, Result<Box<dyn AsyncRead + Send + Unpin>>> {
         async move {
             let components = target_path.components();

--- a/tuf/src/repository/track_repo.rs
+++ b/tuf/src/repository/track_repo.rs
@@ -1,11 +1,7 @@
 use {
     crate::{
-        crypto::{HashAlgorithm, HashValue},
         interchange::DataInterchange,
-        metadata::{
-            Metadata, MetadataPath, MetadataVersion, RawSignedMetadata, TargetDescription,
-            TargetPath,
-        },
+        metadata::{Metadata, MetadataPath, MetadataVersion, RawSignedMetadata, TargetPath},
         repository::{RepositoryProvider, RepositoryStorage},
         Result,
     },
@@ -141,10 +137,10 @@ where
 
     fn store_target<'a>(
         &'a self,
-        target: &'a mut (dyn AsyncRead + Send + Unpin + 'a),
         target_path: &'a TargetPath,
+        target: &'a mut (dyn AsyncRead + Send + Unpin + 'a),
     ) -> BoxFuture<'a, Result<()>> {
-        self.repo.store_target(target, target_path)
+        self.repo.store_target(target_path, target)
     }
 }
 
@@ -157,13 +153,9 @@ where
         &'a self,
         meta_path: &'a MetadataPath,
         version: &'a MetadataVersion,
-        max_length: Option<usize>,
-        hash_data: Option<(&'static HashAlgorithm, HashValue)>,
     ) -> BoxFuture<'a, Result<Box<dyn AsyncRead + Send + Unpin>>> {
         async move {
-            let fut = self
-                .repo
-                .fetch_metadata(meta_path, version, max_length, hash_data);
+            let fut = self.repo.fetch_metadata(meta_path, version);
             match fut.await {
                 Ok(mut rdr) => {
                     let mut buf = Vec::new();
@@ -191,8 +183,7 @@ where
     fn fetch_target<'a>(
         &'a self,
         target_path: &'a TargetPath,
-        target_description: &'a TargetDescription,
     ) -> BoxFuture<'a, Result<Box<dyn AsyncRead + Send + Unpin>>> {
-        self.repo.fetch_target(target_path, target_description)
+        self.repo.fetch_target(target_path)
     }
 }

--- a/tuf/tests/simple_example.rs
+++ b/tuf/tests/simple_example.rs
@@ -112,10 +112,10 @@ async fn init_server(
         let (_, value) = crypto::hash_preference(target_description.hashes())?;
         let hash_prefixed_path = target_path.with_hash_prefix(value)?;
         let _ = remote
-            .store_target(&mut &*target_file, &hash_prefixed_path)
+            .store_target(&hash_prefixed_path, &mut &*target_file)
             .await;
     } else {
-        let _ = remote.store_target(&mut &*target_file, &target_path).await;
+        let _ = remote.store_target(&target_path, &mut &*target_file).await;
     };
 
     let targets = TargetsMetadataBuilder::new()


### PR DESCRIPTION
This removes a few arguments from RepositoryProvider and RepositoryStorage which were never used, and reorders RepositoryStorage::store_target to match other arguments.