### PR TITLE
FileSystemRepository does not need to be failable

### DIFF
--- a/interop-tests/src/lib.rs
+++ b/interop-tests/src/lib.rs
@@ -256,7 +256,7 @@ pub async fn generate_repos(
     let mut repo = FileSystemRepositoryBuilder::new(dir0)
         .metadata_prefix(Path::new("repository"))
         .targets_prefix(Path::new("repository").join("targets"))
-        .build()?;
+        .build();
 
     update_root(&mut repo, &keys, None, 1, consistent_snapshot).await;
     add_target(&mut repo, &keys, 0, consistent_snapshot).await;
@@ -276,8 +276,7 @@ pub async fn generate_repos(
         let mut repo = FileSystemRepositoryBuilder::new(dir_i)
             .metadata_prefix(Path::new("repository"))
             .targets_prefix(Path::new("repository").join("targets"))
-            .build()
-            .unwrap();
+            .build();
         copy_repo(dir, i);
 
         let root_signer = match r {

--- a/interop-tests/tests/test.rs
+++ b/interop-tests/tests/test.rs
@@ -47,7 +47,6 @@ use tuf::metadata::{MetadataPath, MetadataVersion, RawSignedMetadata, RootMetada
 use tuf::repository::{
     EphemeralRepository, FileSystemRepository, FileSystemRepositoryBuilder, RepositoryProvider,
 };
-use tuf::Result;
 
 #[test]
 fn fuchsia_go_tuf_consistent_snapshot_false() {
@@ -171,7 +170,7 @@ where
     }
 
     async fn run_test_step(&mut self, public_keys: &[PublicKey], dir: PathBuf) {
-        let remote = init_remote(&dir).unwrap();
+        let remote = init_remote(&dir);
 
         // Connect to the client with our initial keys.
         let mut client = Client::with_trusted_root_keys(
@@ -210,7 +209,7 @@ async fn extract_keys<D>(dir: &Path) -> Vec<PublicKey>
 where
     D: DataInterchange + Sync,
 {
-    let remote = init_remote::<D>(dir).unwrap();
+    let remote = init_remote::<D>(dir);
 
     let root_path = MetadataPath::root();
 
@@ -229,7 +228,7 @@ where
     metadata.root_keys().cloned().collect()
 }
 
-fn init_remote<D>(dir: &Path) -> Result<FileSystemRepository<D>>
+fn init_remote<D>(dir: &Path) -> FileSystemRepository<D>
 where
     D: DataInterchange + Sync,
 {

--- a/tuf/src/client.rs
+++ b/tuf/src/client.rs
@@ -23,7 +23,7 @@
 //! # fn main() -> Result<()> {
 //! # block_on(async {
 //! let root_public_keys = load_root_public_keys();
-//! let local = FileSystemRepository::<Json>::new(PathBuf::from("~/.rustup"))?;
+//! let local = FileSystemRepository::<Json>::new(PathBuf::from("~/.rustup"));
 //!
 //! let remote = HttpRepositoryBuilder::new_with_uri(
 //!     "https://static.rust-lang.org/".parse::<http::Uri>().unwrap(),

--- a/tuf/src/repository/file_system.rs
+++ b/tuf/src/repository/file_system.rs
@@ -59,26 +59,24 @@ where
     }
 
     /// Build a `FileSystemRepository`.
-    pub fn build(self) -> Result<FileSystemRepository<D>> {
+    pub fn build(self) -> FileSystemRepository<D> {
         let metadata_path = if let Some(metadata_prefix) = self.metadata_prefix {
             self.local_path.join(metadata_prefix)
         } else {
             self.local_path.clone()
         };
-        DirBuilder::new().recursive(true).create(&metadata_path)?;
 
         let targets_path = if let Some(targets_prefix) = self.targets_prefix {
             self.local_path.join(targets_prefix)
         } else {
             self.local_path.clone()
         };
-        DirBuilder::new().recursive(true).create(&targets_path)?;
 
-        Ok(FileSystemRepository {
+        FileSystemRepository {
             metadata_path,
             targets_path,
             _interchange: PhantomData,
-        })
+        }
     }
 }
 
@@ -103,7 +101,7 @@ where
     }
 
     /// Create a new repository on the local file system.
-    pub fn new<P: Into<PathBuf>>(local_path: P) -> Result<Self> {
+    pub fn new<P: Into<PathBuf>>(local_path: P) -> Self {
         FileSystemRepositoryBuilder::new(local_path)
             .metadata_prefix("metadata")
             .targets_prefix("targets")
@@ -437,9 +435,7 @@ mod test {
                 .prefix("rust-tuf")
                 .tempdir()
                 .unwrap();
-            let repo = FileSystemRepositoryBuilder::new(temp_dir.path())
-                .build()
-                .unwrap();
+            let repo = FileSystemRepositoryBuilder::new(temp_dir.path()).build();
 
             assert_matches!(
                 Repository::<_, Json>::new(repo)
@@ -469,12 +465,11 @@ mod test {
             let mut repo = FileSystemRepositoryBuilder::<Json>::new(temp_dir.path().to_path_buf())
                 .metadata_prefix("meta")
                 .targets_prefix("targs")
-                .build()
-                .unwrap();
+                .build();
 
             // test that init worked
-            assert!(temp_dir.path().join("meta").exists());
-            assert!(temp_dir.path().join("targs").exists());
+            //assert!(temp_dir.path().join("meta").exists());
+            //assert!(temp_dir.path().join("targs").exists());
 
             let data: &[u8] = b"like tears in the rain";
             let path = TargetPath::new("foo/bar/baz").unwrap();
@@ -518,8 +513,7 @@ mod test {
             let mut repo = FileSystemRepositoryBuilder::<Json>::new(temp_dir.path().to_path_buf())
                 .metadata_prefix("meta")
                 .targets_prefix("targs")
-                .build()
-                .unwrap();
+                .build();
 
             let meta_path = MetadataPath::new("meta").unwrap();
             let meta_version = MetadataVersion::None;

--- a/tuf/src/repository/http.rs
+++ b/tuf/src/repository/http.rs
@@ -122,6 +122,7 @@ where
 }
 
 /// A repository accessible over HTTP.
+#[derive(Debug)]
 pub struct HttpRepository<C, D>
 where
     C: Connect + Sync + 'static,


### PR DESCRIPTION
This changes the FileSystemRepository already create the metadata and target's parent directories when they are written to disk.