### PR TITLE
Consolidate Database::update_{targets,delegated_targets}

### DIFF
--- a/tuf/src/client.rs
+++ b/tuf/src/client.rs
@@ -960,10 +960,11 @@ where
                 }
             };
 
-            match self
-                .tuf
-                .update_delegation(&targets_role, delegation.role(), &raw_signed_meta)
-            {
+            match self.tuf.update_delegated_targets(
+                &targets_role,
+                delegation.role(),
+                &raw_signed_meta,
+            ) {
                 Ok(_) => {
                     /////////////////////////////////////////
                     // TUF-1.0.9 §5.4.4:


### PR DESCRIPTION
The TUF update flow for targets and delegated targets is mostly the same, just that the targets keys are in the root metadata, and the delegated target keys are from the delegating target metadata.

This is built upon #359, so that should be reviewed first. I'll rebase this on 359 once it lands.