### PR TITLE
Optimize MetadataPath for core metadata types

### DIFF
--- a/interop-tests/src/lib.rs
+++ b/interop-tests/src/lib.rs
@@ -154,7 +154,7 @@ async fn add_target(
         .expires(expiration)
         .version(version);
 
-    let targets_path = MetadataPath::from_role(&Role::Targets);
+    let targets_path = MetadataPath::targets();
     for i in 0..step + 1 {
         let step_str = format!("{}", i);
         let target_data = step_str.as_bytes();
@@ -206,7 +206,7 @@ async fn add_target(
     .await
     .unwrap();
 
-    let snapshot_path = MetadataPath::from_role(&Role::Snapshot);
+    let snapshot_path = MetadataPath::snapshot();
     let snapshot = SnapshotMetadataBuilder::new()
         .expires(expiration)
         .version(version)
@@ -223,7 +223,7 @@ async fn add_target(
     .await
     .unwrap();
 
-    let timestamp_path = MetadataPath::from_role(&Role::Timestamp);
+    let timestamp_path = MetadataPath::timestamp();
     let timestamp = TimestampMetadataBuilder::from_snapshot(&snapshot, &[HashAlgorithm::Sha256])
         .unwrap()
         .expires(expiration)

--- a/interop-tests/tests/test.rs
+++ b/interop-tests/tests/test.rs
@@ -43,9 +43,7 @@ use std::path::{Path, PathBuf};
 use tuf::client::{Client, Config};
 use tuf::crypto::PublicKey;
 use tuf::interchange::{DataInterchange, Json, JsonPretty};
-use tuf::metadata::{
-    MetadataPath, MetadataVersion, RawSignedMetadata, Role, RootMetadata, TargetPath,
-};
+use tuf::metadata::{MetadataPath, MetadataVersion, RawSignedMetadata, RootMetadata, TargetPath};
 use tuf::repository::{
     EphemeralRepository, FileSystemRepository, FileSystemRepositoryBuilder, RepositoryProvider,
 };
@@ -214,7 +212,7 @@ where
 {
     let remote = init_remote::<D>(dir).unwrap();
 
-    let root_path = MetadataPath::from_role(&Role::Root);
+    let root_path = MetadataPath::root();
 
     let mut buf = Vec::new();
     let mut reader = remote

--- a/tuf/src/error.rs
+++ b/tuf/src/error.rs
@@ -9,7 +9,7 @@ use std::io;
 use std::path::Path;
 use thiserror::Error;
 
-use crate::metadata::Role;
+use crate::metadata::MetadataPath;
 
 /// Error type for all TUF related errors.
 #[non_exhaustive]
@@ -25,7 +25,7 @@ pub enum Error {
 
     /// Metadata was expired.
     #[error("expired {0} metadata")]
-    ExpiredMetadata(Role),
+    ExpiredMetadata(MetadataPath),
 
     /// An illegal argument was passed into a function.
     #[error("illegal argument: {0}")]
@@ -52,7 +52,7 @@ pub enum Error {
 
     /// The metadata was missing, so an operation could not be completed.
     #[error("missing {0} metadata")]
-    MissingMetadata(Role),
+    MissingMetadata(MetadataPath),
 
     /// There were no available hash algorithms.
     #[error("no supported hash algorithm")]

--- a/tuf/src/interchange/cjson/shims.rs
+++ b/tuf/src/interchange/cjson/shims.rs
@@ -258,7 +258,7 @@ impl SnapshotMetadata {
                         )));
                     }
 
-                    let s = p.split_at(p.len() - ".json".len()).0;
+                    let s = p.split_at(p.len() - ".json".len()).0.to_owned();
                     let p = metadata::MetadataPath::new(s)?;
 
                     Ok((p, d))

--- a/tuf/src/repo_builder.rs
+++ b/tuf/src/repo_builder.rs
@@ -7,10 +7,10 @@ use {
         interchange::DataInterchange,
         metadata::{
             Metadata, MetadataDescription, MetadataPath, MetadataVersion, RawSignedMetadata,
-            RawSignedMetadataSet, RawSignedMetadataSetBuilder, Role, RootMetadata,
-            RootMetadataBuilder, SignedMetadataBuilder, SnapshotMetadata, SnapshotMetadataBuilder,
-            TargetDescription, TargetPath, TargetsMetadata, TargetsMetadataBuilder,
-            TimestampMetadata, TimestampMetadataBuilder,
+            RawSignedMetadataSet, RawSignedMetadataSetBuilder, RootMetadata, RootMetadataBuilder,
+            SignedMetadataBuilder, SnapshotMetadata, SnapshotMetadataBuilder, TargetDescription,
+            TargetPath, TargetsMetadata, TargetsMetadataBuilder, TimestampMetadata,
+            TimestampMetadataBuilder,
         },
         repository::RepositoryStorage,
         Error, Result,
@@ -707,7 +707,7 @@ where
         } else if let Some(db) = self.ctx.db {
             db.trusted_root().consistent_snapshot()
         } else {
-            return Err(Error::MissingMetadata(Role::Root));
+            return Err(Error::MissingMetadata(MetadataPath::root()));
         };
 
         let target_description = TargetDescription::from_reader_with_custom(
@@ -929,10 +929,8 @@ where
 
         // Overwrite the targets entry if specified.
         if let Some(targets_description) = self.state.targets_description()? {
-            snapshot_builder = snapshot_builder.insert_metadata_description(
-                MetadataPath::from_role(&Role::Targets),
-                targets_description,
-            );
+            snapshot_builder = snapshot_builder
+                .insert_metadata_description(MetadataPath::targets(), targets_description);
         };
 
         let snapshot = f(snapshot_builder).build()?;
@@ -1082,7 +1080,7 @@ where
                 .db
                 .and_then(|db| db.trusted_timestamp())
                 .map(|timestamp| timestamp.snapshot().clone())
-                .ok_or(Error::MissingMetadata(Role::Timestamp))?
+                .ok_or_else(|| Error::MissingMetadata(MetadataPath::timestamp()))?
         };
 
         let timestamp_builder = TimestampMetadataBuilder::from_metadata_description(description)
@@ -1213,7 +1211,7 @@ where
         } else if let Some(ref root) = self.state.staged_root {
             Database::from_trusted_root(&root.raw)?
         } else {
-            return Err(Error::MissingMetadata(Role::Root));
+            return Err(Error::MissingMetadata(MetadataPath::root()));
         };
 
         if let Some(ref timestamp) = self.state.staged_timestamp {
@@ -1236,7 +1234,7 @@ where
             self.ctx
                 .repo
                 .store_metadata(
-                    &MetadataPath::from_role(&Role::Root),
+                    &MetadataPath::root(),
                     MetadataVersion::Number(root.metadata.version()),
                     &mut root.raw.as_bytes(),
                 )
@@ -1245,7 +1243,7 @@ where
             self.ctx
                 .repo
                 .store_metadata(
-                    &MetadataPath::from_role(&Role::Root),
+                    &MetadataPath::root(),
                     MetadataVersion::None,
                     &mut root.raw.as_bytes(),
                 )
@@ -1255,11 +1253,11 @@ where
         } else if let Some(db) = self.ctx.db {
             db.trusted_root().consistent_snapshot()
         } else {
-            return Err(Error::MissingMetadata(Role::Root));
+            return Err(Error::MissingMetadata(MetadataPath::root()));
         };
 
         if let Some(ref targets) = self.state.staged_targets {
-            let path = MetadataPath::from_role(&Role::Targets);
+            let path = MetadataPath::targets();
             self.ctx
                 .repo
                 .store_metadata(&path, MetadataVersion::None, &mut targets.raw.as_bytes())
@@ -1278,7 +1276,7 @@ where
         }
 
         if let Some(ref snapshot) = self.state.staged_snapshot {
-            let path = MetadataPath::from_role(&Role::Snapshot);
+            let path = MetadataPath::snapshot();
             self.ctx
                 .repo
                 .store_metadata(&path, MetadataVersion::None, &mut snapshot.raw.as_bytes())
@@ -1300,7 +1298,7 @@ where
             self.ctx
                 .repo
                 .store_metadata(
-                    &MetadataPath::from_role(&Role::Timestamp),
+                    &MetadataPath::timestamp(),
                     MetadataVersion::None,
                     &mut timestamp.raw.as_bytes(),
                 )
@@ -1432,7 +1430,7 @@ mod tests {
         };
 
         let snapshot = SnapshotMetadataBuilder::new()
-            .insert_metadata_description(MetadataPath::from_role(&Role::Targets), description)
+            .insert_metadata_description(MetadataPath::targets(), description)
             .version(version)
             .expires(expires)
             .build()
@@ -1598,35 +1596,23 @@ mod tests {
         // Make sure we stored the metadata correctly.
         let mut expected_metadata: BTreeMap<_, _> = vec![
             (
-                (
-                    MetadataPath::from_role(&Role::Root),
-                    MetadataVersion::Number(1),
-                ),
+                (MetadataPath::root(), MetadataVersion::Number(1)),
                 raw_root1.as_bytes(),
             ),
             (
-                (MetadataPath::from_role(&Role::Root), MetadataVersion::None),
+                (MetadataPath::root(), MetadataVersion::None),
                 raw_root1.as_bytes(),
             ),
             (
-                (
-                    MetadataPath::from_role(&Role::Targets),
-                    MetadataVersion::None,
-                ),
+                (MetadataPath::targets(), MetadataVersion::None),
                 raw_targets1.as_bytes(),
             ),
             (
-                (
-                    MetadataPath::from_role(&Role::Snapshot),
-                    MetadataVersion::None,
-                ),
+                (MetadataPath::snapshot(), MetadataVersion::None),
                 raw_snapshot1.as_bytes(),
             ),
             (
-                (
-                    MetadataPath::from_role(&Role::Timestamp),
-                    MetadataVersion::None,
-                ),
+                (MetadataPath::timestamp(), MetadataVersion::None),
                 raw_timestamp1.as_bytes(),
             ),
         ]
@@ -1636,17 +1622,11 @@ mod tests {
         if consistent_snapshot {
             expected_metadata.extend(vec![
                 (
-                    (
-                        MetadataPath::from_role(&Role::Targets),
-                        MetadataVersion::Number(1),
-                    ),
+                    (MetadataPath::targets(), MetadataVersion::Number(1)),
                     raw_targets1.as_bytes(),
                 ),
                 (
-                    (
-                        MetadataPath::from_role(&Role::Snapshot),
-                        MetadataVersion::Number(1),
-                    ),
+                    (MetadataPath::snapshot(), MetadataVersion::Number(1)),
                     raw_snapshot1.as_bytes(),
                 ),
             ]);
@@ -1726,35 +1706,23 @@ mod tests {
         // Check that the new metadata was written.
         expected_metadata.extend(vec![
             (
-                (
-                    MetadataPath::from_role(&Role::Root),
-                    MetadataVersion::Number(2),
-                ),
+                (MetadataPath::root(), MetadataVersion::Number(2)),
                 raw_root2.as_bytes(),
             ),
             (
-                (MetadataPath::from_role(&Role::Root), MetadataVersion::None),
+                (MetadataPath::root(), MetadataVersion::None),
                 raw_root2.as_bytes(),
             ),
             (
-                (
-                    MetadataPath::from_role(&Role::Targets),
-                    MetadataVersion::None,
-                ),
+                (MetadataPath::targets(), MetadataVersion::None),
                 raw_targets2.as_bytes(),
             ),
             (
-                (
-                    MetadataPath::from_role(&Role::Snapshot),
-                    MetadataVersion::None,
-                ),
+                (MetadataPath::snapshot(), MetadataVersion::None),
                 raw_snapshot2.as_bytes(),
             ),
             (
-                (
-                    MetadataPath::from_role(&Role::Timestamp),
-                    MetadataVersion::None,
-                ),
+                (MetadataPath::timestamp(), MetadataVersion::None),
                 raw_timestamp2.as_bytes(),
             ),
         ]);
@@ -1762,17 +1730,11 @@ mod tests {
         if consistent_snapshot {
             expected_metadata.extend(vec![
                 (
-                    (
-                        MetadataPath::from_role(&Role::Targets),
-                        MetadataVersion::Number(2),
-                    ),
+                    (MetadataPath::targets(), MetadataVersion::Number(2)),
                     raw_targets2.as_bytes(),
                 ),
                 (
-                    (
-                        MetadataPath::from_role(&Role::Snapshot),
-                        MetadataVersion::Number(2),
-                    ),
+                    (MetadataPath::snapshot(), MetadataVersion::Number(2)),
                     raw_snapshot2.as_bytes(),
                 ),
             ]);
@@ -2222,49 +2184,31 @@ mod tests {
 
             let mut expected_metadata: BTreeMap<_, _> = vec![
                 (
-                    (
-                        MetadataPath::from_role(&Role::Root),
-                        MetadataVersion::Number(1),
-                    ),
+                    (MetadataPath::root(), MetadataVersion::Number(1)),
                     metadata1.root().unwrap().as_bytes(),
                 ),
                 (
-                    (MetadataPath::from_role(&Role::Root), MetadataVersion::None),
+                    (MetadataPath::root(), MetadataVersion::None),
                     metadata1.root().unwrap().as_bytes(),
                 ),
                 (
-                    (
-                        MetadataPath::from_role(&Role::Targets),
-                        MetadataVersion::Number(1),
-                    ),
+                    (MetadataPath::targets(), MetadataVersion::Number(1)),
                     metadata1.targets().unwrap().as_bytes(),
                 ),
                 (
-                    (
-                        MetadataPath::from_role(&Role::Targets),
-                        MetadataVersion::None,
-                    ),
+                    (MetadataPath::targets(), MetadataVersion::None),
                     metadata1.targets().unwrap().as_bytes(),
                 ),
                 (
-                    (
-                        MetadataPath::from_role(&Role::Snapshot),
-                        MetadataVersion::Number(1),
-                    ),
+                    (MetadataPath::snapshot(), MetadataVersion::Number(1)),
                     metadata1.snapshot().unwrap().as_bytes(),
                 ),
                 (
-                    (
-                        MetadataPath::from_role(&Role::Snapshot),
-                        MetadataVersion::None,
-                    ),
+                    (MetadataPath::snapshot(), MetadataVersion::None),
                     metadata1.snapshot().unwrap().as_bytes(),
                 ),
                 (
-                    (
-                        MetadataPath::from_role(&Role::Timestamp),
-                        MetadataVersion::None,
-                    ),
+                    (MetadataPath::timestamp(), MetadataVersion::None),
                     metadata1.timestamp().unwrap().as_bytes(),
                 ),
             ]
@@ -2302,38 +2246,23 @@ mod tests {
             expected_metadata.extend(
                 vec![
                     (
-                        (
-                            MetadataPath::from_role(&Role::Targets),
-                            MetadataVersion::Number(2),
-                        ),
+                        (MetadataPath::targets(), MetadataVersion::Number(2)),
                         metadata2.targets().unwrap().as_bytes(),
                     ),
                     (
-                        (
-                            MetadataPath::from_role(&Role::Targets),
-                            MetadataVersion::None,
-                        ),
+                        (MetadataPath::targets(), MetadataVersion::None),
                         metadata2.targets().unwrap().as_bytes(),
                     ),
                     (
-                        (
-                            MetadataPath::from_role(&Role::Snapshot),
-                            MetadataVersion::Number(2),
-                        ),
+                        (MetadataPath::snapshot(), MetadataVersion::Number(2)),
                         metadata2.snapshot().unwrap().as_bytes(),
                     ),
                     (
-                        (
-                            MetadataPath::from_role(&Role::Snapshot),
-                            MetadataVersion::None,
-                        ),
+                        (MetadataPath::snapshot(), MetadataVersion::None),
                         metadata2.snapshot().unwrap().as_bytes(),
                     ),
                     (
-                        (
-                            MetadataPath::from_role(&Role::Timestamp),
-                            MetadataVersion::None,
-                        ),
+                        (MetadataPath::timestamp(), MetadataVersion::None),
                         metadata2.timestamp().unwrap().as_bytes(),
                     ),
                 ]
@@ -2368,24 +2297,15 @@ mod tests {
             expected_metadata.extend(
                 vec![
                     (
-                        (
-                            MetadataPath::from_role(&Role::Snapshot),
-                            MetadataVersion::Number(3),
-                        ),
+                        (MetadataPath::snapshot(), MetadataVersion::Number(3)),
                         metadata3.snapshot().unwrap().as_bytes(),
                     ),
                     (
-                        (
-                            MetadataPath::from_role(&Role::Snapshot),
-                            MetadataVersion::None,
-                        ),
+                        (MetadataPath::snapshot(), MetadataVersion::None),
                         metadata3.snapshot().unwrap().as_bytes(),
                     ),
                     (
-                        (
-                            MetadataPath::from_role(&Role::Timestamp),
-                            MetadataVersion::None,
-                        ),
+                        (MetadataPath::timestamp(), MetadataVersion::None),
                         metadata3.timestamp().unwrap().as_bytes(),
                     ),
                 ]
@@ -2417,10 +2337,7 @@ mod tests {
 
             expected_metadata.extend(
                 vec![(
-                    (
-                        MetadataPath::from_role(&Role::Timestamp),
-                        MetadataVersion::None,
-                    ),
+                    (MetadataPath::timestamp(), MetadataVersion::None),
                     metadata4.timestamp().unwrap().as_bytes(),
                 )]
                 .into_iter(),

--- a/tuf/src/repository.rs
+++ b/tuf/src/repository.rs
@@ -514,7 +514,7 @@ where
 mod test {
     use super::*;
     use crate::interchange::Json;
-    use crate::metadata::{MetadataPath, MetadataVersion, Role, RootMetadata, SnapshotMetadata};
+    use crate::metadata::{MetadataPath, MetadataVersion, RootMetadata, SnapshotMetadata};
     use crate::repository::EphemeralRepository;
     use assert_matches::assert_matches;
     use futures_executor::block_on;
@@ -526,7 +526,7 @@ mod test {
 
             assert_matches!(
                 repo.fetch_metadata::<RootMetadata>(
-                    &MetadataPath::from_role(&Role::Root),
+                    &MetadataPath::root(),
                     MetadataVersion::None,
                     None,
                     vec![],
@@ -543,17 +543,13 @@ mod test {
             let mut repo = Repository::<_, Json>::new(EphemeralRepository::new());
             let fake_metadata = RawSignedMetadata::<Json, RootMetadata>::new(vec![]);
 
-            repo.store_metadata(
-                &MetadataPath::from_role(&Role::Root),
-                MetadataVersion::None,
-                &fake_metadata,
-            )
-            .await
-            .unwrap();
+            repo.store_metadata(&MetadataPath::root(), MetadataVersion::None, &fake_metadata)
+                .await
+                .unwrap();
 
             assert_matches!(
                 repo.store_metadata(
-                    &MetadataPath::from_role(&Role::Snapshot),
+                    &MetadataPath::snapshot(),
                     MetadataVersion::None,
                     &fake_metadata,
                 )
@@ -563,7 +559,7 @@ mod test {
 
             assert_matches!(
                 repo.fetch_metadata::<SnapshotMetadata>(
-                    &MetadataPath::from_role(&Role::Root),
+                    &MetadataPath::root(),
                     MetadataVersion::None,
                     None,
                     vec![],
@@ -577,7 +573,7 @@ mod test {
     #[test]
     fn repository_verifies_metadata_hash() {
         block_on(async {
-            let path = MetadataPath::from_role(&Role::Root);
+            let path = MetadataPath::root();
             let version = MetadataVersion::None;
             let data: &[u8] = b"valid metadata";
             let _metadata = RawSignedMetadata::<Json, RootMetadata>::new(data.to_vec());
@@ -607,7 +603,7 @@ mod test {
     #[test]
     fn repository_rejects_corrupt_metadata() {
         block_on(async {
-            let path = MetadataPath::from_role(&Role::Root);
+            let path = MetadataPath::root();
             let version = MetadataVersion::None;
             let data: &[u8] = b"corrupt metadata";
 
@@ -635,7 +631,7 @@ mod test {
     #[test]
     fn repository_verifies_metadata_size() {
         block_on(async {
-            let path = MetadataPath::from_role(&Role::Root);
+            let path = MetadataPath::root();
             let version = MetadataVersion::None;
             let data: &[u8] = b"reasonably sized metadata";
             let _metadata = RawSignedMetadata::<Json, RootMetadata>::new(data.to_vec());
@@ -659,7 +655,7 @@ mod test {
     #[test]
     fn repository_rejects_oversized_metadata() {
         block_on(async {
-            let path = MetadataPath::from_role(&Role::Root);
+            let path = MetadataPath::root();
             let version = MetadataVersion::None;
             let data: &[u8] = b"very big metadata";
 

--- a/tuf/src/repository/file_system.rs
+++ b/tuf/src/repository/file_system.rs
@@ -347,7 +347,7 @@ mod test {
     use super::*;
     use crate::error::Error;
     use crate::interchange::Json;
-    use crate::metadata::{Role, RootMetadata};
+    use crate::metadata::RootMetadata;
     use crate::repository::{fetch_metadata_to_string, fetch_target_to_string, Repository};
     use assert_matches::assert_matches;
     use futures_executor::block_on;
@@ -368,7 +368,7 @@ mod test {
             assert_matches!(
                 Repository::<_, Json>::new(repo)
                     .fetch_metadata::<RootMetadata>(
-                        &MetadataPath::from_role(&Role::Root),
+                        &MetadataPath::root(),
                         MetadataVersion::None,
                         None,
                         vec![],

--- a/tuf/src/repository/track_repo.rs
+++ b/tuf/src/repository/track_repo.rs
@@ -48,11 +48,7 @@ impl Track {
         M: Metadata,
         D: DataInterchange,
     {
-        Self::store(
-            &MetadataPath::from_role(&M::ROLE),
-            version,
-            metadata.as_bytes(),
-        )
+        Self::store(&M::ROLE.into(), version, metadata.as_bytes())
     }
 
     pub(crate) fn fetch_found<T>(
@@ -78,11 +74,7 @@ impl Track {
         M: Metadata,
         D: DataInterchange,
     {
-        Track::fetch_found(
-            &MetadataPath::from_role(&M::ROLE),
-            version,
-            metadata.as_bytes(),
-        )
+        Track::fetch_found(&M::ROLE.into(), version, metadata.as_bytes())
     }
 }
 

--- a/tuf/tests/integration.rs
+++ b/tuf/tests/integration.rs
@@ -4,8 +4,7 @@ use maplit::hashmap;
 use tuf::crypto::{Ed25519PrivateKey, HashAlgorithm, PrivateKey};
 use tuf::interchange::Json;
 use tuf::metadata::{
-    Delegation, Delegations, MetadataDescription, MetadataPath, Role, TargetPath,
-    TargetsMetadataBuilder,
+    Delegation, Delegations, MetadataDescription, MetadataPath, TargetPath, TargetsMetadataBuilder,
 };
 use tuf::repo_builder::RepoBuilder;
 use tuf::repository::EphemeralRepository;
@@ -85,7 +84,7 @@ fn simple_delegation() {
         let raw_delegation = delegation.to_raw().unwrap();
 
         tuf.update_delegation(
-            &MetadataPath::from_role(&Role::Targets),
+            &MetadataPath::targets(),
             &MetadataPath::new("delegation").unwrap(),
             &raw_delegation,
         )
@@ -180,7 +179,7 @@ fn nested_delegation() {
         let raw_delegation = delegation.to_raw().unwrap();
 
         tuf.update_delegation(
-            &MetadataPath::from_role(&Role::Targets),
+            &MetadataPath::targets(),
             &MetadataPath::new("delegation-a").unwrap(),
             &raw_delegation,
         )
@@ -281,7 +280,7 @@ fn rejects_bad_delegation_signatures() {
 
         assert_matches!(
             tuf.update_delegation(
-                &MetadataPath::from_role(&Role::Targets),
+                &MetadataPath::targets(),
                 &MetadataPath::new("delegation").unwrap(),
                 &raw_delegation
             ),
@@ -415,7 +414,7 @@ fn diamond_delegation() {
         let raw_delegation = delegation.to_raw().unwrap();
 
         tuf.update_delegation(
-            &MetadataPath::from_role(&Role::Targets),
+            &MetadataPath::targets(),
             &MetadataPath::new("delegation-a").unwrap(),
             &raw_delegation,
         )
@@ -444,7 +443,7 @@ fn diamond_delegation() {
         let raw_delegation = delegation.to_raw().unwrap();
 
         tuf.update_delegation(
-            &MetadataPath::from_role(&Role::Targets),
+            &MetadataPath::targets(),
             &MetadataPath::new("delegation-b").unwrap(),
             &raw_delegation,
         )


### PR DESCRIPTION
This changes MetadataPath to wrap a `Cow<'static, str>`, rather than a `String`, which allows us to avoid an allocation for our most common types. It also adds helpers for making `MetadataPath` from the core metadata types.

In addition, this changes the error types `ExpiredMetadata` and `MissingMetadata` to wrap a `MetadataPath` rather than a `Role`. We'll eventually use this to return proper errors during delegated target resolution.