### PR TITLE
Tweaks to better interop with go-tuf

### DIFF
--- a/tuf/src/interchange/cjson/shims.rs
+++ b/tuf/src/interchange/cjson/shims.rs
@@ -579,3 +579,51 @@ mod deserialize_reject_duplicates {
         })
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::{parse_datetime, valid_spec_version};
+
+    #[test]
+    fn spec_version_validation() {
+        let valid_spec_versions = ["1.0.0", "1.0"];
+
+        for version in valid_spec_versions {
+            assert!(valid_spec_version(version), "{:?} should be valid", version);
+        }
+
+        let invalid_spec_versions = ["1.0.1", "1.1.0", "2.0.0", "3.0"];
+
+        for version in invalid_spec_versions {
+            assert!(
+                !valid_spec_version(version),
+                "{:?} should be invalid",
+                version
+            );
+        }
+    }
+
+    #[test]
+    fn datetime_formats() {
+        // The TUF spec says datetimes should be in ISO8601 format, specifically
+        // "YYYY-MM-DDTHH:MM:SSZ". Since not all TUF clients adhere strictly to that, we choose to
+        // be more lenient here. The following represent the intersection of valid ISO8601
+        // and RFC3339 datetime formats (source: https://ijmacd.github.io/rfc3339-iso8601/).
+        let valid_formats = [
+            "2022-08-30T19:53:55Z",
+            "2022-08-30T19:53:55.7Z",
+            "2022-08-30T19:53:55.77Z",
+            "2022-08-30T19:53:55.775Z",
+            "2022-08-30T19:53:55+00:00",
+            "2022-08-30T19:53:55.7+00:00",
+            "2022-08-30T14:53:55-05:00",
+            "2022-08-30T14:53:55.7-05:00",
+            "2022-08-30T14:53:55.77-05:00",
+            "2022-08-30T14:53:55.775-05:00",
+        ];
+
+        for format in valid_formats {
+            assert!(parse_datetime(format).is_ok(), "should parse {:?}", format);
+        }
+    }
+}

--- a/tuf/src/interchange/cjson/shims.rs
+++ b/tuf/src/interchange/cjson/shims.rs
@@ -25,7 +25,15 @@ fn parse_datetime(ts: &str) -> Result<DateTime<Utc>> {
 }
 
 fn format_datetime(ts: &DateTime<Utc>) -> String {
-    ts.to_rfc3339()
+    format!(
+        "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}Z",
+        ts.year(),
+        ts.month(),
+        ts.day(),
+        ts.hour(),
+        ts.minute(),
+        ts.second()
+    )
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/tuf/src/interchange/cjson/shims.rs
+++ b/tuf/src/interchange/cjson/shims.rs
@@ -8,7 +8,15 @@ use crate::error::Error;
 use crate::metadata::{self, Metadata};
 use crate::Result;
 
-const SPEC_VERSION: &str = "1.0";
+const SPEC_VERSION: &str = "1.0.0";
+
+// Ensure the given spec version matches our spec version.
+//
+// We also need to handle the literal "1.0" here, despite that fact that it is not a valid version
+// according to the SemVer spec, because it is already baked into some of the old roots.
+fn valid_spec_version(other: &str) -> bool {
+    other == SPEC_VERSION || other == "1.0"
+}
 
 fn parse_datetime(ts: &str) -> Result<DateTime<Utc>> {
     Utc.datetime_from_str(ts, "%FT%TZ")
@@ -70,7 +78,7 @@ impl RootMetadata {
             )));
         }
 
-        if self.spec_version != SPEC_VERSION {
+        if !valid_spec_version(&self.spec_version) {
             return Err(Error::Encoding(format!(
                 "Unknown spec version {}",
                 self.spec_version
@@ -184,7 +192,7 @@ impl TimestampMetadata {
             )));
         }
 
-        if self.spec_version != SPEC_VERSION {
+        if !valid_spec_version(&self.spec_version) {
             return Err(Error::Encoding(format!(
                 "Unknown spec version {}",
                 self.spec_version
@@ -233,7 +241,7 @@ impl SnapshotMetadata {
             )));
         }
 
-        if self.spec_version != SPEC_VERSION {
+        if !valid_spec_version(&self.spec_version) {
             return Err(Error::Encoding(format!(
                 "Unknown spec version {}",
                 self.spec_version
@@ -299,7 +307,7 @@ impl TargetsMetadata {
             )));
         }
 
-        if self.spec_version != SPEC_VERSION {
+        if !valid_spec_version(&self.spec_version) {
             return Err(Error::Encoding(format!(
                 "Unknown spec version {}",
                 self.spec_version

--- a/tuf/src/interchange/cjson/shims.rs
+++ b/tuf/src/interchange/cjson/shims.rs
@@ -282,6 +282,8 @@ pub struct TargetsMetadata {
     targets: BTreeMap<metadata::TargetPath, metadata::TargetDescription>,
     #[serde(default, skip_serializing_if = "metadata::Delegations::is_empty")]
     delegations: metadata::Delegations,
+    #[serde(flatten)]
+    additional_fields: BTreeMap<String, serde_json::Value>,
 }
 
 impl TargetsMetadata {
@@ -297,6 +299,11 @@ impl TargetsMetadata {
                 .map(|(p, d)| (p.clone(), d.clone()))
                 .collect(),
             delegations: metadata.delegations().clone(),
+            additional_fields: metadata
+                .additional_fields()
+                .iter()
+                .map(|(p, d)| (p.clone(), d.clone()))
+                .collect(),
         })
     }
 
@@ -320,6 +327,7 @@ impl TargetsMetadata {
             parse_datetime(&self.expires)?,
             self.targets.into_iter().collect(),
             self.delegations,
+            self.additional_fields.into_iter().collect(),
         )
     }
 }

--- a/tuf/src/interchange/cjson/shims.rs
+++ b/tuf/src/interchange/cjson/shims.rs
@@ -47,6 +47,8 @@ pub struct RootMetadata {
     #[serde(deserialize_with = "deserialize_reject_duplicates::deserialize")]
     keys: BTreeMap<crypto::KeyId, crypto::PublicKey>,
     roles: RoleDefinitions,
+    #[serde(flatten)]
+    additional_fields: BTreeMap<String, serde_json::Value>,
 }
 
 impl RootMetadata {
@@ -68,6 +70,7 @@ impl RootMetadata {
                 targets: meta.targets().clone(),
                 timestamp: meta.timestamp().clone(),
             },
+            additional_fields: meta.additional_fields().clone().into_iter().collect(),
         })
     }
 
@@ -104,6 +107,7 @@ impl RootMetadata {
             self.roles.snapshot,
             self.roles.targets,
             self.roles.timestamp,
+            self.additional_fields.into_iter().collect(),
         )
     }
 }
@@ -163,6 +167,8 @@ pub struct TimestampMetadata {
     version: u32,
     expires: String,
     meta: TimestampMeta,
+    #[serde(flatten)]
+    additional_fields: BTreeMap<String, serde_json::Value>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -182,6 +188,7 @@ impl TimestampMetadata {
             meta: TimestampMeta {
                 snapshot: metadata.snapshot().clone(),
             },
+            additional_fields: metadata.additional_fields().clone().into_iter().collect(),
         })
     }
 
@@ -204,6 +211,7 @@ impl TimestampMetadata {
             self.version,
             parse_datetime(&self.expires)?,
             self.meta.snapshot,
+            self.additional_fields.into_iter().collect(),
         )
     }
 }
@@ -217,6 +225,8 @@ pub struct SnapshotMetadata {
     expires: String,
     #[serde(deserialize_with = "deserialize_reject_duplicates::deserialize")]
     meta: BTreeMap<String, metadata::MetadataDescription>,
+    #[serde(flatten)]
+    additional_fields: BTreeMap<String, serde_json::Value>,
 }
 
 impl SnapshotMetadata {
@@ -231,6 +241,7 @@ impl SnapshotMetadata {
                 .iter()
                 .map(|(p, d)| (format!("{}.json", p), d.clone()))
                 .collect(),
+            additional_fields: metadata.additional_fields().clone().into_iter().collect(),
         })
     }
 
@@ -268,6 +279,7 @@ impl SnapshotMetadata {
                     Ok((p, d))
                 })
                 .collect::<Result<_>>()?,
+            self.additional_fields.into_iter().collect(),
         )
     }
 }

--- a/tuf/src/interchange/cjson/shims.rs
+++ b/tuf/src/interchange/cjson/shims.rs
@@ -19,20 +19,13 @@ fn valid_spec_version(other: &str) -> bool {
 }
 
 fn parse_datetime(ts: &str) -> Result<DateTime<Utc>> {
-    Utc.datetime_from_str(ts, "%FT%TZ")
+    DateTime::parse_from_rfc3339(ts)
+        .map(|ts| ts.with_timezone(&Utc))
         .map_err(|e| Error::Encoding(format!("Can't parse DateTime: {:?}", e)))
 }
 
 fn format_datetime(ts: &DateTime<Utc>) -> String {
-    format!(
-        "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}Z",
-        ts.year(),
-        ts.month(),
-        ts.day(),
-        ts.hour(),
-        ts.minute(),
-        ts.second()
-    )
+    ts.to_rfc3339()
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/tuf/src/interchange/mod.rs
+++ b/tuf/src/interchange/mod.rs
@@ -10,7 +10,7 @@ use std::fmt::Debug;
 use crate::Result;
 
 /// The format used for data interchange, serialization, and deserialization.
-pub trait DataInterchange: Debug + PartialEq + Clone {
+pub trait DataInterchange: Debug + PartialEq + Clone + Send {
     /// The type of data that is contained in the `signed` portion of metadata.
     type RawData: Serialize + DeserializeOwned + Clone + PartialEq;
 

--- a/tuf/src/metadata.rs
+++ b/tuf/src/metadata.rs
@@ -718,6 +718,7 @@ impl RootMetadataBuilder {
             RoleDefinition::new(self.snapshot_threshold, self.snapshot_key_ids)?,
             RoleDefinition::new(self.targets_threshold, self.targets_key_ids)?,
             RoleDefinition::new(self.timestamp_threshold, self.timestamp_key_ids)?,
+            Default::default(),
         )
     }
 
@@ -766,6 +767,7 @@ pub struct RootMetadata {
     snapshot: RoleDefinition,
     targets: RoleDefinition,
     timestamp: RoleDefinition,
+    additional_fields: HashMap<String, serde_json::Value>,
 }
 
 impl RootMetadata {
@@ -779,6 +781,7 @@ impl RootMetadata {
         snapshot: RoleDefinition,
         targets: RoleDefinition,
         timestamp: RoleDefinition,
+        additional_fields: HashMap<String, serde_json::Value>,
     ) -> Result<Self> {
         if version < 1 {
             return Err(Error::IllegalArgument(format!(
@@ -796,6 +799,7 @@ impl RootMetadata {
             snapshot,
             targets,
             timestamp,
+            additional_fields,
         })
     }
 
@@ -860,6 +864,11 @@ impl RootMetadata {
     /// An immutable reference to the timestamp role's definition.
     pub fn timestamp(&self) -> &RoleDefinition {
         &self.timestamp
+    }
+
+    /// An immutable reference to any additional fields on the metadata.
+    pub fn additional_fields(&self) -> &HashMap<String, serde_json::Value> {
+        &self.additional_fields
     }
 }
 
@@ -1127,7 +1136,12 @@ impl TimestampMetadataBuilder {
 
     /// Construct a new `TimestampMetadata`.
     pub fn build(self) -> Result<TimestampMetadata> {
-        TimestampMetadata::new(self.version, self.expires, self.snapshot)
+        TimestampMetadata::new(
+            self.version,
+            self.expires,
+            self.snapshot,
+            Default::default(),
+        )
     }
 
     /// Construct a new `SignedMetadata<D, TimestampMetadata>`.
@@ -1148,6 +1162,7 @@ pub struct TimestampMetadata {
     version: u32,
     expires: DateTime<Utc>,
     snapshot: MetadataDescription,
+    additional_fields: HashMap<String, serde_json::Value>,
 }
 
 impl TimestampMetadata {
@@ -1156,6 +1171,7 @@ impl TimestampMetadata {
         version: u32,
         expires: DateTime<Utc>,
         snapshot: MetadataDescription,
+        additional_fields: HashMap<String, serde_json::Value>,
     ) -> Result<Self> {
         if version < 1 {
             return Err(Error::IllegalArgument(format!(
@@ -1168,12 +1184,18 @@ impl TimestampMetadata {
             version,
             expires,
             snapshot,
+            additional_fields,
         })
     }
 
     /// An immutable reference to the snapshot description.
     pub fn snapshot(&self) -> &MetadataDescription {
         &self.snapshot
+    }
+
+    /// An immutable reference to any additional fields on the metadata.
+    pub fn additional_fields(&self) -> &HashMap<String, serde_json::Value> {
+        &self.additional_fields
     }
 }
 
@@ -1379,7 +1401,7 @@ impl SnapshotMetadataBuilder {
 
     /// Construct a new `SnapshotMetadata`.
     pub fn build(self) -> Result<SnapshotMetadata> {
-        SnapshotMetadata::new(self.version, self.expires, self.meta)
+        SnapshotMetadata::new(self.version, self.expires, self.meta, Default::default())
     }
 
     /// Construct a new `SignedMetadata<D, SnapshotMetadata>`.
@@ -1416,6 +1438,7 @@ pub struct SnapshotMetadata {
     version: u32,
     expires: DateTime<Utc>,
     meta: HashMap<MetadataPath, MetadataDescription>,
+    additional_fields: HashMap<String, serde_json::Value>,
 }
 
 impl SnapshotMetadata {
@@ -1424,6 +1447,7 @@ impl SnapshotMetadata {
         version: u32,
         expires: DateTime<Utc>,
         meta: HashMap<MetadataPath, MetadataDescription>,
+        additional_fields: HashMap<String, serde_json::Value>,
     ) -> Result<Self> {
         if version < 1 {
             return Err(Error::IllegalArgument(format!(
@@ -1436,12 +1460,18 @@ impl SnapshotMetadata {
             version,
             expires,
             meta,
+            additional_fields,
         })
     }
 
     /// An immutable reference to the metadata paths and descriptions.
     pub fn meta(&self) -> &HashMap<MetadataPath, MetadataDescription> {
         &self.meta
+    }
+
+    /// An immutable reference to any additional fields on the metadata.
+    pub fn additional_fields(&self) -> &HashMap<String, serde_json::Value> {
+        &self.additional_fields
     }
 }
 

--- a/tuf/src/metadata.rs
+++ b/tuf/src/metadata.rs
@@ -1841,6 +1841,7 @@ pub struct TargetsMetadata {
     expires: DateTime<Utc>,
     targets: HashMap<TargetPath, TargetDescription>,
     delegations: Delegations,
+    additional_fields: HashMap<String, serde_json::Value>,
 }
 
 impl TargetsMetadata {
@@ -1850,6 +1851,7 @@ impl TargetsMetadata {
         expires: DateTime<Utc>,
         targets: HashMap<TargetPath, TargetDescription>,
         delegations: Delegations,
+        additional_fields: HashMap<String, serde_json::Value>,
     ) -> Result<Self> {
         if version < 1 {
             return Err(Error::IllegalArgument(format!(
@@ -1863,6 +1865,7 @@ impl TargetsMetadata {
             expires,
             targets,
             delegations,
+            additional_fields,
         })
     }
 
@@ -1874,6 +1877,11 @@ impl TargetsMetadata {
     /// An immutable reference to the optional delegations.
     pub fn delegations(&self) -> &Delegations {
         &self.delegations
+    }
+
+    /// An immutable reference to any additional fields on the metadata.
+    pub fn additional_fields(&self) -> &HashMap<String, serde_json::Value> {
+        &self.additional_fields
     }
 }
 
@@ -1991,6 +1999,7 @@ impl TargetsMetadataBuilder {
             self.expires,
             self.targets,
             self.delegations.unwrap_or_default(),
+            Default::default(),
         )
     }
 
@@ -3260,6 +3269,7 @@ mod test {
             Utc.ymd(2038, 1, 1).and_hms(0, 0, 0),
             hashmap!(),
             Delegations::default(),
+            Default::default(),
         )
         .unwrap();
 

--- a/tuf/src/metadata.rs
+++ b/tuf/src/metadata.rs
@@ -2314,6 +2314,24 @@ mod test {
     }
 
     #[test]
+    fn allow_asterisk_in_target_path() {
+        let good_paths = &[
+            "*",
+            "*/some/path",
+            "*/some/path/",
+            "some/*/path",
+            "some/*/path/*",
+        ];
+
+        for path in good_paths.iter() {
+            assert!(safe_path(path).is_ok());
+            assert!(TargetPath::new(path.to_string()).is_ok());
+            assert!(MetadataPath::new(path.to_string()).is_ok());
+            assert!(TargetPath::new(path.to_string()).is_ok());
+        }
+    }
+
+    #[test]
     fn path_matches_chain() {
         let test_cases: &[(bool, &str, &[&[&str]])] = &[
             // simplest case

--- a/tuf/src/metadata.rs
+++ b/tuf/src/metadata.rs
@@ -66,7 +66,6 @@ static PATH_ILLEGAL_STRINGS: &[&str] = &[
     "\"",
     "|",
     "?",
-    "*",
     // control characters, all illegal in FAT
     "\u{000}",
     "\u{001}",

--- a/tuf/src/metadata.rs
+++ b/tuf/src/metadata.rs
@@ -2479,7 +2479,7 @@ mod test {
 
         let jsn = json!({
             "_type": "root",
-            "spec_version": "1.0",
+            "spec_version": "1.0.0",
             "version": 1,
             "expires": "2017-01-01T00:00:00Z",
             "consistent_snapshot": true,
@@ -2546,7 +2546,7 @@ mod test {
     fn jsn_root_metadata_without_keyid_hash_algos() -> serde_json::Value {
         json!({
             "_type": "root",
-            "spec_version": "1.0",
+            "spec_version": "1.0.0",
             "version": 1,
             "expires": "2017-01-01T00:00:00Z",
             "consistent_snapshot": false,
@@ -2651,7 +2651,7 @@ mod test {
         let jsn = json!({
             "signatures": [{
                 "keyid": "a9f3ebc9b138762563a9c27b6edd439959e559709babd123e8d449ba2c18c61a",
-                "sig": "c4ba838e0d3f783716393a4d691f568f840733ff488bb79ac68287e97e0b31d63fcef392dbc978e878c2103ba231905af634cc651d6f0e63a35782d051ac6e00"
+                "sig": "1f944e022d0b30c5a9ddc9c210026f396e18a17cc9a4ee92c339a8ee63357608dba8121847a825c3a5c84c1081435436bd784c8086c3103cdd1489e79cff2802"
             }],
             "signed": jsn_root_metadata_without_keyid_hash_algos()
         });
@@ -2676,11 +2676,11 @@ mod test {
         let jsn = json!({
             "signatures": [{
                 "keyid": "a9f3ebc9b138762563a9c27b6edd439959e559709babd123e8d449ba2c18c61a",
-                "sig": "c4ba838e0d3f783716393a4d691f568f840733ff488bb79ac68287e97e0b31d63fcef392dbc978e878c2103ba231905af634cc651d6f0e63a35782d051ac6e00"
+                "sig": "1f944e022d0b30c5a9ddc9c210026f396e18a17cc9a4ee92c339a8ee63357608dba8121847a825c3a5c84c1081435436bd784c8086c3103cdd1489e79cff2802"
             },
             {
                 "keyid": "a9f3ebc9b138762563a9c27b6edd439959e559709babd123e8d449ba2c18c61a",
-                "sig": "c4ba838e0d3f783716393a4d691f568f840733ff488bb79ac68287e97e0b31d63fcef392dbc978e878c2103ba231905af634cc651d6f0e63a35782d051ac6e00"
+                "sig": "1f944e022d0b30c5a9ddc9c210026f396e18a17cc9a4ee92c339a8ee63357608dba8121847a825c3a5c84c1081435436bd784c8086c3103cdd1489e79cff2802"
             }],
             "signed": jsn_root_metadata_without_keyid_hash_algos()
         });
@@ -2688,6 +2688,7 @@ mod test {
         let decoded: SignedMetadata<crate::interchange::cjson::Json, RootMetadata> =
             serde_json::from_value(jsn).unwrap();
         let raw_root = decoded.to_raw().unwrap();
+
         assert_matches!(
             verify_signatures(&MetadataPath::root(), &raw_root, 2, &[root_key.public().clone()]),
             Err(Error::MetadataMissingSignatures {
@@ -2825,7 +2826,7 @@ mod test {
 
         let jsn = json!({
             "_type": "timestamp",
-            "spec_version": "1.0",
+            "spec_version": "1.0.0",
             "version": 1,
             "expires": "2017-01-01T00:00:00Z",
             "meta": {
@@ -2857,7 +2858,7 @@ mod test {
 
         let jsn = json!({
             "_type": "timestamp",
-            "spec_version": "1.0",
+            "spec_version": "1.0.0",
             "version": 1,
             "expires": "2017-01-01T00:00:00Z",
             "meta": {
@@ -2877,7 +2878,7 @@ mod test {
     fn serde_timestamp_metadata_missing_snapshot() {
         let jsn = json!({
             "_type": "timestamp",
-            "spec_version": "1.0",
+            "spec_version": "1.0.0",
             "version": 1,
             "expires": "2017-01-01T00:00:00Z",
             "meta": {}
@@ -2893,7 +2894,7 @@ mod test {
     fn serde_timestamp_metadata_extra_metadata() {
         let jsn = json!({
             "_type": "timestamp",
-            "spec_version": "1.0",
+            "spec_version": "1.0.0",
             "version": 1,
             "expires": "2017-01-01T00:00:00Z",
             "meta": {
@@ -2939,7 +2940,7 @@ mod test {
 
         let jsn = json!({
             "_type": "snapshot",
-            "spec_version": "1.0",
+            "spec_version": "1.0.0",
             "version": 1,
             "expires": "2017-01-01T00:00:00Z",
             "meta": {
@@ -2973,7 +2974,7 @@ mod test {
 
         let jsn = json!({
             "_type": "snapshot",
-            "spec_version": "1.0",
+            "spec_version": "1.0.0",
             "version": 1,
             "expires": "2017-01-01T00:00:00Z",
             "meta": {
@@ -3034,7 +3035,7 @@ mod test {
 
             let jsn = json!({
                 "_type": "targets",
-                "spec_version": "1.0",
+                "spec_version": "1.0.0",
                 "version": 1,
                 "expires": "2017-01-01T00:00:00Z",
                 "targets": {
@@ -3104,7 +3105,7 @@ mod test {
 
         let jsn = json!({
             "_type": "targets",
-            "spec_version": "1.0",
+            "spec_version": "1.0.0",
             "version": 1,
             "expires": "2017-01-01T00:00:00Z",
             "targets": {},
@@ -3162,14 +3163,14 @@ mod test {
             "signatures": [
                 {
                     "keyid": "a9f3ebc9b138762563a9c27b6edd439959e559709babd123e8d449ba2c18c61a",
-                    "sig": "ea48ddc7b3ea614b394e508eb8722100f94ff1a4e3aac3af09d\
-                        a0dada4f878431e8ac26160833405ec239924dfe62edf605fee8294\
-                        c49b4acade55c76e817602",
+                    "sig": "a9b97b2439cd41e9a8c62e4d2f8f73b25a06095e0a994e8631a0\
+                        88977271909af2cc829c68637af98b07ebffeea308cc1a1c83d18fa2\
+                        9ec401493973b3dfa90e",
                 }
             ],
             "signed": {
                 "_type": "snapshot",
-                "spec_version": "1.0",
+                "spec_version": "1.0.0",
                 "version": 1,
                 "expires": "2017-01-01T00:00:00Z",
                 "meta": {
@@ -3329,7 +3330,7 @@ mod test {
     fn deserialize_json_root_duplicate_keys() {
         let root_json = r#"{
             "_type": "root",
-            "spec_version": "1.0",
+            "spec_version": "1.0.0",
             "version": 1,
             "expires": "2017-01-01T00:00:00Z",
             "consistent_snapshot": false,
@@ -3515,7 +3516,7 @@ mod test {
     fn deserialize_json_snapshot_duplicate_metadata() {
         let snapshot_json = r#"{
             "_type": "snapshot",
-            "spec_version": "1.0",
+            "spec_version": "1.0.0",
             "version": 1,
             "expires": "2017-01-01T00:00:00Z",
             "meta": {
@@ -3580,7 +3581,7 @@ mod test {
     fn deserialize_json_timestamp_duplicate_metadata() {
         let timestamp_json = r#"{
             "_type": "timestamp",
-            "spec_version": "1.0",
+            "spec_version": "1.0.0",
             "version": 1,
             "expires": "2017-01-01T00:00:00Z",
             "meta": {

--- a/tuf/src/repository.rs
+++ b/tuf/src/repository.rs
@@ -108,7 +108,7 @@ where
 
 /// A writable TUF repository. Most implementors of this trait should also implement
 /// `RepositoryProvider`.
-pub trait RepositoryStorage<D>
+pub trait RepositoryStorage<D>: Send
 where
     D: DataInterchange + Sync,
 {


### PR DESCRIPTION
👋 I've been working on integrating the [Vector](https://github.com/vectordotdev/vector) project with Datadog's TUF/Uptane implementation, and this PR contains the handful of tweaks I've had to make to get everything interoperating happily:

1. A `spec_version` of `"1.0"` is not actually valid according to SemVer. It should probably be `"1.0.0"` everywhere, but I've kept a check for the old value so that it continues to work with existing metadata.
2. The datetime parsing was overly strict relative to the spec, which only specifies ISO8601. Here it's adjusted to use a full RFC3339 parser that handles the slightly differing format that go-tuf can emit.
3. Allowing `*` in paths, which is legal according to the spec and used somewhat heavily when specifying delegations.
4. Adding a couple of `Send` bounds, which isn't related to interop but made the library easier to use.

The `spec_version` change does seem to break the interop tests, but I wanted to make sure we want to move forward with the change before doing the work of regenerating the test data.

If any these seem undesirable or warrant more discussion, I'd be happy to split them into separate PRs.

/cc @zenithar @cedricvanrompay-datadog