### PR TITLE
Implement update start time

### DIFF
--- a/tuf/src/repo_builder.rs
+++ b/tuf/src/repo_builder.rs
@@ -1214,16 +1214,18 @@ where
             return Err(Error::MissingMetadata(MetadataPath::root()));
         };
 
+        let now = Utc::now();
+
         if let Some(ref timestamp) = self.state.staged_timestamp {
-            db.update_timestamp(&timestamp.raw)?;
+            db.update_timestamp(&now, &timestamp.raw)?;
         }
 
         if let Some(ref snapshot) = self.state.staged_snapshot {
-            db.update_snapshot(&snapshot.raw)?;
+            db.update_snapshot(&now, &snapshot.raw)?;
         }
 
         if let Some(ref targets) = self.state.staged_targets {
-            db.update_targets(&targets.raw)?;
+            db.update_targets(&now, &targets.raw)?;
         }
 
         Ok(())

--- a/tuf/tests/integration.rs
+++ b/tuf/tests/integration.rs
@@ -1,4 +1,5 @@
 use assert_matches::assert_matches;
+use chrono::offset::Utc;
 use futures_executor::block_on;
 use maplit::hashmap;
 use tuf::crypto::{Ed25519PrivateKey, HashAlgorithm, PrivateKey};
@@ -21,6 +22,8 @@ const ED25519_6_PK8: &[u8] = include_bytes!("./ed25519/ed25519-6.pk8.der");
 #[test]
 fn simple_delegation() {
     block_on(async {
+        let now = Utc::now();
+
         let root_key = Ed25519PrivateKey::from_pkcs8(ED25519_1_PK8).unwrap();
         let snapshot_key = Ed25519PrivateKey::from_pkcs8(ED25519_2_PK8).unwrap();
         let targets_key = Ed25519PrivateKey::from_pkcs8(ED25519_3_PK8).unwrap();
@@ -84,6 +87,7 @@ fn simple_delegation() {
         let raw_delegation = delegation.to_raw().unwrap();
 
         tuf.update_delegated_targets(
+            &now,
             &MetadataPath::targets(),
             &MetadataPath::new("delegation").unwrap(),
             &raw_delegation,
@@ -99,6 +103,8 @@ fn simple_delegation() {
 #[test]
 fn nested_delegation() {
     block_on(async {
+        let now = Utc::now();
+
         let root_key = Ed25519PrivateKey::from_pkcs8(ED25519_1_PK8).unwrap();
         let snapshot_key = Ed25519PrivateKey::from_pkcs8(ED25519_2_PK8).unwrap();
         let targets_key = Ed25519PrivateKey::from_pkcs8(ED25519_3_PK8).unwrap();
@@ -179,6 +185,7 @@ fn nested_delegation() {
         let raw_delegation = delegation.to_raw().unwrap();
 
         tuf.update_delegated_targets(
+            &now,
             &MetadataPath::targets(),
             &MetadataPath::new("delegation-a").unwrap(),
             &raw_delegation,
@@ -201,6 +208,7 @@ fn nested_delegation() {
         let raw_delegation = delegation.to_raw().unwrap();
 
         tuf.update_delegated_targets(
+            &now,
             &MetadataPath::new("delegation-a").unwrap(),
             &MetadataPath::new("delegation-b").unwrap(),
             &raw_delegation,
@@ -216,6 +224,8 @@ fn nested_delegation() {
 #[test]
 fn rejects_bad_delegation_signatures() {
     block_on(async {
+        let now = Utc::now();
+
         let root_key = Ed25519PrivateKey::from_pkcs8(ED25519_1_PK8).unwrap();
         let snapshot_key = Ed25519PrivateKey::from_pkcs8(ED25519_2_PK8).unwrap();
         let targets_key = Ed25519PrivateKey::from_pkcs8(ED25519_3_PK8).unwrap();
@@ -280,6 +290,7 @@ fn rejects_bad_delegation_signatures() {
 
         assert_matches!(
             tuf.update_delegated_targets(
+                &now,
                 &MetadataPath::targets(),
                 &MetadataPath::new("delegation").unwrap(),
                 &raw_delegation
@@ -297,6 +308,8 @@ fn rejects_bad_delegation_signatures() {
 #[test]
 fn diamond_delegation() {
     block_on(async {
+        let now = Utc::now();
+
         let etc_key = Ed25519PrivateKey::from_pkcs8(ED25519_1_PK8).unwrap();
         let targets_key = Ed25519PrivateKey::from_pkcs8(ED25519_2_PK8).unwrap();
         let delegation_a_key = Ed25519PrivateKey::from_pkcs8(ED25519_3_PK8).unwrap();
@@ -474,6 +487,7 @@ fn diamond_delegation() {
         //// Verify we can trust delegation-a and delegation-b..
 
         tuf.update_delegated_targets(
+            &now,
             &MetadataPath::targets(),
             &MetadataPath::new("delegation-a").unwrap(),
             &raw_delegation_a,
@@ -481,6 +495,7 @@ fn diamond_delegation() {
         .unwrap();
 
         tuf.update_delegated_targets(
+            &now,
             &MetadataPath::targets(),
             &MetadataPath::new("delegation-b").unwrap(),
             &raw_delegation_b,
@@ -491,6 +506,7 @@ fn diamond_delegation() {
 
         assert_matches!(
             tuf.update_delegated_targets(
+                &now,
                 &MetadataPath::new("delegation-b").unwrap(),
                 &MetadataPath::new("delegation-c").unwrap(),
                 &raw_delegation_c
@@ -499,6 +515,7 @@ fn diamond_delegation() {
         );
 
         tuf.update_delegated_targets(
+            &now,
             &MetadataPath::new("delegation-a").unwrap(),
             &MetadataPath::new("delegation-c").unwrap(),
             &raw_delegation_c,


### PR DESCRIPTION
This patch implements [TUF 1.0.30 section 5.1.1], where we record the update start time at the beginning of the client update workflow, and compare all expirations to this. This allows us to avoid the risk of the metadata expiring during the update process.
    
In addition, this adds `Client::update_with_start_time()`, which allows the client to specify the start time to use, rather than the current time. This allows the client to work with expired metadata (and so there is a warning in the documentation), it could also be used to share expiration time with TUF and other external processes.
    
[TUF 1.0.30 section 5.1.1]: https://theupdateframework.github.io/specification/latest/#fix-time