### PR TITLE
Fix unknown keyid and signature schemes

### DIFF
--- a/tuf/src/error.rs
+++ b/tuf/src/error.rs
@@ -76,6 +76,10 @@ pub enum Error {
     #[error("unknown key type: {0}")]
     UnknownKeyType(String),
 
+    /// There is no known or available signature scheme.
+    #[error("unknown signature scheme: {0}")]
+    UnknownSignatureScheme(String),
+
     /// The metadata or target failed to verify.
     #[error("verification failure: {0}")]
     VerificationFailure(String),


### PR DESCRIPTION
Even though rust-tuf tried to support working with unknown key types and signature schemes, there weren't any tests to validate that it actually worked. This corrects the issue.