### PR TITLE
Optional metafile length and snapshot

### DIFF
--- a/tuf/src/interchange/cjson/shims.rs
+++ b/tuf/src/interchange/cjson/shims.rs
@@ -482,7 +482,9 @@ impl TargetDescription {
 #[derive(Deserialize)]
 pub struct MetadataDescription {
     version: u32,
-    length: usize,
+    #[serde(default)]
+    length: Option<usize>,
+    #[serde(default)]
     hashes: BTreeMap<crypto::HashAlgorithm, crypto::HashValue>,
 }
 

--- a/tuf/src/metadata.rs
+++ b/tuf/src/metadata.rs
@@ -2564,7 +2564,7 @@ mod test {
 
     // Deserialize timestamp metadata with optional length and hashes
     #[test]
-    fn serde_timestamp_metadata_optional_length_and_hashes() {
+    fn serde_timestamp_metadata_without_length_and_hashes() {
         let description = MetadataDescription::new(1, None, HashMap::new()).unwrap();
 
         let timestamp = TimestampMetadataBuilder::from_metadata_description(description)


### PR DESCRIPTION
According to the [spec] it is optional for timestamp to contain the length and hash of the snapshot, and for snapshot to contain the length and hash for targets. This is considered safe because the metadata still needs to have it's metadata signature verified before used. However, the client must set an upper bound on the download size if the metadata does not specify the download length.

The upper bounds have been updated to sync with python-tuf's [defaults].

[spec]: https://theupdateframework.github.io/specification/latest/#metapath-hashes
[defaults]: https://github.com/theupdateframework/python-tuf/blob/30ba6e9f9ab25e0370e29ce574dada2d8809afa0/tuf/settings.py