### PR TITLE
Add RepoBuilder::add_target_with_custom; don't serialize empty custom fields

### DIFF
--- a/interop-tests/Cargo.toml
+++ b/interop-tests/Cargo.toml
@@ -1,7 +1,13 @@
 [package]
 name = "interop-tests"
 version = "0.1.0"
+authors = [ "heartsucker <heartsucker@autistici.org>", "Erick Tryzelaar <etryzelaar@google.com>" ]
+description = "TUF library interoperation tests"
+homepage = "https://github.com/theupdateframework/rust-tuf"
+repository = "https://github.com/theupdateframework/rust-tuf"
 edition = "2018"
+readme = "README.md"
+license = "MIT/Apache-2.0"
 publish = false
 
 [dependencies]
@@ -11,7 +17,7 @@ futures-executor = "0.3.1"
 serde = "1"
 serde_derive = "1"
 serde_json = "1"
-tuf = { version = "0.3.0-beta1", path = "../tuf" }
+tuf = { version = "0.3.0-beta5", path = "../tuf" }
 walkdir = "2.3.2"
 
 [dev-dependencies]

--- a/interop-tests/LICENSE-APACHE
+++ b/interop-tests/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/interop-tests/LICENSE-MIT
+++ b/interop-tests/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/interop-tests/README.md
+++ b/interop-tests/README.md
@@ -1,0 +1,1 @@
+../README.md

--- a/tuf/Cargo.toml
+++ b/tuf/Cargo.toml
@@ -49,6 +49,5 @@ default = ["hyper_014/tcp"]
 
 # FIXME(https://github.com/theupdateframework/rust-tuf/issues/329) - RSA key
 # support does not yet conform to the TUF spec, so it is disabled by default.
-# As a # warning it may experience breaking changes without a major version
-# bump.
+# As a warning it may experience breaking changes without a major version bump.
 unstable_rsa = []

--- a/tuf/Cargo.toml
+++ b/tuf/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "tuf"
 edition = "2018"
-version = "0.3.0-beta4"
+version = "0.3.0-beta5"
 authors = [ "heartsucker <heartsucker@autistici.org>", "Erick Tryzelaar <etryzelaar@google.com>" ]
 description = "Library for The Update Framework (TUF)"
-homepage = "https://github.com/heartsucker/rust-tuf"
-repository = "https://github.com/heartsucker/rust-tuf"
+homepage = "https://github.com/theupdateframework/rust-tuf"
+repository = "https://github.com/theupdateframework/rust-tuf"
 documentation = "https://docs.rs/tuf"
 readme = "README.md"
 license = "MIT/Apache-2.0"
@@ -47,7 +47,8 @@ pretty_assertions = "1"
 [features]
 default = ["hyper_014/tcp"]
 
-# FIXME(https://github.com/heartsucker/rust-tuf/issues/329) - RSA key support
-# does not yet conform to the TUF spec, so it is disabled by default. As a
-# warning it may experience breaking changes without a major version bump.
+# FIXME(https://github.com/theupdateframework/rust-tuf/issues/329) - RSA key
+# support does not yet conform to the TUF spec, so it is disabled by default.
+# As a # warning it may experience breaking changes without a major version
+# bump.
 unstable_rsa = []

--- a/tuf/src/interchange/cjson/shims.rs
+++ b/tuf/src/interchange/cjson/shims.rs
@@ -451,8 +451,8 @@ impl Delegations {
 pub struct TargetDescription {
     length: u64,
     hashes: BTreeMap<crypto::HashAlgorithm, crypto::HashValue>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    custom: Option<BTreeMap<String, serde_json::Value>>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    custom: BTreeMap<String, serde_json::Value>,
 }
 
 impl TargetDescription {
@@ -466,7 +466,9 @@ impl TargetDescription {
                 .collect(),
             custom: description
                 .custom()
-                .map(|custom| custom.iter().map(|(k, v)| (k.clone(), v.clone())).collect()),
+                .iter()
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect(),
         }
     }
 
@@ -474,7 +476,7 @@ impl TargetDescription {
         metadata::TargetDescription::new(
             self.length,
             self.hashes.into_iter().collect(),
-            self.custom.map(|custom| custom.into_iter().collect()),
+            self.custom.into_iter().collect(),
         )
     }
 }

--- a/tuf/src/metadata.rs
+++ b/tuf/src/metadata.rs
@@ -2802,12 +2802,21 @@ mod test {
         block_on(async {
             let targets = TargetsMetadataBuilder::new()
                 .expires(Utc.ymd(2017, 1, 1).and_hms(0, 0, 0))
-                .insert_target_description(
-                    TargetPath::new("foo").unwrap(),
-                    TargetDescription::from_slice(&b"foo"[..], &[HashAlgorithm::Sha256]).unwrap(),
+                .insert_target_from_slice(
+                    TargetPath::new("insert-target-from-slice").unwrap(),
+                    &b"foo"[..],
+                    &[HashAlgorithm::Sha256],
                 )
+                .unwrap()
+                .insert_target_from_reader(
+                    TargetPath::new("insert-target-from-reader").unwrap(),
+                    &b"foo"[..],
+                    &[HashAlgorithm::Sha256],
+                )
+                .await
+                .unwrap()
                 .insert_target_description(
-                    TargetPath::new("bar").unwrap(),
+                    TargetPath::new("insert-target-description-from-slice-with-custom").unwrap(),
                     TargetDescription::from_slice_with_custom(
                         &b"foo"[..],
                         &[HashAlgorithm::Sha256],
@@ -2816,7 +2825,7 @@ mod test {
                     .unwrap(),
                 )
                 .insert_target_description(
-                    TargetPath::new("baz").unwrap(),
+                    TargetPath::new("insert-target-description-from-reader-with-custom").unwrap(),
                     TargetDescription::from_reader_with_custom(
                         &b"foo"[..],
                         &[HashAlgorithm::Sha256],
@@ -2837,21 +2846,28 @@ mod test {
                 "version": 1,
                 "expires": "2017-01-01T00:00:00Z",
                 "targets": {
-                    "foo": {
+                    "insert-target-from-slice": {
                         "length": 3,
                         "hashes": {
                             "sha256": "2c26b46b68ffc68ff99b453c1d30413413422d706483\
                                 bfa0f98a5e886266e7ae",
                         },
                     },
-                    "bar": {
+                    "insert-target-description-from-slice-with-custom": {
                         "length": 3,
                         "hashes": {
                             "sha256": "2c26b46b68ffc68ff99b453c1d30413413422d706483\
                                 bfa0f98a5e886266e7ae",
                         },
                     },
-                    "baz": {
+                    "insert-target-from-reader": {
+                        "length": 3,
+                        "hashes": {
+                            "sha256": "2c26b46b68ffc68ff99b453c1d30413413422d706483\
+                                bfa0f98a5e886266e7ae",
+                        },
+                    },
+                    "insert-target-description-from-reader-with-custom": {
                         "length": 3,
                         "hashes": {
                             "sha256": "2c26b46b68ffc68ff99b453c1d30413413422d706483\


### PR DESCRIPTION
This makes two changes. First, it allows RepoBuilder to create targets with custom fields. Second, it changes TargetDescription to not allow for empty custom fields. Instead they are not serialized.

Finally, it bumps the version to prep for release.