### PR TITLE
Rename client fetching targets

### DIFF
--- a/interop-tests/tests/test.rs
+++ b/interop-tests/tests/test.rs
@@ -200,10 +200,8 @@ where
         // fetch all the targets and check they have the correct content
         for (target_path, expected) in self.expected_targets.iter() {
             let mut buf = Vec::new();
-            assert_matches!(
-                client.fetch_target_to_writer(target_path, &mut buf).await,
-                Ok(())
-            );
+            let rdr = client.fetch_target(target_path).await.unwrap();
+            futures_util::io::copy(rdr, &mut buf).await.unwrap();
             assert_eq!(&String::from_utf8(buf).unwrap(), expected);
         }
     }

--- a/tuf/tests/simple_example.rs
+++ b/tuf/tests/simple_example.rs
@@ -60,7 +60,7 @@ async fn init_client(
     .await?;
     let _ = client.update().await?;
     let target_path = TargetPath::new("foo-bar".into())?;
-    client.fetch_target(&target_path).await
+    client.fetch_target_to_local(&target_path).await
 }
 
 async fn init_server(


### PR DESCRIPTION
This patch:

* renames `Client::fetch_target` to `Client::fetch_target_to_local` to make it more obvious all it does is write the target to the local store.
* adds a new `Client::fetch_target`, which returns the target AsyncRead.
* removes `Client::fetch_target_to_writer`, since clients could implement that by using the result of `Client::fetch_target`.