### PR TITLE
Make MetadataVersion a value type

### DIFF
--- a/interop-tests/src/lib.rs
+++ b/interop-tests/src/lib.rs
@@ -200,7 +200,7 @@ async fn add_target(
 
     repo.store_metadata(
         &targets_path,
-        &version_prefix,
+        version_prefix,
         &mut signed_targets.to_raw().unwrap().as_bytes(),
     )
     .await
@@ -217,7 +217,7 @@ async fn add_target(
 
     repo.store_metadata(
         &snapshot_path,
-        &version_prefix,
+        version_prefix,
         &mut snapshot.to_raw().unwrap().as_bytes(),
     )
     .await
@@ -234,7 +234,7 @@ async fn add_target(
     // Timestamp doesn't require a version prefix even in consistent_snapshot.
     repo.store_metadata(
         &timestamp_path,
-        &MetadataVersion::None,
+        MetadataVersion::None,
         &mut timestamp.to_raw().unwrap().as_bytes(),
     )
     .await

--- a/interop-tests/tests/test.rs
+++ b/interop-tests/tests/test.rs
@@ -178,7 +178,7 @@ where
         // Connect to the client with our initial keys.
         let mut client = Client::with_trusted_root_keys(
             Config::default(),
-            &MetadataVersion::Number(1),
+            MetadataVersion::Number(1),
             1,
             public_keys,
             &mut self.local,
@@ -218,7 +218,7 @@ where
 
     let mut buf = Vec::new();
     let mut reader = remote
-        .fetch_metadata(&root_path, &MetadataVersion::Number(1))
+        .fetch_metadata(&root_path, MetadataVersion::Number(1))
         .await
         .unwrap();
     reader.read_to_end(&mut buf).await.unwrap();

--- a/tuf/src/metadata.rs
+++ b/tuf/src/metadata.rs
@@ -205,7 +205,7 @@ impl Display for Role {
 }
 
 /// Enum used for addressing versioned TUF metadata.
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Copy, Clone, Hash)]
 pub enum MetadataVersion {
     /// The metadata is unversioned. This is the latest version of the metadata.
     None,
@@ -1021,12 +1021,12 @@ impl MetadataPath {
     /// # use tuf::metadata::{MetadataPath, MetadataVersion};
     /// #
     /// let path = MetadataPath::new("foo/bar").unwrap();
-    /// assert_eq!(path.components::<Json>(&MetadataVersion::None),
+    /// assert_eq!(path.components::<Json>(MetadataVersion::None),
     ///            ["foo".to_string(), "bar.json".to_string()]);
-    /// assert_eq!(path.components::<Json>(&MetadataVersion::Number(1)),
+    /// assert_eq!(path.components::<Json>(MetadataVersion::Number(1)),
     ///            ["foo".to_string(), "1.bar.json".to_string()]);
     /// ```
-    pub fn components<D>(&self, version: &MetadataVersion) -> Vec<String>
+    pub fn components<D>(&self, version: MetadataVersion) -> Vec<String>
     where
         D: DataInterchange,
     {

--- a/tuf/src/repo_builder.rs
+++ b/tuf/src/repo_builder.rs
@@ -1216,7 +1216,7 @@ where
                 .repo
                 .store_metadata(
                     &MetadataPath::from_role(&Role::Root),
-                    &MetadataVersion::Number(root.metadata.version()),
+                    MetadataVersion::Number(root.metadata.version()),
                     &mut root.raw.as_bytes(),
                 )
                 .await?;
@@ -1225,7 +1225,7 @@ where
                 .repo
                 .store_metadata(
                     &MetadataPath::from_role(&Role::Root),
-                    &MetadataVersion::None,
+                    MetadataVersion::None,
                     &mut root.raw.as_bytes(),
                 )
                 .await?;
@@ -1241,7 +1241,7 @@ where
             let path = MetadataPath::from_role(&Role::Targets);
             self.ctx
                 .repo
-                .store_metadata(&path, &MetadataVersion::None, &mut targets.raw.as_bytes())
+                .store_metadata(&path, MetadataVersion::None, &mut targets.raw.as_bytes())
                 .await?;
 
             if consistent_snapshot {
@@ -1249,7 +1249,7 @@ where
                     .repo
                     .store_metadata(
                         &path,
-                        &MetadataVersion::Number(targets.metadata.version()),
+                        MetadataVersion::Number(targets.metadata.version()),
                         &mut targets.raw.as_bytes(),
                     )
                     .await?;
@@ -1260,7 +1260,7 @@ where
             let path = MetadataPath::from_role(&Role::Snapshot);
             self.ctx
                 .repo
-                .store_metadata(&path, &MetadataVersion::None, &mut snapshot.raw.as_bytes())
+                .store_metadata(&path, MetadataVersion::None, &mut snapshot.raw.as_bytes())
                 .await?;
 
             if consistent_snapshot {
@@ -1268,7 +1268,7 @@ where
                     .repo
                     .store_metadata(
                         &path,
-                        &MetadataVersion::Number(snapshot.metadata.version()),
+                        MetadataVersion::Number(snapshot.metadata.version()),
                         &mut snapshot.raw.as_bytes(),
                     )
                     .await?;
@@ -1280,7 +1280,7 @@ where
                 .repo
                 .store_metadata(
                     &MetadataPath::from_role(&Role::Timestamp),
-                    &MetadataVersion::None,
+                    MetadataVersion::None,
                     &mut timestamp.raw.as_bytes(),
                 )
                 .await?;

--- a/tuf/src/repository.rs
+++ b/tuf/src/repository.rs
@@ -56,7 +56,7 @@ where
     fn fetch_metadata<'a>(
         &'a self,
         meta_path: &MetadataPath,
-        version: &MetadataVersion,
+        version: MetadataVersion,
     ) -> BoxFuture<'a, Result<Box<dyn AsyncRead + Send + Unpin + 'a>>>;
 
     /// Fetch the given target.
@@ -78,7 +78,7 @@ where
 pub(crate) async fn fetch_metadata_to_string<D, R>(
     repo: &R,
     meta_path: &MetadataPath,
-    version: &MetadataVersion,
+    version: MetadataVersion,
 ) -> Result<String>
 where
     D: DataInterchange + Sync,
@@ -119,7 +119,7 @@ where
     fn store_metadata<'a>(
         &'a mut self,
         meta_path: &MetadataPath,
-        version: &MetadataVersion,
+        version: MetadataVersion,
         metadata: &'a mut (dyn AsyncRead + Send + Unpin + 'a),
     ) -> BoxFuture<'a, Result<()>>;
 
@@ -155,7 +155,7 @@ where
     fn fetch_metadata<'a>(
         &'a self,
         meta_path: &MetadataPath,
-        version: &MetadataVersion,
+        version: MetadataVersion,
     ) -> BoxFuture<'a, Result<Box<dyn AsyncRead + Send + Unpin + 'a>>> {
         (**self).fetch_metadata(meta_path, version)
     }
@@ -176,7 +176,7 @@ where
     fn fetch_metadata<'a>(
         &'a self,
         meta_path: &MetadataPath,
-        version: &MetadataVersion,
+        version: MetadataVersion,
     ) -> BoxFuture<'a, Result<Box<dyn AsyncRead + Send + Unpin + 'a>>> {
         (**self).fetch_metadata(meta_path, version)
     }
@@ -197,7 +197,7 @@ where
     fn store_metadata<'a>(
         &'a mut self,
         meta_path: &MetadataPath,
-        version: &MetadataVersion,
+        version: MetadataVersion,
         metadata: &'a mut (dyn AsyncRead + Send + Unpin + 'a),
     ) -> BoxFuture<'a, Result<()>> {
         (**self).store_metadata(meta_path, version, metadata)
@@ -220,7 +220,7 @@ where
     fn store_metadata<'a>(
         &'a mut self,
         meta_path: &MetadataPath,
-        version: &MetadataVersion,
+        version: MetadataVersion,
         metadata: &'a mut (dyn AsyncRead + Send + Unpin + 'a),
     ) -> BoxFuture<'a, Result<()>> {
         (**self).store_metadata(meta_path, version, metadata)
@@ -243,7 +243,7 @@ where
     fn fetch_metadata<'a>(
         &'a self,
         meta_path: &MetadataPath,
-        version: &MetadataVersion,
+        version: MetadataVersion,
     ) -> BoxFuture<'a, Result<Box<dyn AsyncRead + Send + Unpin + 'a>>> {
         (**self).fetch_metadata(meta_path, version)
     }
@@ -264,7 +264,7 @@ where
     fn fetch_metadata<'a>(
         &'a self,
         meta_path: &MetadataPath,
-        version: &MetadataVersion,
+        version: MetadataVersion,
     ) -> BoxFuture<'a, Result<Box<dyn AsyncRead + Send + Unpin + 'a>>> {
         (**self).fetch_metadata(meta_path, version)
     }
@@ -336,7 +336,7 @@ where
     pub(crate) async fn fetch_metadata<'a, M>(
         &'a self,
         meta_path: &'a MetadataPath,
-        version: &'a MetadataVersion,
+        version: MetadataVersion,
         max_length: Option<usize>,
         hashes: Vec<(&'static HashAlgorithm, HashValue)>,
     ) -> Result<RawSignedMetadata<D, M>>
@@ -422,7 +422,7 @@ where
     pub async fn store_metadata<'a, M>(
         &'a mut self,
         path: &'a MetadataPath,
-        version: &'a MetadataVersion,
+        version: MetadataVersion,
         metadata: &'a RawSignedMetadata<D, M>,
     ) -> Result<()>
     where
@@ -462,7 +462,7 @@ mod test {
             assert_matches!(
                 repo.fetch_metadata::<RootMetadata>(
                     &MetadataPath::from_role(&Role::Root),
-                    &MetadataVersion::None,
+                    MetadataVersion::None,
                     None,
                     vec![],
                 )
@@ -480,7 +480,7 @@ mod test {
 
             repo.store_metadata(
                 &MetadataPath::from_role(&Role::Root),
-                &MetadataVersion::None,
+                MetadataVersion::None,
                 &fake_metadata,
             )
             .await
@@ -489,7 +489,7 @@ mod test {
             assert_matches!(
                 repo.store_metadata(
                     &MetadataPath::from_role(&Role::Snapshot),
-                    &MetadataVersion::None,
+                    MetadataVersion::None,
                     &fake_metadata,
                 )
                 .await,
@@ -499,7 +499,7 @@ mod test {
             assert_matches!(
                 repo.fetch_metadata::<SnapshotMetadata>(
                     &MetadataPath::from_role(&Role::Root),
-                    &MetadataVersion::None,
+                    MetadataVersion::None,
                     None,
                     vec![],
                 )
@@ -519,7 +519,7 @@ mod test {
             let data_hash = crypto::calculate_hash(data, &HashAlgorithm::Sha256);
 
             let mut repo = EphemeralRepository::new();
-            repo.store_metadata(&path, &version, &mut &*data)
+            repo.store_metadata(&path, version, &mut &*data)
                 .await
                 .unwrap();
 
@@ -529,7 +529,7 @@ mod test {
                 client
                     .fetch_metadata::<RootMetadata>(
                         &path,
-                        &version,
+                        version,
                         None,
                         vec![(&HashAlgorithm::Sha256, data_hash)],
                     )
@@ -547,7 +547,7 @@ mod test {
             let data: &[u8] = b"corrupt metadata";
 
             let mut repo = EphemeralRepository::new();
-            repo.store_metadata(&path, &version, &mut &*data)
+            repo.store_metadata(&path, version, &mut &*data)
                 .await
                 .unwrap();
 
@@ -557,7 +557,7 @@ mod test {
                 client
                     .fetch_metadata::<RootMetadata>(
                         &path,
-                        &version,
+                        version,
                         None,
                         vec![(&HashAlgorithm::Sha256, HashValue::new(vec![]))],
                     )
@@ -576,7 +576,7 @@ mod test {
             let _metadata = RawSignedMetadata::<Json, RootMetadata>::new(data.to_vec());
 
             let mut repo = EphemeralRepository::new();
-            repo.store_metadata(&path, &version, &mut &*data)
+            repo.store_metadata(&path, version, &mut &*data)
                 .await
                 .unwrap();
 
@@ -584,7 +584,7 @@ mod test {
 
             assert_matches!(
                 client
-                    .fetch_metadata::<RootMetadata>(&path, &version, Some(100), vec![])
+                    .fetch_metadata::<RootMetadata>(&path, version, Some(100), vec![])
                     .await,
                 Ok(_metadata)
             );
@@ -599,7 +599,7 @@ mod test {
             let data: &[u8] = b"very big metadata";
 
             let mut repo = EphemeralRepository::new();
-            repo.store_metadata(&path, &version, &mut &*data)
+            repo.store_metadata(&path, version, &mut &*data)
                 .await
                 .unwrap();
 
@@ -607,7 +607,7 @@ mod test {
 
             assert_matches!(
                 client
-                    .fetch_metadata::<RootMetadata>(&path, &version, Some(4), vec![])
+                    .fetch_metadata::<RootMetadata>(&path, version, Some(4), vec![])
                     .await,
                 Err(_)
             );

--- a/tuf/src/repository/ephemeral.rs
+++ b/tuf/src/repository/ephemeral.rs
@@ -13,7 +13,7 @@ use crate::repository::{RepositoryProvider, RepositoryStorage};
 use crate::Result;
 
 /// An ephemeral repository contained solely in memory.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct EphemeralRepository<D> {
     metadata: HashMap<(MetadataPath, MetadataVersion), Box<[u8]>>,
     targets: HashMap<TargetPath, Box<[u8]>>,
@@ -45,15 +45,6 @@ where
     #[cfg(test)]
     pub(crate) fn metadata(&self) -> &HashMap<(MetadataPath, MetadataVersion), Box<[u8]>> {
         &self.metadata
-    }
-}
-
-impl<D> Default for EphemeralRepository<D>
-where
-    D: DataInterchange,
-{
-    fn default() -> Self {
-        EphemeralRepository::new()
     }
 }
 
@@ -225,11 +216,19 @@ mod test {
     use crate::interchange::Json;
     use crate::repository::{fetch_metadata_to_string, fetch_target_to_string};
     use futures_executor::block_on;
+    use matches::assert_matches;
 
     #[test]
     fn ephemeral_repo_targets() {
         block_on(async {
             let mut repo = EphemeralRepository::<Json>::new();
+
+            let path = TargetPath::new("batty").unwrap();
+            if let Err(err) = repo.fetch_target(&path).await {
+                assert_matches!(err, Error::NotFound);
+            } else {
+                panic!("expected fetch_target to fail");
+            }
 
             let data: &[u8] = b"like tears in the rain";
             let path = TargetPath::new("batty").unwrap();

--- a/tuf/src/repository/ephemeral.rs
+++ b/tuf/src/repository/ephemeral.rs
@@ -64,9 +64,9 @@ where
     fn fetch_metadata<'a>(
         &'a self,
         meta_path: &MetadataPath,
-        version: &MetadataVersion,
+        version: MetadataVersion,
     ) -> BoxFuture<'a, Result<Box<dyn AsyncRead + Send + Unpin + 'a>>> {
-        let bytes = match self.metadata.get(&(meta_path.clone(), version.clone())) {
+        let bytes = match self.metadata.get(&(meta_path.clone(), version)) {
             Some(bytes) => Ok(bytes),
             None => Err(Error::NotFound),
         };
@@ -92,11 +92,10 @@ where
     fn store_metadata<'a>(
         &'a mut self,
         meta_path: &MetadataPath,
-        version: &MetadataVersion,
+        version: MetadataVersion,
         metadata: &'a mut (dyn AsyncRead + Send + Unpin + 'a),
     ) -> BoxFuture<'a, Result<()>> {
         let meta_path = meta_path.clone();
-        let version = version.clone();
         let self_metadata = &mut self.metadata;
         async move {
             let mut buf = Vec::new();
@@ -161,9 +160,9 @@ where
     fn fetch_metadata<'a>(
         &'a self,
         meta_path: &MetadataPath,
-        version: &MetadataVersion,
+        version: MetadataVersion,
     ) -> BoxFuture<'a, Result<Box<dyn AsyncRead + Send + Unpin + 'a>>> {
-        let key = (meta_path.clone(), version.clone());
+        let key = (meta_path.clone(), version);
         let bytes = if let Some(bytes) = self.staging_repo.metadata.get(&key) {
             Ok(bytes)
         } else {
@@ -195,7 +194,7 @@ where
     fn store_metadata<'a>(
         &'a mut self,
         meta_path: &MetadataPath,
-        version: &MetadataVersion,
+        version: MetadataVersion,
         metadata: &'a mut (dyn AsyncRead + Send + Unpin + 'a),
     ) -> BoxFuture<'a, Result<()>> {
         self.staging_repo
@@ -265,7 +264,7 @@ mod test {
             let committed_meta = "committed meta";
             let committed_target = "committed target";
 
-            repo.store_metadata(&meta_path, &meta_version, &mut committed_meta.as_bytes())
+            repo.store_metadata(&meta_path, meta_version, &mut committed_meta.as_bytes())
                 .await
                 .unwrap();
 
@@ -277,7 +276,7 @@ mod test {
 
             // Make sure we can read back the committed stuff.
             assert_eq!(
-                fetch_metadata_to_string(&batch, &meta_path, &meta_version)
+                fetch_metadata_to_string(&batch, &meta_path, meta_version)
                     .await
                     .unwrap(),
                 committed_meta,
@@ -291,7 +290,7 @@ mod test {
             let staged_meta = "staged meta";
             let staged_target = "staged target";
             batch
-                .store_metadata(&meta_path, &meta_version, &mut staged_meta.as_bytes())
+                .store_metadata(&meta_path, meta_version, &mut staged_meta.as_bytes())
                 .await
                 .unwrap();
             batch
@@ -301,7 +300,7 @@ mod test {
 
             // Make sure it got staged.
             assert_eq!(
-                fetch_metadata_to_string(&batch, &meta_path, &meta_version)
+                fetch_metadata_to_string(&batch, &meta_path, meta_version)
                     .await
                     .unwrap(),
                 staged_meta,
@@ -316,7 +315,7 @@ mod test {
             drop(batch);
 
             assert_eq!(
-                fetch_metadata_to_string(&repo, &meta_path, &meta_version)
+                fetch_metadata_to_string(&repo, &meta_path, meta_version)
                     .await
                     .unwrap(),
                 committed_meta,
@@ -329,7 +328,7 @@ mod test {
             // Do the batch_update again, but this time write the data.
             let mut batch = repo.batch_update();
             batch
-                .store_metadata(&meta_path, &meta_version, &mut staged_meta.as_bytes())
+                .store_metadata(&meta_path, meta_version, &mut staged_meta.as_bytes())
                 .await
                 .unwrap();
             batch
@@ -340,7 +339,7 @@ mod test {
 
             // Make sure the new data got to the repository.
             assert_eq!(
-                fetch_metadata_to_string(&repo, &meta_path, &meta_version)
+                fetch_metadata_to_string(&repo, &meta_path, meta_version)
                     .await
                     .unwrap(),
                 staged_meta,

--- a/tuf/src/repository/error_repo.rs
+++ b/tuf/src/repository/error_repo.rs
@@ -40,7 +40,7 @@ where
     fn fetch_metadata<'a>(
         &'a self,
         meta_path: &MetadataPath,
-        version: &MetadataVersion,
+        version: MetadataVersion,
     ) -> BoxFuture<'a, Result<Box<dyn AsyncRead + Send + Unpin + 'a>>> {
         self.repo.fetch_metadata(meta_path, version)
     }
@@ -61,7 +61,7 @@ where
     fn store_metadata<'a>(
         &'a mut self,
         meta_path: &MetadataPath,
-        version: &MetadataVersion,
+        version: MetadataVersion,
         metadata: &'a mut (dyn AsyncRead + Send + Unpin + 'a),
     ) -> BoxFuture<'a, Result<()>> {
         if self.fail_metadata_stores.load(Ordering::SeqCst) {

--- a/tuf/src/repository/http.rs
+++ b/tuf/src/repository/http.rs
@@ -248,7 +248,7 @@ where
     fn fetch_metadata<'a>(
         &'a self,
         meta_path: &MetadataPath,
-        version: &MetadataVersion,
+        version: MetadataVersion,
     ) -> BoxFuture<'a, Result<Box<dyn AsyncRead + Send + Unpin + 'a>>> {
         let components = meta_path.components::<D>(version);
         async move {

--- a/tuf/tests/simple_example.rs
+++ b/tuf/tests/simple_example.rs
@@ -52,7 +52,7 @@ async fn init_client(
     let local = EphemeralRepository::new();
     let mut client = Client::with_trusted_root_keys(
         config,
-        &MetadataVersion::Number(1),
+        MetadataVersion::Number(1),
         1,
         root_public_keys,
         local,


### PR DESCRIPTION
There's no reason to pass around the MetadataVersion as a reference, so pass it around as a value, and impl Copy.