### PR TITLE
Fix error message

### DIFF
--- a/tuf/src/error.rs
+++ b/tuf/src/error.rs
@@ -120,7 +120,9 @@ pub enum Error {
     MetadataVersionMustBeSmallerThanMaxU32(MetadataPath),
 
     /// The metadata was not signed with enough valid signatures.
-    #[error("metadata {role} signature threshold not met: {number_of_valid_signatures}/{threshold}")]
+    #[error(
+        "metadata {role} signature threshold not met: {number_of_valid_signatures}/{threshold}"
+    )]
     MetadataMissingSignatures {
         /// The signed metadata.
         role: MetadataPath,
@@ -131,7 +133,9 @@ pub enum Error {
     },
 
     /// Attempted to update metadata with an older version.
-    #[error("attempted to roll back metadata {role} from version {trusted_version} to {new_version}")]
+    #[error(
+        "attempted to roll back metadata {role} from version {trusted_version} to {new_version}"
+    )]
     AttemptedMetadataRollBack {
         /// The metadata.
         role: MetadataPath,

--- a/tuf/src/repo_builder.rs
+++ b/tuf/src/repo_builder.rs
@@ -1080,7 +1080,7 @@ where
                 .and_then(|db| db.trusted_timestamp())
                 .map(|timestamp| timestamp.snapshot().clone())
                 .ok_or_else(|| Error::MetadataNotFound {
-                    path: MetadataPath::timestamp(),
+                    path: MetadataPath::snapshot(),
                     version: MetadataVersion::None,
                 })?
         };


### PR DESCRIPTION
When building a timestamp and we can't find the trusted snapshot, error out that the snapshot metadata is missing, not the timestamp.