### PR TITLE
Remove synchronous io

### DIFF
--- a/interop-tests/src/lib.rs
+++ b/interop-tests/src/lib.rs
@@ -173,7 +173,7 @@ async fn add_target(
         let step_str = format!("{}", i);
         let target_data = step_str.as_bytes();
         targets_builder = targets_builder
-            .insert_target_from_reader(
+            .insert_target_from_slice(
                 TargetPath::new(i.to_string()).unwrap(),
                 target_data,
                 &[HashAlgorithm::Sha256],

--- a/tuf/src/client.rs
+++ b/tuf/src/client.rs
@@ -1946,7 +1946,7 @@ mod test {
     fn test_fetch_target_description_standard() {
         block_on(test_fetch_target_description(
             "standard/metadata".to_string(),
-            TargetDescription::from_reader(
+            TargetDescription::from_slice(
                 "target with no custom metadata".as_bytes(),
                 &[HashAlgorithm::Sha256],
             )
@@ -1958,7 +1958,7 @@ mod test {
     fn test_fetch_target_description_custom_empty() {
         block_on(test_fetch_target_description(
             "custom-empty".to_string(),
-            TargetDescription::from_reader_with_custom(
+            TargetDescription::from_slice_with_custom(
                 "target with empty custom metadata".as_bytes(),
                 &[HashAlgorithm::Sha256],
                 hashmap!(),
@@ -1971,7 +1971,7 @@ mod test {
     fn test_fetch_target_description_custom() {
         block_on(test_fetch_target_description(
             "custom/metadata".to_string(),
-            TargetDescription::from_reader_with_custom(
+            TargetDescription::from_slice_with_custom(
                 "target with lots of custom metadata".as_bytes(),
                 &[HashAlgorithm::Sha256],
                 hashmap!(

--- a/tuf/src/crypto.rs
+++ b/tuf/src/crypto.rs
@@ -98,8 +98,33 @@ pub(crate) fn calculate_hash(data: &[u8], hash_alg: HashAlgorithm) -> HashValue 
     HashValue::new(context.finish().as_ref().to_vec())
 }
 
+/// Calculate the size and hash digest from a given `AsyncRead`.
+pub fn calculate_hashes_from_slice(
+    buf: &[u8],
+    hash_algs: &[HashAlgorithm],
+) -> Result<HashMap<HashAlgorithm, HashValue>> {
+    if hash_algs.is_empty() {
+        return Err(Error::IllegalArgument(
+            "Cannot provide empty set of hash algorithms".into(),
+        ));
+    }
+
+    let mut hashes = HashMap::new();
+    for alg in hash_algs {
+        let mut context = alg.digest_context()?;
+        context.update(buf);
+
+        hashes.insert(
+            alg.clone(),
+            HashValue::new(context.finish().as_ref().to_vec()),
+        );
+    }
+
+    Ok(hashes)
+}
+
 /// Calculate the size and hash digest from a given `Read`.
-pub fn calculate_hashes<R: Read>(
+pub fn calculate_hashes_from_reader<R: Read>(
     mut read: R,
     hash_algs: &[HashAlgorithm],
 ) -> Result<(u64, HashMap<HashAlgorithm, HashValue>)> {

--- a/tuf/src/crypto.rs
+++ b/tuf/src/crypto.rs
@@ -3,6 +3,8 @@
 use {
     data_encoding::{BASE64URL, HEXLOWER},
     derp::{self, Der, Tag},
+    futures_io::AsyncRead,
+    futures_util::AsyncReadExt as _,
     ring::{
         digest::{self, SHA256, SHA512},
         rand::SystemRandom,
@@ -18,7 +20,6 @@ use {
         collections::HashMap,
         fmt::{self, Debug, Display},
         hash,
-        io::Read,
         str::FromStr,
     },
     untrusted::Input,
@@ -123,11 +124,14 @@ pub fn calculate_hashes_from_slice(
     Ok(hashes)
 }
 
-/// Calculate the size and hash digest from a given `Read`.
-pub fn calculate_hashes_from_reader<R: Read>(
+/// Calculate the size and hash digest from a given `AsyncRead`.
+pub async fn calculate_hashes_from_reader<R>(
     mut read: R,
     hash_algs: &[HashAlgorithm],
-) -> Result<(u64, HashMap<HashAlgorithm, HashValue>)> {
+) -> Result<(u64, HashMap<HashAlgorithm, HashValue>)>
+where
+    R: AsyncRead + Unpin,
+{
     if hash_algs.is_empty() {
         return Err(Error::IllegalArgument(
             "Cannot provide empty set of hash algorithms".into(),
@@ -142,7 +146,7 @@ pub fn calculate_hashes_from_reader<R: Read>(
 
     let mut buf = vec![0; 1024];
     loop {
-        match read.read(&mut buf) {
+        match read.read(&mut buf).await {
             Ok(read_bytes) => {
                 if read_bytes == 0 {
                     break;

--- a/tuf/src/interchange/cjson/mod.rs
+++ b/tuf/src/interchange/cjson/mod.rs
@@ -1,7 +1,6 @@
 use serde::de::DeserializeOwned;
 use serde::ser::Serialize;
 use std::collections::BTreeMap;
-use std::io::Read;
 
 use crate::error::Error;
 use crate::interchange::DataInterchange;
@@ -200,7 +199,7 @@ impl DataInterchange for Json {
     /// # use tuf::interchange::{DataInterchange, Json};
     /// # use std::collections::HashMap;
     /// let jsn: &[u8] = br#"{"foo": "bar", "baz": "quux"}"#;
-    /// let raw = Json::from_reader(jsn).unwrap();
+    /// let raw = Json::from_slice(jsn).unwrap();
     /// let out = Json::canonicalize(&raw).unwrap();
     /// assert_eq!(out, br#"{"baz":"quux","foo":"bar"}"#);
     /// ```
@@ -254,20 +253,6 @@ impl DataInterchange for Json {
         T: Serialize,
     {
         Ok(serde_json::to_value(data)?)
-    }
-
-    /// ```
-    /// # use tuf::interchange::{DataInterchange, Json};
-    /// # use std::collections::HashMap;
-    /// let jsn: &[u8] = br#"{"foo": "bar", "baz": "quux"}"#;
-    /// let _: HashMap<String, String> = Json::from_reader(jsn).unwrap();
-    /// ```
-    fn from_reader<R, T>(rdr: R) -> Result<T>
-    where
-        R: Read,
-        T: DeserializeOwned,
-    {
-        Ok(serde_json::from_reader(rdr)?)
     }
 
     /// ```

--- a/tuf/src/interchange/cjson/pretty.rs
+++ b/tuf/src/interchange/cjson/pretty.rs
@@ -1,6 +1,5 @@
 use serde::de::DeserializeOwned;
 use serde::ser::Serialize;
-use std::io::Read;
 
 use super::Json;
 use crate::interchange::DataInterchange;
@@ -110,20 +109,6 @@ impl DataInterchange for JsonPretty {
         T: Serialize,
     {
         Json::serialize(data)
-    }
-
-    /// ```
-    /// # use tuf::interchange::{DataInterchange, JsonPretty};
-    /// # use std::collections::HashMap;
-    /// let jsn: &[u8] = br#"{"foo": "bar", "baz": "quux"}"#;
-    /// let _: HashMap<String, String> = JsonPretty::from_reader(jsn).unwrap();
-    /// ```
-    fn from_reader<R, T>(rdr: R) -> Result<T>
-    where
-        R: Read,
-        T: DeserializeOwned,
-    {
-        Json::from_reader(rdr)
     }
 
     /// ```

--- a/tuf/src/interchange/mod.rs
+++ b/tuf/src/interchange/mod.rs
@@ -6,7 +6,6 @@ pub use cjson::{Json, JsonPretty};
 use serde::de::DeserializeOwned;
 use serde::ser::Serialize;
 use std::fmt::Debug;
-use std::io::Read;
 
 use crate::Result;
 
@@ -30,12 +29,6 @@ pub trait DataInterchange: Debug + PartialEq + Clone {
     fn serialize<T>(data: &T) -> Result<Self::RawData>
     where
         T: Serialize;
-
-    /// Read a struct from a stream.
-    fn from_reader<R, T>(rdr: R) -> Result<T>
-    where
-        R: Read,
-        T: DeserializeOwned;
 
     /// Read a struct from a stream.
     fn from_slice<T>(slice: &[u8]) -> Result<T>

--- a/tuf/src/repository.rs
+++ b/tuf/src/repository.rs
@@ -552,7 +552,7 @@ mod test {
 
             let data: &[u8] = b"like tears in the rain";
             let target_description =
-                TargetDescription::from_reader(data, &[HashAlgorithm::Sha256]).unwrap();
+                TargetDescription::from_slice(data, &[HashAlgorithm::Sha256]).unwrap();
             let path = TargetPath::new("batty".into()).unwrap();
             client.store_target(&path, &mut &*data).await.unwrap();
 
@@ -583,7 +583,7 @@ mod test {
 
             let data: &[u8] = b"like tears in the rain";
             let target_description =
-                TargetDescription::from_reader(data, &[HashAlgorithm::Sha256]).unwrap();
+                TargetDescription::from_slice(data, &[HashAlgorithm::Sha256]).unwrap();
             let path = TargetPath::new("batty".into()).unwrap();
             client.store_target(&path, &mut &*data).await.unwrap();
 
@@ -606,7 +606,7 @@ mod test {
 
             let data: &[u8] = b"like tears in the rain";
             let target_description =
-                TargetDescription::from_reader(data, &[HashAlgorithm::Sha256]).unwrap();
+                TargetDescription::from_slice(data, &[HashAlgorithm::Sha256]).unwrap();
             let path = TargetPath::new("batty".into()).unwrap();
             client.store_target(&path, &mut &*data).await.unwrap();
 

--- a/tuf/src/util.rs
+++ b/tuf/src/util.rs
@@ -180,7 +180,7 @@ impl<R: AsyncRead + Unpin> AsyncRead for SafeReader<R> {
         }
 
         if let Some((ref mut context, _)) = self.hasher {
-            context.update(&buf[..(read_bytes)]);
+            context.update(&buf[..read_bytes]);
         }
 
         Poll::Ready(Ok(read_bytes))

--- a/tuf/tests/integration.rs
+++ b/tuf/tests/integration.rs
@@ -45,11 +45,11 @@ fn simple_delegation() {
     let snapshot = SnapshotMetadataBuilder::new()
         .insert_metadata_description(
             MetadataPath::new("targets").unwrap(),
-            MetadataDescription::from_reader(&*vec![0u8], 1, &[HashAlgorithm::Sha256]).unwrap(),
+            MetadataDescription::from_slice(&[0u8], 1, &[HashAlgorithm::Sha256]).unwrap(),
         )
         .insert_metadata_description(
             MetadataPath::new("delegation").unwrap(),
-            MetadataDescription::from_reader(&*vec![0u8], 1, &[HashAlgorithm::Sha256]).unwrap(),
+            MetadataDescription::from_slice(&[0u8], 1, &[HashAlgorithm::Sha256]).unwrap(),
         )
         .signed::<Json>(&snapshot_key)
         .unwrap();
@@ -94,7 +94,7 @@ fn simple_delegation() {
     //// build the delegation ////
     let target_file: &[u8] = b"bar";
     let delegation = TargetsMetadataBuilder::new()
-        .insert_target_from_reader(
+        .insert_target_from_slice(
             TargetPath::new("foo".into()).unwrap(),
             target_file,
             &[HashAlgorithm::Sha256],
@@ -145,15 +145,15 @@ fn nested_delegation() {
     let snapshot = SnapshotMetadataBuilder::new()
         .insert_metadata_description(
             MetadataPath::new("targets").unwrap(),
-            MetadataDescription::from_reader(&*vec![0u8], 1, &[HashAlgorithm::Sha256]).unwrap(),
+            MetadataDescription::from_slice(&[0u8], 1, &[HashAlgorithm::Sha256]).unwrap(),
         )
         .insert_metadata_description(
             MetadataPath::new("delegation-a").unwrap(),
-            MetadataDescription::from_reader(&*vec![0u8], 1, &[HashAlgorithm::Sha256]).unwrap(),
+            MetadataDescription::from_slice(&[0u8], 1, &[HashAlgorithm::Sha256]).unwrap(),
         )
         .insert_metadata_description(
             MetadataPath::new("delegation-b").unwrap(),
-            MetadataDescription::from_reader(&*vec![0u8], 1, &[HashAlgorithm::Sha256]).unwrap(),
+            MetadataDescription::from_slice(&[0u8], 1, &[HashAlgorithm::Sha256]).unwrap(),
         )
         .signed::<Json>(&snapshot_key)
         .unwrap();
@@ -231,7 +231,7 @@ fn nested_delegation() {
     let target_file: &[u8] = b"bar";
 
     let delegation = TargetsMetadataBuilder::new()
-        .insert_target_from_reader(
+        .insert_target_from_slice(
             TargetPath::new("foo".into()).unwrap(),
             target_file,
             &[HashAlgorithm::Sha256],
@@ -282,11 +282,11 @@ fn rejects_bad_delegation_signatures() {
     let snapshot = SnapshotMetadataBuilder::new()
         .insert_metadata_description(
             MetadataPath::new("targets").unwrap(),
-            MetadataDescription::from_reader(&*vec![0u8], 1, &[HashAlgorithm::Sha256]).unwrap(),
+            MetadataDescription::from_slice(&*vec![0u8], 1, &[HashAlgorithm::Sha256]).unwrap(),
         )
         .insert_metadata_description(
             MetadataPath::new("delegation").unwrap(),
-            MetadataDescription::from_reader(&*vec![0u8], 1, &[HashAlgorithm::Sha256]).unwrap(),
+            MetadataDescription::from_slice(&*vec![0u8], 1, &[HashAlgorithm::Sha256]).unwrap(),
         )
         .signed::<Json>(&snapshot_key)
         .unwrap();
@@ -331,7 +331,7 @@ fn rejects_bad_delegation_signatures() {
     //// build the delegation ////
     let target_file: &[u8] = b"bar";
     let delegation = TargetsMetadataBuilder::new()
-        .insert_target_from_reader(
+        .insert_target_from_slice(
             TargetPath::new("foo".into()).unwrap(),
             target_file,
             &[HashAlgorithm::Sha256],
@@ -400,19 +400,19 @@ fn diamond_delegation() {
     let snapshot = SnapshotMetadataBuilder::new()
         .insert_metadata_description(
             MetadataPath::new("targets").unwrap(),
-            MetadataDescription::from_reader(&*vec![0u8], 1, &[HashAlgorithm::Sha256]).unwrap(),
+            MetadataDescription::from_slice(&*vec![0u8], 1, &[HashAlgorithm::Sha256]).unwrap(),
         )
         .insert_metadata_description(
             MetadataPath::new("delegation-a").unwrap(),
-            MetadataDescription::from_reader(&*vec![0u8], 1, &[HashAlgorithm::Sha256]).unwrap(),
+            MetadataDescription::from_slice(&*vec![0u8], 1, &[HashAlgorithm::Sha256]).unwrap(),
         )
         .insert_metadata_description(
             MetadataPath::new("delegation-b").unwrap(),
-            MetadataDescription::from_reader(&*vec![0u8], 1, &[HashAlgorithm::Sha256]).unwrap(),
+            MetadataDescription::from_slice(&*vec![0u8], 1, &[HashAlgorithm::Sha256]).unwrap(),
         )
         .insert_metadata_description(
             MetadataPath::new("delegation-c").unwrap(),
-            MetadataDescription::from_reader(&*vec![0u8], 1, &[HashAlgorithm::Sha256]).unwrap(),
+            MetadataDescription::from_slice(&*vec![0u8], 1, &[HashAlgorithm::Sha256]).unwrap(),
         )
         .signed::<Json>(&etc_key)
         .unwrap();
@@ -537,13 +537,13 @@ fn diamond_delegation() {
     let bar_target_file: &[u8] = b"bar contents";
 
     let delegation = TargetsMetadataBuilder::new()
-        .insert_target_from_reader(
+        .insert_target_from_slice(
             TargetPath::new("foo".into()).unwrap(),
             foo_target_file,
             &[HashAlgorithm::Sha256],
         )
         .unwrap()
-        .insert_target_from_reader(
+        .insert_target_from_slice(
             TargetPath::new("bar".into()).unwrap(),
             bar_target_file,
             &[HashAlgorithm::Sha256],

--- a/tuf/tests/simple_example.rs
+++ b/tuf/tests/simple_example.rs
@@ -102,7 +102,7 @@ async fn init_server(
     //// build the targets ////
 
     let target_file: &[u8] = b"things fade, alternatives exclude";
-    let target_description = TargetDescription::from_reader(target_file, &[HashAlgorithm::Sha256])?;
+    let target_description = TargetDescription::from_slice(target_file, &[HashAlgorithm::Sha256])?;
 
     let target_path = TargetPath::new("foo-bar".into())?;
 


### PR DESCRIPTION
We had a few places where we performed synchronous io:

* DataInterchange::from_reader
* MetadataDescription::from_reader
* TargetDescription::from_reader
* TargetDescription::from_reader_with_custom

The first two are unnecessary since metadata is only working with `&[u8]`s. The last two we can switch to using asynchronous io.