### PR TITLE
Remove Repository interior mutability

### DIFF
--- a/interop-tests/tests/test.rs
+++ b/interop-tests/tests/test.rs
@@ -181,7 +181,7 @@ where
             &MetadataVersion::Number(1),
             1,
             public_keys,
-            &self.local,
+            &mut self.local,
             remote,
         )
         .await

--- a/tuf/Cargo.toml
+++ b/tuf/Cargo.toml
@@ -27,7 +27,6 @@ hyper_013 = { package = "hyper", version = "0.13.2", default-features = false, f
 hyper_014 = { package = "hyper", version = "0.14.15", default-features = false, features = [ "stream", "client", "http1" ], optional = true }
 itoa = "0.4"
 log = "0.4"
-parking_lot = "0.11"
 percent-encoding = "2.1"
 ring = { version = "0.16" }
 serde = "1"

--- a/tuf/src/repository/ephemeral.rs
+++ b/tuf/src/repository/ephemeral.rs
@@ -3,10 +3,8 @@
 use futures_io::AsyncRead;
 use futures_util::future::{BoxFuture, FutureExt};
 use futures_util::io::{AsyncReadExt, Cursor};
-use parking_lot::RwLock;
 use std::collections::HashMap;
 use std::marker::PhantomData;
-use std::sync::Arc;
 
 use crate::error::Error;
 use crate::interchange::DataInterchange;
@@ -14,13 +12,11 @@ use crate::metadata::{MetadataPath, MetadataVersion, TargetPath};
 use crate::repository::{RepositoryProvider, RepositoryStorage};
 use crate::Result;
 
-type ArcHashMap<K, V> = Arc<RwLock<HashMap<K, V>>>;
-
 /// An ephemeral repository contained solely in memory.
 #[derive(Debug)]
 pub struct EphemeralRepository<D> {
-    metadata: ArcHashMap<(MetadataPath, MetadataVersion), Arc<[u8]>>,
-    targets: ArcHashMap<TargetPath, Arc<[u8]>>,
+    metadata: HashMap<(MetadataPath, MetadataVersion), Box<[u8]>>,
+    targets: HashMap<TargetPath, Box<[u8]>>,
     _interchange: PhantomData<D>,
 }
 
@@ -31,8 +27,8 @@ where
     /// Create a new ephemeral repository.
     pub fn new() -> Self {
         Self {
-            metadata: Arc::new(RwLock::new(HashMap::new())),
-            targets: Arc::new(RwLock::new(HashMap::new())),
+            metadata: HashMap::new(),
+            targets: HashMap::new(),
             _interchange: PhantomData,
         }
     }
@@ -53,21 +49,15 @@ where
 {
     fn fetch_metadata<'a>(
         &'a self,
-        meta_path: &'a MetadataPath,
-        version: &'a MetadataVersion,
-    ) -> BoxFuture<'a, Result<Box<dyn AsyncRead + Send + Unpin>>> {
+        meta_path: &MetadataPath,
+        version: &MetadataVersion,
+    ) -> BoxFuture<'a, Result<Box<dyn AsyncRead + Send + Unpin + 'a>>> {
+        let bytes = match self.metadata.get(&(meta_path.clone(), version.clone())) {
+            Some(bytes) => Ok(bytes),
+            None => Err(Error::NotFound),
+        };
         async move {
-            let bytes = match self
-                .metadata
-                .read()
-                .get(&(meta_path.clone(), version.clone()))
-            {
-                Some(bytes) => Arc::clone(bytes),
-                None => {
-                    return Err(Error::NotFound);
-                }
-            };
-
+            let bytes = bytes?;
             let reader: Box<dyn AsyncRead + Send + Unpin> = Box::new(Cursor::new(bytes));
             Ok(reader)
         }
@@ -76,16 +66,14 @@ where
 
     fn fetch_target<'a>(
         &'a self,
-        target_path: &'a TargetPath,
-    ) -> BoxFuture<'a, Result<Box<dyn AsyncRead + Send + Unpin>>> {
+        target_path: &TargetPath,
+    ) -> BoxFuture<'a, Result<Box<dyn AsyncRead + Send + Unpin + 'a>>> {
+        let bytes = match self.targets.get(target_path) {
+            Some(bytes) => Ok(bytes),
+            None => Err(Error::NotFound),
+        };
         async move {
-            let bytes = match self.targets.read().get(target_path) {
-                Some(bytes) => Arc::clone(bytes),
-                None => {
-                    return Err(Error::NotFound);
-                }
-            };
-
+            let bytes = bytes?;
             let reader: Box<dyn AsyncRead + Send + Unpin> = Box::new(Cursor::new(bytes));
             Ok(reader)
         }
@@ -98,33 +86,36 @@ where
     D: DataInterchange + Sync,
 {
     fn store_metadata<'a>(
-        &'a self,
-        meta_path: &'a MetadataPath,
-        version: &'a MetadataVersion,
+        &'a mut self,
+        meta_path: &MetadataPath,
+        version: &MetadataVersion,
         metadata: &'a mut (dyn AsyncRead + Send + Unpin + 'a),
     ) -> BoxFuture<'a, Result<()>> {
+        let meta_path = meta_path.clone();
+        let version = version.clone();
+        let self_metadata = &mut self.metadata;
         async move {
             let mut buf = Vec::new();
             metadata.read_to_end(&mut buf).await?;
-            self.metadata
-                .write()
-                .insert((meta_path.clone(), version.clone()), Arc::from(buf));
+            buf.shrink_to_fit();
+            self_metadata.insert((meta_path, version), buf.into_boxed_slice());
             Ok(())
         }
         .boxed()
     }
 
     fn store_target<'a>(
-        &'a self,
-        target_path: &'a TargetPath,
+        &'a mut self,
+        target_path: &TargetPath,
         read: &'a mut (dyn AsyncRead + Send + Unpin + 'a),
     ) -> BoxFuture<'a, Result<()>> {
+        let target_path = target_path.clone();
+        let self_targets = &mut self.targets;
         async move {
             let mut buf = Vec::new();
             read.read_to_end(&mut buf).await?;
-            self.targets
-                .write()
-                .insert(target_path.clone(), Arc::from(buf));
+            buf.shrink_to_fit();
+            self_targets.insert(target_path.clone(), buf.into_boxed_slice());
             Ok(())
         }
         .boxed()
@@ -140,7 +131,7 @@ mod test {
     #[test]
     fn ephemeral_repo_targets() {
         block_on(async {
-            let repo = EphemeralRepository::<Json>::new();
+            let mut repo = EphemeralRepository::<Json>::new();
 
             let data: &[u8] = b"like tears in the rain";
             let path = TargetPath::new("batty".into()).unwrap();
@@ -150,6 +141,7 @@ mod test {
             let mut buf = Vec::new();
             read.read_to_end(&mut buf).await.unwrap();
             assert_eq!(buf.as_slice(), data);
+            drop(read);
 
             // RepositoryProvider implementations do not guarantee data is not corrupt.
             let bad_data: &[u8] = b"you're in a desert";

--- a/tuf/src/repository/error_repo.rs
+++ b/tuf/src/repository/error_repo.rs
@@ -7,25 +7,28 @@ use {
     },
     futures_io::AsyncRead,
     futures_util::future::{BoxFuture, FutureExt},
-    parking_lot::Mutex,
-    std::sync::Arc,
+    std::sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
 };
 
 pub(crate) struct ErrorRepository<R> {
     repo: R,
-    fail_metadata_stores: Arc<Mutex<bool>>,
+    fail_metadata_stores: Arc<AtomicBool>,
 }
 
 impl<R> ErrorRepository<R> {
     pub(crate) fn new(repo: R) -> Self {
         Self {
             repo,
-            fail_metadata_stores: Arc::new(Mutex::new(false)),
+            fail_metadata_stores: Arc::new(AtomicBool::new(false)),
         }
     }
 
     pub(crate) fn fail_metadata_stores(&self, fail_metadata_stores: bool) {
-        *self.fail_metadata_stores.lock() = fail_metadata_stores;
+        self.fail_metadata_stores
+            .store(fail_metadata_stores, Ordering::SeqCst);
     }
 }
 
@@ -36,16 +39,16 @@ where
 {
     fn fetch_metadata<'a>(
         &'a self,
-        meta_path: &'a MetadataPath,
-        version: &'a MetadataVersion,
-    ) -> BoxFuture<'a, Result<Box<dyn AsyncRead + Send + Unpin>>> {
+        meta_path: &MetadataPath,
+        version: &MetadataVersion,
+    ) -> BoxFuture<'a, Result<Box<dyn AsyncRead + Send + Unpin + 'a>>> {
         self.repo.fetch_metadata(meta_path, version)
     }
 
     fn fetch_target<'a>(
         &'a self,
-        target_path: &'a TargetPath,
-    ) -> BoxFuture<'a, Result<Box<dyn AsyncRead + Send + Unpin>>> {
+        target_path: &TargetPath,
+    ) -> BoxFuture<'a, Result<Box<dyn AsyncRead + Send + Unpin + 'a>>> {
         self.repo.fetch_target(target_path)
     }
 }
@@ -56,12 +59,12 @@ where
     D: DataInterchange + Sync,
 {
     fn store_metadata<'a>(
-        &'a self,
-        meta_path: &'a MetadataPath,
-        version: &'a MetadataVersion,
+        &'a mut self,
+        meta_path: &MetadataPath,
+        version: &MetadataVersion,
         metadata: &'a mut (dyn AsyncRead + Send + Unpin + 'a),
     ) -> BoxFuture<'a, Result<()>> {
-        if *self.fail_metadata_stores.lock() {
+        if self.fail_metadata_stores.load(Ordering::SeqCst) {
             async { Err(Error::Encoding("failed".into())) }.boxed()
         } else {
             self.repo.store_metadata(meta_path, version, metadata)
@@ -69,8 +72,8 @@ where
     }
 
     fn store_target<'a>(
-        &'a self,
-        target_path: &'a TargetPath,
+        &'a mut self,
+        target_path: &TargetPath,
         target: &'a mut (dyn AsyncRead + Send + Unpin + 'a),
     ) -> BoxFuture<'a, Result<()>> {
         self.repo.store_target(target_path, target)

--- a/tuf/src/repository/http.rs
+++ b/tuf/src/repository/http.rs
@@ -247,9 +247,9 @@ where
 {
     fn fetch_metadata<'a>(
         &'a self,
-        meta_path: &'a MetadataPath,
-        version: &'a MetadataVersion,
-    ) -> BoxFuture<'a, Result<Box<dyn AsyncRead + Send + Unpin>>> {
+        meta_path: &MetadataPath,
+        version: &MetadataVersion,
+    ) -> BoxFuture<'a, Result<Box<dyn AsyncRead + Send + Unpin + 'a>>> {
         let components = meta_path.components::<D>(version);
         async move {
             let resp = self.get(&self.metadata_prefix, &components).await?;
@@ -270,13 +270,13 @@ where
 
     fn fetch_target<'a>(
         &'a self,
-        target_path: &'a TargetPath,
-    ) -> BoxFuture<'a, Result<Box<dyn AsyncRead + Send + Unpin>>> {
-        async move {
-            let components = target_path.components();
-            let resp = self.get(&self.targets_prefix, &components).await?;
+        target_path: &TargetPath,
+    ) -> BoxFuture<'a, Result<Box<dyn AsyncRead + Send + Unpin + 'a>>> {
+        let components = target_path.components();
 
+        async move {
             // TODO(#278) check content length if known and fail early if the payload is too large.
+            let resp = self.get(&self.targets_prefix, &components).await?;
 
             let reader = resp
                 .into_body()

--- a/tuf/tests/simple_example.rs
+++ b/tuf/tests/simple_example.rs
@@ -35,8 +35,10 @@ fn consistent_snapshot_true() {
 }
 
 async fn run_tests(config: Config, consistent_snapshots: bool) {
-    let remote = EphemeralRepository::new();
-    let root_public_keys = init_server(&remote, consistent_snapshots).await.unwrap();
+    let mut remote = EphemeralRepository::new();
+    let root_public_keys = init_server(&mut remote, consistent_snapshots)
+        .await
+        .unwrap();
 
     init_client(&root_public_keys, remote, config)
         .await
@@ -64,7 +66,7 @@ async fn init_client(
 }
 
 async fn init_server(
-    remote: &EphemeralRepository<Json>,
+    remote: &mut EphemeralRepository<Json>,
     consistent_snapshot: bool,
 ) -> Result<Vec<PublicKey>> {
     // in real life, you wouldn't want these keys on the same machine ever


### PR DESCRIPTION
A long time ago we switched to using interior mutability for updating the repository. But since then it turns out that this was unnecessary. This patch removes the need for that.

As part of this, we also:

* fetch_{metadata,target} now can contain 'a values.
* Remove impl of RepositoryStorage for Arc<T>, since that requires interior mutability.
* Remove dependency on parking_lot.