### PR TITLE
Clean up some client and RepoBuilder APIs

### DIFF
--- a/tuf/src/client.rs
+++ b/tuf/src/client.rs
@@ -1372,7 +1372,7 @@ mod test {
             .unwrap()
             .stage_snapshot_with_builder(|bld| bld.version(2))
             .unwrap()
-            .with_timestamp_builder(|bld| bld.version(2))
+            .stage_timestamp_with_builder(|bld| bld.version(2))
             .unwrap()
             .commit()
             .await
@@ -1591,7 +1591,7 @@ mod test {
                 .unwrap()
                 .stage_snapshot_with_builder(|bld| bld.version(2))
                 .unwrap()
-                .with_timestamp_builder(|bld| bld.version(2))
+                .stage_timestamp_with_builder(|bld| bld.version(2))
                 .unwrap()
                 .commit()
                 .await
@@ -1671,7 +1671,7 @@ mod test {
                 .unwrap()
                 .stage_snapshot_with_builder(|bld| bld.version(2))
                 .unwrap()
-                .with_timestamp_builder(|bld| bld.version(2))
+                .stage_timestamp_with_builder(|bld| bld.version(2))
                 .unwrap()
                 .commit_skip_validation()
                 .await
@@ -1725,7 +1725,7 @@ mod test {
                 .unwrap()
                 .stage_snapshot_with_builder(|bld| bld.version(2))
                 .unwrap()
-                .with_timestamp_builder(|bld| bld.version(2))
+                .stage_timestamp_with_builder(|bld| bld.version(2))
                 .unwrap()
                 .commit()
                 .await
@@ -2130,7 +2130,7 @@ mod test {
                 .unwrap()
                 .stage_snapshot_with_builder(|bld| bld.version(2))
                 .unwrap()
-                .with_timestamp_builder(|bld| bld.version(2))
+                .stage_timestamp_with_builder(|bld| bld.version(2))
                 .unwrap()
                 .commit()
                 .await

--- a/tuf/src/repo_builder.rs
+++ b/tuf/src/repo_builder.rs
@@ -1000,7 +1000,7 @@ where
     /// * stage a targets metadata if necessary.
     /// * stage a snapshot metadata if necessary.
     pub fn stage_timestamp(self) -> Result<RepoBuilder<'a, D, R, Done<D>>> {
-        self.with_timestamp_builder(|builder| builder)
+        self.stage_timestamp_with_builder(|builder| builder)
     }
 
     /// Stage a new timestamp using the default settings if:
@@ -1036,7 +1036,7 @@ where
     ///
     /// * version: 1 if a new repository, otherwise 1 past the trusted snapshot's version.
     /// * expires: 1 day from the current day.
-    pub fn with_timestamp_builder<F>(self, f: F) -> Result<RepoBuilder<'a, D, R, Done<D>>>
+    pub fn stage_timestamp_with_builder<F>(self, f: F) -> Result<RepoBuilder<'a, D, R, Done<D>>>
     where
         F: FnOnce(TimestampMetadataBuilder) -> TimestampMetadataBuilder,
     {
@@ -1547,7 +1547,7 @@ mod tests {
             .unwrap()
             .timestamp_includes_length(true)
             .timestamp_includes_hashes(&[HashAlgorithm::Sha256])
-            .with_timestamp_builder(|builder| builder.expires(expires1))
+            .stage_timestamp_with_builder(|builder| builder.expires(expires1))
             .unwrap()
             .commit()
             .await
@@ -1667,7 +1667,7 @@ mod tests {
             .unwrap()
             .timestamp_includes_length(false)
             .timestamp_includes_hashes(&[])
-            .with_timestamp_builder(|builder| builder.expires(expires2))
+            .stage_timestamp_with_builder(|builder| builder.expires(expires2))
             .unwrap()
             .commit()
             .await
@@ -2085,7 +2085,7 @@ mod tests {
                 .unwrap()
                 .stage_snapshot_with_builder(|builder| builder.expires(expires1))
                 .unwrap()
-                .with_timestamp_builder(|builder| builder.expires(expires1))
+                .stage_timestamp_with_builder(|builder| builder.expires(expires1))
                 .unwrap()
                 .commit()
                 .await
@@ -2163,7 +2163,7 @@ mod tests {
                 .unwrap()
                 .stage_snapshot_with_builder(|builder| builder.expires(expires2))
                 .unwrap()
-                .with_timestamp_builder(|builder| builder.expires(expires2))
+                .stage_timestamp_with_builder(|builder| builder.expires(expires2))
                 .unwrap()
                 .commit()
                 .await
@@ -2228,7 +2228,7 @@ mod tests {
                 .skip_targets()
                 .stage_snapshot_with_builder(|builder| builder.expires(expires3))
                 .unwrap()
-                .with_timestamp_builder(|builder| builder.expires(expires3))
+                .stage_timestamp_with_builder(|builder| builder.expires(expires3))
                 .unwrap()
                 .commit()
                 .await
@@ -2278,7 +2278,7 @@ mod tests {
                 .skip_root()
                 .skip_targets()
                 .skip_snapshot()
-                .with_timestamp_builder(|builder| builder.expires(expires4))
+                .stage_timestamp_with_builder(|builder| builder.expires(expires4))
                 .unwrap()
                 .commit()
                 .await

--- a/tuf/src/repo_builder.rs
+++ b/tuf/src/repo_builder.rs
@@ -1643,10 +1643,19 @@ mod tests {
         .await
         .unwrap();
         client.update().await.unwrap();
-        assert_eq!(client.trusted_root().version(), 1);
-        assert_eq!(client.trusted_targets().map(|m| m.version()), Some(1));
-        assert_eq!(client.trusted_snapshot().map(|m| m.version()), Some(1));
-        assert_eq!(client.trusted_timestamp().map(|m| m.version()), Some(1));
+        assert_eq!(client.database().trusted_root().version(), 1);
+        assert_eq!(
+            client.database().trusted_targets().map(|m| m.version()),
+            Some(1)
+        );
+        assert_eq!(
+            client.database().trusted_snapshot().map(|m| m.version()),
+            Some(1)
+        );
+        assert_eq!(
+            client.database().trusted_timestamp().map(|m| m.version()),
+            Some(1)
+        );
 
         // Create a new metadata, derived from the tuf database we created
         // with the client.
@@ -1752,10 +1761,19 @@ mod tests {
         // And make sure the client can update to the latest metadata.
         let mut client = Client::from_parts(parts);
         client.update().await.unwrap();
-        assert_eq!(client.trusted_root().version(), 2);
-        assert_eq!(client.trusted_targets().map(|m| m.version()), Some(2));
-        assert_eq!(client.trusted_snapshot().map(|m| m.version()), Some(2));
-        assert_eq!(client.trusted_timestamp().map(|m| m.version()), Some(2));
+        assert_eq!(client.database().trusted_root().version(), 2);
+        assert_eq!(
+            client.database().trusted_targets().map(|m| m.version()),
+            Some(2)
+        );
+        assert_eq!(
+            client.database().trusted_snapshot().map(|m| m.version()),
+            Some(2)
+        );
+        assert_eq!(
+            client.database().trusted_timestamp().map(|m| m.version()),
+            Some(2)
+        );
     }
 
     #[test]
@@ -1792,7 +1810,7 @@ mod tests {
         .unwrap();
 
         assert!(client.update().await.unwrap());
-        assert_eq!(client.trusted_root().version(), 1);
+        assert_eq!(client.database().trusted_root().version(), 1);
 
         // Make sure doing another commit makes no changes.
         let mut parts = client.into_parts();
@@ -1809,7 +1827,7 @@ mod tests {
 
         let mut client = Client::from_parts(parts);
         assert!(!client.update().await.unwrap());
-        assert_eq!(client.trusted_root().version(), 1);
+        assert_eq!(client.database().trusted_root().version(), 1);
     }
 
     #[test]
@@ -1849,15 +1867,19 @@ mod tests {
         .unwrap();
 
         assert!(client.update().await.unwrap());
-        assert_eq!(client.trusted_root().version(), 1);
+        assert_eq!(client.database().trusted_root().version(), 1);
         assert_eq!(
-            client.trusted_root().root_keys().collect::<Vec<_>>(),
+            client
+                .database()
+                .trusted_root()
+                .root_keys()
+                .collect::<Vec<_>>(),
             vec![KEYS[1].public()],
         );
 
         // Another update should not fetch anything.
         assert!(!client.update().await.unwrap());
-        assert_eq!(client.trusted_root().version(), 1);
+        assert_eq!(client.database().trusted_root().version(), 1);
 
         // Now bump the root to version 2. We sign the root metadata with both
         // key 1 and 2, but the builder should only trust key 2.
@@ -1874,19 +1896,23 @@ mod tests {
 
         let mut client = Client::from_parts(parts);
         assert!(client.update().await.unwrap());
-        assert_eq!(client.trusted_root().version(), 2);
+        assert_eq!(client.database().trusted_root().version(), 2);
         assert_eq!(
-            client.trusted_root().consistent_snapshot(),
+            client.database().trusted_root().consistent_snapshot(),
             consistent_snapshot
         );
         assert_eq!(
-            client.trusted_root().root_keys().collect::<Vec<_>>(),
+            client
+                .database()
+                .trusted_root()
+                .root_keys()
+                .collect::<Vec<_>>(),
             vec![KEYS[2].public()],
         );
 
         // Another update should not fetch anything.
         assert!(!client.update().await.unwrap());
-        assert_eq!(client.trusted_root().version(), 2);
+        assert_eq!(client.database().trusted_root().version(), 2);
 
         // Now bump the root to version 3. The metadata will only be signed with
         // key 2, and trusted by key 2.
@@ -1904,15 +1930,19 @@ mod tests {
 
         let mut client = Client::from_parts(parts);
         assert!(client.update().await.unwrap());
-        assert_eq!(client.trusted_root().version(), 3);
+        assert_eq!(client.database().trusted_root().version(), 3);
         assert_eq!(
-            client.trusted_root().root_keys().collect::<Vec<_>>(),
+            client
+                .database()
+                .trusted_root()
+                .root_keys()
+                .collect::<Vec<_>>(),
             vec![KEYS[2].public()],
         );
 
         // Another update should not fetch anything.
         assert!(!client.update().await.unwrap());
-        assert_eq!(client.trusted_root().version(), 3);
+        assert_eq!(client.database().trusted_root().version(), 3);
     }
 
     #[test]

--- a/tuf/src/repository.rs
+++ b/tuf/src/repository.rs
@@ -315,9 +315,12 @@ impl<R, D> Repository<R, D> {
         self.repository
     }
 
-    #[cfg(test)]
     pub(crate) fn as_inner(&self) -> &R {
         &self.repository
+    }
+
+    pub(crate) fn as_inner_mut(&mut self) -> &mut R {
+        &mut self.repository
     }
 }
 


### PR DESCRIPTION
This exposes the database, and repositories from the client, remotes some now redundant APIs, and renames RepoBuilder::with_timestamp_builder() to stage_timestamp_with_builder().