### PR TITLE
Switch RepositoryStorage::store_* to take &self

### DIFF
--- a/tuf/src/client.rs
+++ b/tuf/src/client.rs
@@ -1797,7 +1797,7 @@ mod test {
     fn constructor_succeeds_with_malformed_metadata() {
         block_on(async {
             // Store a malformed timestamp in the local repository.
-            let mut local = EphemeralRepository::<Json>::new();
+            let local = EphemeralRepository::<Json>::new();
             let junk_timestamp = "junk timestamp";
 
             local
@@ -2339,7 +2339,7 @@ mod test {
     #[test]
     fn client_can_update_with_unknown_len_and_hashes() {
         block_on(async {
-            let mut repo = EphemeralRepository::<Json>::new();
+            let repo = EphemeralRepository::<Json>::new();
 
             let root = RootMetadataBuilder::new()
                 .consistent_snapshot(true)

--- a/tuf/src/repo_builder.rs
+++ b/tuf/src/repo_builder.rs
@@ -1441,7 +1441,11 @@ where
             let path = MetadataPath::targets();
             self.ctx
                 .repo
-                .store_metadata(&path, MetadataVersion::None, &mut targets.raw.as_bytes())
+                .store_metadata(
+                    &path.clone(),
+                    MetadataVersion::None,
+                    &mut targets.raw.as_bytes(),
+                )
                 .await?;
 
             if consistent_snapshot {

--- a/tuf/src/repository.rs
+++ b/tuf/src/repository.rs
@@ -189,6 +189,29 @@ where
     }
 }
 
+impl<T, D> RepositoryStorage<D> for &T
+where
+    T: RepositoryStorage<D>,
+    D: DataInterchange + Sync,
+{
+    fn store_metadata<'a>(
+        &'a self,
+        meta_path: &MetadataPath,
+        version: MetadataVersion,
+        metadata: &'a mut (dyn AsyncRead + Send + Unpin),
+    ) -> BoxFuture<'a, Result<()>> {
+        (**self).store_metadata(meta_path, version, metadata)
+    }
+
+    fn store_target<'a>(
+        &'a self,
+        target_path: &TargetPath,
+        target: &'a mut (dyn AsyncRead + Send + Unpin),
+    ) -> BoxFuture<'a, Result<()>> {
+        (**self).store_target(target_path, target)
+    }
+}
+
 impl<T, D> RepositoryStorage<D> for &mut T
 where
     T: RepositoryStorage<D>,
@@ -314,6 +337,28 @@ where
         target_path: &TargetPath,
     ) -> BoxFuture<'a, Result<Box<dyn AsyncRead + Send + Unpin + 'a>>> {
         (**self).fetch_target(target_path)
+    }
+}
+
+impl<D> RepositoryStorage<D> for &dyn RepositoryStorage<D>
+where
+    D: DataInterchange + Sync,
+{
+    fn store_metadata<'a>(
+        &'a self,
+        meta_path: &MetadataPath,
+        version: MetadataVersion,
+        metadata: &'a mut (dyn AsyncRead + Send + Unpin),
+    ) -> BoxFuture<'a, Result<()>> {
+        (**self).store_metadata(meta_path, version, metadata)
+    }
+
+    fn store_target<'a>(
+        &'a self,
+        target_path: &TargetPath,
+        target: &'a mut (dyn AsyncRead + Send + Unpin),
+    ) -> BoxFuture<'a, Result<()>> {
+        (**self).store_target(target_path, target)
     }
 }
 

--- a/tuf/src/repository.rs
+++ b/tuf/src/repository.rs
@@ -117,18 +117,18 @@ where
     ///
     /// [extension]: crate::interchange::DataInterchange::extension
     fn store_metadata<'a>(
-        &'a mut self,
+        &'a self,
         meta_path: &MetadataPath,
         version: MetadataVersion,
-        metadata: &'a mut (dyn AsyncRead + Send + Unpin + 'a),
+        metadata: &'a mut (dyn AsyncRead + Send + Unpin),
     ) -> BoxFuture<'a, Result<()>>;
 
     /// Store the provided `target` in a location identified by `target_path`, overwriting any
     /// existing target at that location.
     fn store_target<'a>(
-        &'a mut self,
+        &'a self,
         target_path: &TargetPath,
-        target: &'a mut (dyn AsyncRead + Send + Unpin + 'a),
+        target: &'a mut (dyn AsyncRead + Send + Unpin),
     ) -> BoxFuture<'a, Result<()>>;
 }
 
@@ -195,18 +195,18 @@ where
     D: DataInterchange + Sync,
 {
     fn store_metadata<'a>(
-        &'a mut self,
+        &'a self,
         meta_path: &MetadataPath,
         version: MetadataVersion,
-        metadata: &'a mut (dyn AsyncRead + Send + Unpin + 'a),
+        metadata: &'a mut (dyn AsyncRead + Send + Unpin),
     ) -> BoxFuture<'a, Result<()>> {
         (**self).store_metadata(meta_path, version, metadata)
     }
 
     fn store_target<'a>(
-        &'a mut self,
+        &'a self,
         target_path: &TargetPath,
-        target: &'a mut (dyn AsyncRead + Send + Unpin + 'a),
+        target: &'a mut (dyn AsyncRead + Send + Unpin),
     ) -> BoxFuture<'a, Result<()>> {
         (**self).store_target(target_path, target)
     }
@@ -218,16 +218,16 @@ where
     D: DataInterchange + Sync,
 {
     fn store_metadata<'a>(
-        &'a mut self,
+        &'a self,
         meta_path: &MetadataPath,
         version: MetadataVersion,
-        metadata: &'a mut (dyn AsyncRead + Send + Unpin + 'a),
+        metadata: &'a mut (dyn AsyncRead + Send + Unpin),
     ) -> BoxFuture<'a, Result<()>> {
         (**self).store_metadata(meta_path, version, metadata)
     }
 
     fn store_target<'a>(
-        &'a mut self,
+        &'a self,
         target_path: &TargetPath,
         target: &'a mut (dyn AsyncRead + Send + Unpin + 'a),
     ) -> BoxFuture<'a, Result<()>> {
@@ -322,18 +322,18 @@ where
     D: DataInterchange + Sync,
 {
     fn store_metadata<'a>(
-        &'a mut self,
+        &'a self,
         meta_path: &MetadataPath,
         version: MetadataVersion,
-        metadata: &'a mut (dyn AsyncRead + Send + Unpin + 'a),
+        metadata: &'a mut (dyn AsyncRead + Send + Unpin),
     ) -> BoxFuture<'a, Result<()>> {
         (**self).store_metadata(meta_path, version, metadata)
     }
 
     fn store_target<'a>(
-        &'a mut self,
+        &'a self,
         target_path: &TargetPath,
-        target: &'a mut (dyn AsyncRead + Send + Unpin + 'a),
+        target: &'a mut (dyn AsyncRead + Send + Unpin),
     ) -> BoxFuture<'a, Result<()>> {
         (**self).store_target(target_path, target)
     }
@@ -486,7 +486,7 @@ where
     /// [extension]: crate::interchange::DataInterchange::extension
     pub async fn store_metadata<'a, M>(
         &'a mut self,
-        path: &'a MetadataPath,
+        path: &MetadataPath,
         version: MetadataVersion,
         metadata: &'a RawSignedMetadata<D, M>,
     ) -> Result<()>
@@ -503,7 +503,7 @@ where
     /// Store the provided `target` in a location identified by `target_path`.
     pub async fn store_target<'a>(
         &'a mut self,
-        target_path: &'a TargetPath,
+        target_path: &TargetPath,
         target: &'a mut (dyn AsyncRead + Send + Unpin + 'a),
     ) -> Result<()> {
         self.repository.store_target(target_path, target).await
@@ -580,7 +580,7 @@ mod test {
             let _metadata = RawSignedMetadata::<Json, RootMetadata>::new(data.to_vec());
             let data_hash = crypto::calculate_hash(data, &HashAlgorithm::Sha256);
 
-            let mut repo = EphemeralRepository::new();
+            let repo = EphemeralRepository::new();
             repo.store_metadata(&path, version, &mut &*data)
                 .await
                 .unwrap();
@@ -608,7 +608,7 @@ mod test {
             let version = MetadataVersion::None;
             let data: &[u8] = b"corrupt metadata";
 
-            let mut repo = EphemeralRepository::new();
+            let repo = EphemeralRepository::new();
             repo.store_metadata(&path, version, &mut &*data)
                 .await
                 .unwrap();
@@ -637,7 +637,7 @@ mod test {
             let data: &[u8] = b"reasonably sized metadata";
             let _metadata = RawSignedMetadata::<Json, RootMetadata>::new(data.to_vec());
 
-            let mut repo = EphemeralRepository::new();
+            let repo = EphemeralRepository::new();
             repo.store_metadata(&path, version, &mut &*data)
                 .await
                 .unwrap();
@@ -660,7 +660,7 @@ mod test {
             let version = MetadataVersion::None;
             let data: &[u8] = b"very big metadata";
 
-            let mut repo = EphemeralRepository::new();
+            let repo = EphemeralRepository::new();
             repo.store_metadata(&path, version, &mut &*data)
                 .await
                 .unwrap();

--- a/tuf/src/repository/ephemeral.rs
+++ b/tuf/src/repository/ephemeral.rs
@@ -1,23 +1,40 @@
 //! Repository implementation backed by memory
 
-use futures_io::AsyncRead;
-use futures_util::future::{BoxFuture, FutureExt};
-use futures_util::io::{AsyncReadExt, Cursor};
-use std::collections::HashMap;
-use std::marker::PhantomData;
-
-use crate::error::Error;
-use crate::interchange::DataInterchange;
-use crate::metadata::{MetadataPath, MetadataVersion, TargetPath};
-use crate::repository::{RepositoryProvider, RepositoryStorage};
-use crate::Result;
+use {
+    crate::{
+        error::Error,
+        interchange::DataInterchange,
+        metadata::{MetadataPath, MetadataVersion, TargetPath},
+        repository::{RepositoryProvider, RepositoryStorage},
+        Result,
+    },
+    futures_io::AsyncRead,
+    futures_util::{
+        future::{BoxFuture, FutureExt},
+        io::{AsyncReadExt, Cursor},
+    },
+    std::{
+        collections::HashMap,
+        marker::PhantomData,
+        sync::{Arc, RwLock},
+    },
+};
 
 /// An ephemeral repository contained solely in memory.
 #[derive(Debug, Default)]
 pub struct EphemeralRepository<D> {
-    metadata: HashMap<(MetadataPath, MetadataVersion), Box<[u8]>>,
-    targets: HashMap<TargetPath, Box<[u8]>>,
+    inner: RwLock<Inner>,
     _interchange: PhantomData<D>,
+}
+
+type MetadataMap = HashMap<(MetadataPath, MetadataVersion), Arc<[u8]>>;
+type TargetsMap = HashMap<TargetPath, Arc<[u8]>>;
+
+#[derive(Debug, Default)]
+struct Inner {
+    version: u64,
+    metadata: MetadataMap,
+    targets: TargetsMap,
 }
 
 impl<D> EphemeralRepository<D>
@@ -27,24 +44,33 @@ where
     /// Create a new ephemeral repository.
     pub fn new() -> Self {
         Self {
-            metadata: HashMap::new(),
-            targets: HashMap::new(),
+            inner: RwLock::new(Inner {
+                version: 0,
+                metadata: MetadataMap::new(),
+                targets: TargetsMap::new(),
+            }),
             _interchange: PhantomData,
         }
     }
 
     /// Returns a [EphemeralBatchUpdate] for manipulating this repository. This allows callers to
     /// stage a number of mutations, and optionally atomically write them all at once.
-    pub fn batch_update(&mut self) -> EphemeralBatchUpdate<'_, D> {
+    pub fn batch_update(&self) -> EphemeralBatchUpdate<'_, D> {
         EphemeralBatchUpdate {
-            parent_repo: self,
-            staging_repo: EphemeralRepository::new(),
+            initial_parent_version: self.inner.read().unwrap().version,
+            parent_repo: &self.inner,
+            staging_repo: RwLock::new(Inner {
+                version: 0,
+                metadata: MetadataMap::new(),
+                targets: TargetsMap::new(),
+            }),
+            _interchange: self._interchange,
         }
     }
 
     #[cfg(test)]
-    pub(crate) fn metadata(&self) -> &HashMap<(MetadataPath, MetadataVersion), Box<[u8]>> {
-        &self.metadata
+    pub(crate) fn metadata(&self) -> MetadataMap {
+        self.inner.read().unwrap().metadata.clone()
     }
 }
 
@@ -57,8 +83,14 @@ where
         meta_path: &MetadataPath,
         version: MetadataVersion,
     ) -> BoxFuture<'a, Result<Box<dyn AsyncRead + Send + Unpin + 'a>>> {
-        let bytes = match self.metadata.get(&(meta_path.clone(), version)) {
-            Some(bytes) => Ok(bytes),
+        let bytes = match self
+            .inner
+            .read()
+            .unwrap()
+            .metadata
+            .get(&(meta_path.clone(), version))
+        {
+            Some(bytes) => Ok(Arc::clone(bytes)),
             None => Err(Error::MetadataNotFound {
                 path: meta_path.clone(),
                 version,
@@ -71,8 +103,8 @@ where
         &'a self,
         target_path: &TargetPath,
     ) -> BoxFuture<'a, Result<Box<dyn AsyncRead + Send + Unpin + 'a>>> {
-        let bytes = match self.targets.get(target_path) {
-            Some(bytes) => Ok(bytes),
+        let bytes = match self.inner.read().unwrap().targets.get(target_path) {
+            Some(bytes) => Ok(Arc::clone(bytes)),
             None => Err(Error::TargetNotFound(target_path.clone())),
         };
         bytes_to_reader(bytes).boxed()
@@ -84,38 +116,20 @@ where
     D: DataInterchange + Sync,
 {
     fn store_metadata<'a>(
-        &'a mut self,
+        &'a self,
         meta_path: &MetadataPath,
         version: MetadataVersion,
         metadata: &'a mut (dyn AsyncRead + Send + Unpin + 'a),
     ) -> BoxFuture<'a, Result<()>> {
-        let meta_path = meta_path.clone();
-        let self_metadata = &mut self.metadata;
-        async move {
-            let mut buf = Vec::new();
-            metadata.read_to_end(&mut buf).await?;
-            buf.shrink_to_fit();
-            self_metadata.insert((meta_path, version), buf.into_boxed_slice());
-            Ok(())
-        }
-        .boxed()
+        store_metadata(&self.inner, meta_path, version, metadata)
     }
 
     fn store_target<'a>(
-        &'a mut self,
+        &'a self,
         target_path: &TargetPath,
         read: &'a mut (dyn AsyncRead + Send + Unpin + 'a),
     ) -> BoxFuture<'a, Result<()>> {
-        let target_path = target_path.clone();
-        let self_targets = &mut self.targets;
-        async move {
-            let mut buf = Vec::new();
-            read.read_to_end(&mut buf).await?;
-            buf.shrink_to_fit();
-            self_targets.insert(target_path.clone(), buf.into_boxed_slice());
-            Ok(())
-        }
-        .boxed()
+        store_target(&self.inner, target_path, read)
     }
 }
 
@@ -126,24 +140,43 @@ where
 /// targets to the [EphemeralRepository]. Otherwise any queued changes will be lost on drop.
 #[derive(Debug)]
 pub struct EphemeralBatchUpdate<'a, D> {
-    parent_repo: &'a mut EphemeralRepository<D>,
-    staging_repo: EphemeralRepository<D>,
+    initial_parent_version: u64,
+    parent_repo: &'a RwLock<Inner>,
+    staging_repo: RwLock<Inner>,
+    _interchange: PhantomData<D>,
 }
 
-impl<'a, D> EphemeralBatchUpdate<'a, D>
+/// Conflict occurred during commit.
+#[derive(Debug, thiserror::Error)]
+pub enum CommitError {
+    // Conflicting change occurred during commit.
+    #[error("conflicting change occurred during commit")]
+    Conflict,
+}
+
+impl<D> EphemeralBatchUpdate<'_, D>
 where
     D: DataInterchange + Sync,
 {
     /// Write all the metadata and targets in the [EphemeralBatchUpdate] to the source
     /// [EphemeralRepository] in a single batch operation.
-    pub fn commit(self) {
-        self.parent_repo
-            .metadata
-            .extend(self.staging_repo.metadata.into_iter());
+    pub async fn commit(self) -> std::result::Result<(), CommitError> {
+        let mut parent_repo = self.parent_repo.write().unwrap();
 
-        self.parent_repo
-            .targets
-            .extend(self.staging_repo.targets.into_iter());
+        // Check if the parent changed while this batch was being processed.
+        if self.initial_parent_version != parent_repo.version {
+            return Err(CommitError::Conflict);
+        }
+
+        // Since parent hasn't changed, merged everything we wrote into its tables.
+        let staging_repo = self.staging_repo.into_inner().unwrap();
+        parent_repo.metadata.extend(staging_repo.metadata);
+        parent_repo.targets.extend(staging_repo.targets);
+
+        // Increment the version number because we modified the repository.
+        parent_repo.version += 1;
+
+        Ok(())
     }
 }
 
@@ -157,12 +190,15 @@ where
         version: MetadataVersion,
     ) -> BoxFuture<'a, Result<Box<dyn AsyncRead + Send + Unpin + 'a>>> {
         let key = (meta_path.clone(), version);
-        let bytes = if let Some(bytes) = self.staging_repo.metadata.get(&key) {
-            Ok(bytes)
+        let bytes = if let Some(bytes) = self.staging_repo.read().unwrap().metadata.get(&key) {
+            Ok(Arc::clone(bytes))
         } else {
             self.parent_repo
+                .read()
+                .unwrap()
                 .metadata
                 .get(&key)
+                .map(Arc::clone)
                 .ok_or_else(|| Error::MetadataNotFound {
                     path: meta_path.clone(),
                     version,
@@ -175,12 +211,16 @@ where
         &'a self,
         target_path: &TargetPath,
     ) -> BoxFuture<'a, Result<Box<dyn AsyncRead + Send + Unpin + 'a>>> {
-        let bytes = if let Some(bytes) = self.staging_repo.targets.get(target_path) {
-            Ok(bytes)
+        let bytes = if let Some(bytes) = self.staging_repo.read().unwrap().targets.get(target_path)
+        {
+            Ok(Arc::clone(bytes))
         } else {
             self.parent_repo
+                .read()
+                .unwrap()
                 .targets
                 .get(target_path)
+                .map(Arc::clone)
                 .ok_or_else(|| Error::TargetNotFound(target_path.clone()))
         };
         bytes_to_reader(bytes).boxed()
@@ -192,28 +232,74 @@ where
     D: DataInterchange + Sync,
 {
     fn store_metadata<'a>(
-        &'a mut self,
+        &'a self,
         meta_path: &MetadataPath,
         version: MetadataVersion,
-        metadata: &'a mut (dyn AsyncRead + Send + Unpin + 'a),
+        metadata: &'a mut (dyn AsyncRead + Send + Unpin),
     ) -> BoxFuture<'a, Result<()>> {
-        self.staging_repo
-            .store_metadata(meta_path, version, metadata)
+        store_metadata(&self.staging_repo, meta_path, version, metadata)
     }
 
     fn store_target<'a>(
-        &'a mut self,
+        &'a self,
         target_path: &TargetPath,
-        read: &'a mut (dyn AsyncRead + Send + Unpin + 'a),
+        read: &'a mut (dyn AsyncRead + Send + Unpin),
     ) -> BoxFuture<'a, Result<()>> {
-        self.staging_repo.store_target(target_path, read)
+        store_target(&self.staging_repo, target_path, read)
     }
 }
 
+fn store_metadata<'a>(
+    inner: &'a RwLock<Inner>,
+    meta_path: &MetadataPath,
+    version: MetadataVersion,
+    metadata: &'a mut (dyn AsyncRead + Send + Unpin),
+) -> BoxFuture<'a, Result<()>> {
+    let meta_path = meta_path.clone();
+    async move {
+        let mut buf = Vec::new();
+        metadata.read_to_end(&mut buf).await?;
+        buf.shrink_to_fit();
+
+        let mut inner = inner.write().unwrap();
+
+        inner.metadata.insert((meta_path, version), buf.into());
+
+        // Increment the version since we changed.
+        inner.version += 1;
+
+        Ok(())
+    }
+    .boxed()
+}
+
+fn store_target<'a>(
+    inner: &'a RwLock<Inner>,
+    target_path: &TargetPath,
+    read: &'a mut (dyn AsyncRead + Send + Unpin + 'a),
+) -> BoxFuture<'a, Result<()>> {
+    let target_path = target_path.clone();
+    async move {
+        let mut buf = Vec::new();
+        read.read_to_end(&mut buf).await?;
+        buf.shrink_to_fit();
+
+        let mut inner = inner.write().unwrap();
+
+        inner.targets.insert(target_path, buf.into());
+
+        // Increment the version since we changed.
+        inner.version += 1;
+
+        Ok(())
+    }
+    .boxed()
+}
+
 #[allow(clippy::borrowed_box)]
-async fn bytes_to_reader(
-    bytes: Result<&'_ Box<[u8]>>,
-) -> Result<Box<dyn AsyncRead + Send + Unpin + '_>> {
+async fn bytes_to_reader<'a>(
+    bytes: Result<Arc<[u8]>>,
+) -> Result<Box<dyn AsyncRead + Send + Unpin + 'a>> {
     let bytes = bytes?;
     let reader: Box<dyn AsyncRead + Send + Unpin> = Box::new(Cursor::new(bytes));
     Ok(reader)
@@ -230,7 +316,7 @@ mod test {
     #[test]
     fn ephemeral_repo_targets() {
         block_on(async {
-            let mut repo = EphemeralRepository::<Json>::new();
+            let repo = EphemeralRepository::<Json>::new();
 
             let path = TargetPath::new("batty").unwrap();
             if let Err(err) = repo.fetch_target(&path).await {
@@ -262,7 +348,7 @@ mod test {
     #[test]
     fn ephemeral_repo_batch_update() {
         block_on(async {
-            let mut repo = EphemeralRepository::<Json>::new();
+            let repo = EphemeralRepository::<Json>::new();
 
             let meta_path = MetadataPath::new("meta").unwrap();
             let meta_version = MetadataVersion::None;
@@ -280,7 +366,7 @@ mod test {
                 .await
                 .unwrap();
 
-            let mut batch = repo.batch_update();
+            let batch = repo.batch_update();
 
             // Make sure we can read back the committed stuff.
             assert_eq!(
@@ -334,7 +420,7 @@ mod test {
             );
 
             // Do the batch_update again, but this time write the data.
-            let mut batch = repo.batch_update();
+            let batch = repo.batch_update();
             batch
                 .store_metadata(&meta_path, meta_version, &mut staged_meta.as_bytes())
                 .await
@@ -343,7 +429,8 @@ mod test {
                 .store_target(&target_path, &mut staged_target.as_bytes())
                 .await
                 .unwrap();
-            batch.commit();
+
+            batch.commit().await.unwrap();
 
             // Make sure the new data got to the repository.
             assert_eq!(
@@ -356,6 +443,87 @@ mod test {
                 fetch_target_to_string(&repo, &target_path).await.unwrap(),
                 staged_target,
             );
+        })
+    }
+
+    #[test]
+    fn ephemeral_repo_batch_commit_fails_with_metadata_conflicts() {
+        block_on(async {
+            let repo = EphemeralRepository::<Json>::new();
+
+            // commit() fails if we did nothing to the batch, but the repo changed.
+            let batch = repo.batch_update();
+
+            repo.store_metadata(
+                &MetadataPath::new("meta1").unwrap(),
+                MetadataVersion::None,
+                &mut "meta1".as_bytes(),
+            )
+            .await
+            .unwrap();
+
+            assert_matches!(batch.commit().await, Err(CommitError::Conflict));
+
+            // writing to both the repo and the batch should conflict.
+            let batch = repo.batch_update();
+
+            repo.store_metadata(
+                &MetadataPath::new("meta2").unwrap(),
+                MetadataVersion::None,
+                &mut "meta2".as_bytes(),
+            )
+            .await
+            .unwrap();
+
+            batch
+                .store_metadata(
+                    &MetadataPath::new("meta3").unwrap(),
+                    MetadataVersion::None,
+                    &mut "meta3".as_bytes(),
+                )
+                .await
+                .unwrap();
+
+            assert_matches!(batch.commit().await, Err(CommitError::Conflict));
+        })
+    }
+
+    #[test]
+    fn ephemeral_repo_batch_commit_fails_with_target_conflicts() {
+        block_on(async {
+            let repo = EphemeralRepository::<Json>::new();
+
+            // commit() fails if we did nothing to the batch, but the repo changed.
+            let batch = repo.batch_update();
+
+            repo.store_target(
+                &TargetPath::new("target1").unwrap(),
+                &mut "target1".as_bytes(),
+            )
+            .await
+            .unwrap();
+
+            assert_matches!(batch.commit().await, Err(CommitError::Conflict));
+
+            // writing to both the repo and the batch should conflict.
+            let batch = repo.batch_update();
+
+            repo.store_target(
+                &TargetPath::new("target2").unwrap(),
+                &mut "target2".as_bytes(),
+            )
+            .await
+            .unwrap();
+
+            batch
+                .store_target(
+                    &TargetPath::new("target3").unwrap(),
+                    &mut "target3".as_bytes(),
+                )
+                .await
+                .unwrap();
+
+            assert_matches!(batch.commit().await, Err(CommitError::Conflict));
         })
     }
 }

--- a/tuf/src/repository/ephemeral.rs
+++ b/tuf/src/repository/ephemeral.rs
@@ -524,6 +524,29 @@ mod test {
                 .unwrap();
 
             assert_matches!(batch.commit().await, Err(CommitError::Conflict));
+
+            // multiple batches should conflict.
+            let batch1 = repo.batch_update();
+            let batch2 = repo.batch_update();
+
+            batch1
+                .store_target(
+                    &TargetPath::new("target4").unwrap(),
+                    &mut "target4".as_bytes(),
+                )
+                .await
+                .unwrap();
+
+            batch2
+                .store_target(
+                    &TargetPath::new("target5").unwrap(),
+                    &mut "target5".as_bytes(),
+                )
+                .await
+                .unwrap();
+
+            assert_matches!(batch1.commit().await, Ok(()));
+            assert_matches!(batch2.commit().await, Err(CommitError::Conflict));
         })
     }
 }

--- a/tuf/src/repository/error_repo.rs
+++ b/tuf/src/repository/error_repo.rs
@@ -59,10 +59,10 @@ where
     D: DataInterchange + Sync,
 {
     fn store_metadata<'a>(
-        &'a mut self,
+        &'a self,
         meta_path: &MetadataPath,
         version: MetadataVersion,
-        metadata: &'a mut (dyn AsyncRead + Send + Unpin + 'a),
+        metadata: &'a mut (dyn AsyncRead + Send + Unpin),
     ) -> BoxFuture<'a, Result<()>> {
         if self.fail_metadata_stores.load(Ordering::SeqCst) {
             async { Err(Error::Encoding("failed".into())) }.boxed()
@@ -72,9 +72,9 @@ where
     }
 
     fn store_target<'a>(
-        &'a mut self,
+        &'a self,
         target_path: &TargetPath,
-        target: &'a mut (dyn AsyncRead + Send + Unpin + 'a),
+        target: &'a mut (dyn AsyncRead + Send + Unpin),
     ) -> BoxFuture<'a, Result<()>> {
         self.repo.store_target(target_path, target)
     }

--- a/tuf/src/repository/file_system.rs
+++ b/tuf/src/repository/file_system.rs
@@ -1,20 +1,26 @@
 //! Repository implementation backed by a file system.
 
-use futures_io::AsyncRead;
-use futures_util::future::{BoxFuture, FutureExt};
-use futures_util::io::{copy, AllowStdIo};
-use log::debug;
-use std::collections::HashMap;
-use std::fs::{DirBuilder, File};
-use std::io;
-use std::marker::PhantomData;
-use std::path::{Path, PathBuf};
-use tempfile::{NamedTempFile, TempPath};
-
-use crate::error::{Error, Result};
-use crate::interchange::DataInterchange;
-use crate::metadata::{MetadataPath, MetadataVersion, TargetPath};
-use crate::repository::{RepositoryProvider, RepositoryStorage};
+use {
+    crate::{
+        error::{Error, Result},
+        interchange::DataInterchange,
+        metadata::{MetadataPath, MetadataVersion, TargetPath},
+        repository::{RepositoryProvider, RepositoryStorage},
+    },
+    futures_io::AsyncRead,
+    futures_util::future::{BoxFuture, FutureExt},
+    futures_util::io::{copy, AllowStdIo},
+    log::debug,
+    std::{
+        collections::HashMap,
+        fs::{DirBuilder, File},
+        io,
+        marker::PhantomData,
+        path::{Path, PathBuf},
+        sync::RwLock,
+    },
+    tempfile::{NamedTempFile, TempPath},
+};
 
 /// A builder to create a repository contained on the local file system.
 pub struct FileSystemRepositoryBuilder<D> {
@@ -73,6 +79,7 @@ where
         };
 
         FileSystemRepository {
+            version: RwLock::new(0),
             metadata_path,
             targets_path,
             _interchange: PhantomData,
@@ -86,6 +93,7 @@ pub struct FileSystemRepository<D>
 where
     D: DataInterchange,
 {
+    version: RwLock<u64>,
     metadata_path: PathBuf,
     targets_path: PathBuf,
     _interchange: PhantomData<D>,
@@ -110,11 +118,20 @@ where
 
     /// Returns a [FileSystemBatchUpdate] for manipulating this repository. This allows callers to
     /// stage a number of mutations, and optionally write them all at once.
-    pub fn batch_update(&mut self) -> FileSystemBatchUpdate<D> {
+    ///
+    /// [FileSystemBatchUpdate] will try to update any changed metadata or targets in a
+    /// single transaction, and will fail if there are any conflict writes, either by directly
+    /// calling [FileSystemRepository::store_metadata], [FileSystemRepository::store_target], or
+    /// another [FileSystemRepository::batch_update].
+    ///
+    /// Warning: The current implementation makes no effort to prevent manipulations of the
+    /// underlying filesystem, either in-process, or by an external process.
+    pub fn batch_update(&self) -> FileSystemBatchUpdate<D> {
         FileSystemBatchUpdate {
-            repo: self,
-            metadata: HashMap::new(),
-            targets: HashMap::new(),
+            initial_parent_version: *self.version.read().unwrap(),
+            parent_repo: self,
+            metadata: RwLock::new(HashMap::new()),
+            targets: RwLock::new(HashMap::new()),
         }
     }
 
@@ -210,10 +227,10 @@ where
     D: DataInterchange + Sync + Send,
 {
     fn store_metadata<'a>(
-        &'a mut self,
+        &'a self,
         meta_path: &MetadataPath,
         version: MetadataVersion,
-        metadata: &'a mut (dyn AsyncRead + Send + Unpin + 'a),
+        metadata: &'a mut (dyn AsyncRead + Send + Unpin),
     ) -> BoxFuture<'a, Result<()>> {
         let path = self.metadata_path(meta_path, version);
 
@@ -226,6 +243,11 @@ where
             if let Err(err) = copy(metadata, &mut temp_file).await {
                 return Err(Error::IoPath { path, err });
             }
+
+            // Lock the version counter to prevent other writers from manipulating the repository to
+            // avoid race conditions.
+            let mut version = self.version.write().unwrap();
+
             temp_file
                 .into_inner()
                 .persist(&path)
@@ -234,15 +256,18 @@ where
                     err: err.error,
                 })?;
 
+            // Increment our version since the repository changed.
+            *version += 1;
+
             Ok(())
         }
         .boxed()
     }
 
     fn store_target<'a>(
-        &'a mut self,
+        &'a self,
         target_path: &TargetPath,
-        read: &'a mut (dyn AsyncRead + Send + Unpin + 'a),
+        read: &'a mut (dyn AsyncRead + Send + Unpin),
     ) -> BoxFuture<'a, Result<()>> {
         let path = self.target_path(target_path);
 
@@ -255,6 +280,9 @@ where
             if let Err(err) = copy(read, &mut temp_file).await {
                 return Err(Error::IoPath { path, err });
             }
+
+            let mut version = self.version.write().unwrap();
+
             temp_file
                 .into_inner()
                 .persist(&path)
@@ -262,6 +290,9 @@ where
                     path,
                     err: err.error,
                 })?;
+
+            // Increment our version since the repository changed.
+            *version += 1;
 
             Ok(())
         }
@@ -276,9 +307,31 @@ where
 /// targets to the [FileSystemRepository]. Otherwise any queued changes will be lost on drop.
 #[derive(Debug)]
 pub struct FileSystemBatchUpdate<'a, D: DataInterchange> {
-    repo: &'a mut FileSystemRepository<D>,
-    metadata: HashMap<PathBuf, TempPath>,
-    targets: HashMap<PathBuf, TempPath>,
+    initial_parent_version: u64,
+    parent_repo: &'a FileSystemRepository<D>,
+    metadata: RwLock<HashMap<PathBuf, TempPath>>,
+    targets: RwLock<HashMap<PathBuf, TempPath>>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum CommitError {
+    /// Conflict occurred during commit.
+    #[error("conflicting change occurred during commit")]
+    Conflict,
+
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+
+    /// An IO error occurred for a path.
+    #[error("IO error on path {path}")]
+    IoPath {
+        /// Path where the error occurred.
+        path: std::path::PathBuf,
+
+        /// The IO error.
+        #[source]
+        err: io::Error,
+    },
 }
 
 impl<'a, D> FileSystemBatchUpdate<'a, D>
@@ -290,23 +343,35 @@ where
     ///
     /// Note: While this function will atomically write each file, it's possible that this could
     /// fail with part of the files written if we experience a system error during the process.
-    pub async fn commit(self) -> Result<()> {
-        for (path, tmp_path) in self.targets {
+    pub async fn commit(self) -> std::result::Result<(), CommitError> {
+        let mut parent_version = self.parent_repo.version.write().unwrap();
+
+        if self.initial_parent_version != *parent_version {
+            return Err(CommitError::Conflict);
+        }
+
+        for (path, tmp_path) in self.targets.into_inner().unwrap() {
             if path.exists() {
                 debug!("Target path exists. Overwriting: {:?}", path);
             }
-            tmp_path.persist(&path).map_err(|err| Error::IoPath {
+            tmp_path.persist(&path).map_err(|err| CommitError::IoPath {
                 path,
                 err: err.error,
             })?;
         }
 
-        for (path, tmp_path) in self.metadata {
+        for (path, tmp_path) in self.metadata.into_inner().unwrap() {
             if path.exists() {
                 debug!("Metadata path exists. Overwriting: {:?}", path);
             }
-            tmp_path.persist(path).map_err(|err| err.error)?;
+            tmp_path.persist(&path).map_err(|err| CommitError::IoPath {
+                path,
+                err: err.error,
+            })?;
         }
+
+        // Increment the version because we wrote to it.
+        *parent_version += 1;
 
         Ok(())
     }
@@ -321,12 +386,12 @@ where
         meta_path: &MetadataPath,
         version: MetadataVersion,
     ) -> BoxFuture<'a, Result<Box<dyn AsyncRead + Send + Unpin + 'a>>> {
-        let path = self.repo.metadata_path(meta_path, version);
-        if let Some(temp_path) = self.metadata.get(&path) {
-            self.repo
+        let path = self.parent_repo.metadata_path(meta_path, version);
+        if let Some(temp_path) = self.metadata.read().unwrap().get(&path) {
+            self.parent_repo
                 .fetch_metadata_from_path(meta_path, version, temp_path)
         } else {
-            self.repo
+            self.parent_repo
                 .fetch_metadata_from_path(meta_path, version, &path)
         }
     }
@@ -335,11 +400,12 @@ where
         &'a self,
         target_path: &TargetPath,
     ) -> BoxFuture<'a, Result<Box<dyn AsyncRead + Send + Unpin + 'a>>> {
-        let path = self.repo.target_path(target_path);
-        if let Some(temp_path) = self.targets.get(&path) {
-            self.repo.fetch_target_from_path(target_path, temp_path)
+        let path = self.parent_repo.target_path(target_path);
+        if let Some(temp_path) = self.targets.read().unwrap().get(&path) {
+            self.parent_repo
+                .fetch_target_from_path(target_path, temp_path)
         } else {
-            self.repo.fetch_target_from_path(target_path, &path)
+            self.parent_repo.fetch_target_from_path(target_path, &path)
         }
     }
 }
@@ -349,20 +415,22 @@ where
     D: DataInterchange + Sync,
 {
     fn store_metadata<'a>(
-        &'a mut self,
+        &'a self,
         meta_path: &MetadataPath,
         version: MetadataVersion,
-        read: &'a mut (dyn AsyncRead + Send + Unpin + 'a),
+        read: &'a mut (dyn AsyncRead + Send + Unpin),
     ) -> BoxFuture<'a, Result<()>> {
-        let path = self.repo.metadata_path(meta_path, version);
-        let metadata = &mut self.metadata;
+        let path = self.parent_repo.metadata_path(meta_path, version);
 
         async move {
             let mut temp_file = AllowStdIo::new(create_temp_file(&path)?);
             if let Err(err) = copy(read, &mut temp_file).await {
                 return Err(Error::IoPath { path, err });
             }
-            metadata.insert(path, temp_file.into_inner().into_temp_path());
+            self.metadata
+                .write()
+                .unwrap()
+                .insert(path, temp_file.into_inner().into_temp_path());
 
             Ok(())
         }
@@ -370,19 +438,21 @@ where
     }
 
     fn store_target<'a>(
-        &'a mut self,
+        &'a self,
         target_path: &TargetPath,
-        read: &'a mut (dyn AsyncRead + Send + Unpin + 'a),
+        read: &'a mut (dyn AsyncRead + Send + Unpin),
     ) -> BoxFuture<'a, Result<()>> {
-        let path = self.repo.target_path(target_path);
-        let targets = &mut self.targets;
+        let path = self.parent_repo.target_path(target_path);
 
         async move {
             let mut temp_file = AllowStdIo::new(create_temp_file(&path)?);
             if let Err(err) = copy(read, &mut temp_file).await {
                 return Err(Error::IoPath { path, err });
             }
-            targets.insert(path, temp_file.into_inner().into_temp_path());
+            self.targets
+                .write()
+                .unwrap()
+                .insert(path, temp_file.into_inner().into_temp_path());
 
             Ok(())
         }
@@ -462,7 +532,7 @@ mod test {
                 .prefix("rust-tuf")
                 .tempdir()
                 .unwrap();
-            let mut repo = FileSystemRepositoryBuilder::<Json>::new(temp_dir.path().to_path_buf())
+            let repo = FileSystemRepositoryBuilder::<Json>::new(temp_dir.path().to_path_buf())
                 .metadata_prefix("meta")
                 .targets_prefix("targs")
                 .build();
@@ -510,7 +580,8 @@ mod test {
                 .prefix("rust-tuf")
                 .tempdir()
                 .unwrap();
-            let mut repo = FileSystemRepositoryBuilder::<Json>::new(temp_dir.path().to_path_buf())
+
+            let repo = FileSystemRepositoryBuilder::<Json>::new(temp_dir.path().to_path_buf())
                 .metadata_prefix("meta")
                 .targets_prefix("targs")
                 .build();
@@ -531,7 +602,7 @@ mod test {
                 .await
                 .unwrap();
 
-            let mut batch = repo.batch_update();
+            let batch = repo.batch_update();
 
             // Make sure we can read back the committed stuff.
             assert_eq!(
@@ -585,7 +656,7 @@ mod test {
             );
 
             // Do the batch_update again, but this time write the data.
-            let mut batch = repo.batch_update();
+            let batch = repo.batch_update();
             batch
                 .store_metadata(&meta_path, meta_version, &mut staged_meta.as_bytes())
                 .await
@@ -607,6 +678,97 @@ mod test {
                 fetch_target_to_string(&repo, &target_path).await.unwrap(),
                 staged_target,
             );
+        })
+    }
+
+    #[test]
+    fn file_system_repo_batch_commit_fails_with_metadata_conflicts() {
+        block_on(async {
+            let temp_dir = tempfile::Builder::new()
+                .prefix("rust-tuf")
+                .tempdir()
+                .unwrap();
+
+            let repo = FileSystemRepository::<Json>::new(temp_dir.path().to_path_buf());
+
+            // commit() fails if we did nothing to the batch, but the repo changed.
+            let batch = repo.batch_update();
+
+            repo.store_metadata(
+                &MetadataPath::new("meta1").unwrap(),
+                MetadataVersion::None,
+                &mut "meta1".as_bytes(),
+            )
+            .await
+            .unwrap();
+
+            assert_matches!(batch.commit().await, Err(CommitError::Conflict));
+
+            // writing to both the repo and the batch should conflict.
+            let batch = repo.batch_update();
+
+            repo.store_metadata(
+                &MetadataPath::new("meta2").unwrap(),
+                MetadataVersion::None,
+                &mut "meta2".as_bytes(),
+            )
+            .await
+            .unwrap();
+
+            batch
+                .store_metadata(
+                    &MetadataPath::new("meta3").unwrap(),
+                    MetadataVersion::None,
+                    &mut "meta3".as_bytes(),
+                )
+                .await
+                .unwrap();
+
+            assert_matches!(batch.commit().await, Err(CommitError::Conflict));
+        })
+    }
+
+    #[test]
+    fn file_system_repo_batch_commit_fails_with_target_conflicts() {
+        block_on(async {
+            let temp_dir = tempfile::Builder::new()
+                .prefix("rust-tuf")
+                .tempdir()
+                .unwrap();
+
+            let repo = FileSystemRepository::<Json>::new(temp_dir.path().to_path_buf());
+
+            // commit() fails if we did nothing to the batch, but the repo changed.
+            let batch = repo.batch_update();
+
+            repo.store_target(
+                &TargetPath::new("target1").unwrap(),
+                &mut "target1".as_bytes(),
+            )
+            .await
+            .unwrap();
+
+            assert_matches!(batch.commit().await, Err(CommitError::Conflict));
+
+            // writing to both the repo and the batch should conflict.
+            let batch = repo.batch_update();
+
+            repo.store_target(
+                &TargetPath::new("target2").unwrap(),
+                &mut "target2".as_bytes(),
+            )
+            .await
+            .unwrap();
+
+            batch
+                .store_target(
+                    &TargetPath::new("target3").unwrap(),
+                    &mut "target3".as_bytes(),
+                )
+                .await
+                .unwrap();
+
+            assert_matches!(batch.commit().await, Err(CommitError::Conflict));
         })
     }
 }

--- a/tuf/src/repository/file_system.rs
+++ b/tuf/src/repository/file_system.rs
@@ -769,6 +769,29 @@ mod test {
                 .unwrap();
 
             assert_matches!(batch.commit().await, Err(CommitError::Conflict));
+
+            // multiple batches should conflict.
+            let batch1 = repo.batch_update();
+            let batch2 = repo.batch_update();
+
+            batch1
+                .store_target(
+                    &TargetPath::new("target4").unwrap(),
+                    &mut "target4".as_bytes(),
+                )
+                .await
+                .unwrap();
+
+            batch2
+                .store_target(
+                    &TargetPath::new("target5").unwrap(),
+                    &mut "target5".as_bytes(),
+                )
+                .await
+                .unwrap();
+
+            assert_matches!(batch1.commit().await, Ok(()));
+            assert_matches!(batch2.commit().await, Err(CommitError::Conflict));
         })
     }
 }

--- a/tuf/src/repository/track_repo.rs
+++ b/tuf/src/repository/track_repo.rs
@@ -10,7 +10,7 @@ use {
         future::{BoxFuture, FutureExt},
         io::{AsyncReadExt, Cursor},
     },
-    std::sync::{Arc, Mutex},
+    std::sync::Mutex,
 };
 
 #[derive(Debug, PartialEq)]
@@ -81,14 +81,14 @@ impl Track {
 /// Helper Repository wrapper that tracks all the metadata fetches and stores for testing purposes.
 pub(crate) struct TrackRepository<R> {
     repo: R,
-    tracks: Arc<Mutex<Vec<Track>>>,
+    tracks: Mutex<Vec<Track>>,
 }
 
 impl<R> TrackRepository<R> {
     pub(crate) fn new(repo: R) -> Self {
         Self {
             repo,
-            tracks: Arc::new(Mutex::new(vec![])),
+            tracks: Mutex::new(vec![]),
         }
     }
 
@@ -107,10 +107,10 @@ where
     D: DataInterchange + Sync,
 {
     fn store_metadata<'a>(
-        &'a mut self,
+        &'a self,
         meta_path: &MetadataPath,
         version: MetadataVersion,
-        metadata: &'a mut (dyn AsyncRead + Send + Unpin + 'a),
+        metadata: &'a mut (dyn AsyncRead + Send + Unpin),
     ) -> BoxFuture<'a, Result<()>> {
         let meta_path = meta_path.clone();
         async move {
@@ -133,9 +133,9 @@ where
     }
 
     fn store_target<'a>(
-        &'a mut self,
+        &'a self,
         target_path: &TargetPath,
-        target: &'a mut (dyn AsyncRead + Send + Unpin + 'a),
+        target: &'a mut (dyn AsyncRead + Send + Unpin),
     ) -> BoxFuture<'a, Result<()>> {
         self.repo.store_target(target_path, target)
     }


### PR DESCRIPTION
During our migration to futures, we switched
`RepositoryStorage::store_metadata` and `RepositoryStorage::store_targets` to take `&mut self` to make it easier to reason about changes. This change however prevented us from concurrently changing the repository, which can speed up large commits. This change switches the repositories back to use `&self` to enable this.

One consequence of doing this is we need to change the batch update implementation `commit()` to now be fallible. This is implemented by incrementing a version number on every repository change, and storing the initial version number in the batch. We have a conflict if the versions don't match during commit.