### PR TITLE
Simplify types

### DIFF
--- a/interop-tests/tests/test.rs
+++ b/interop-tests/tests/test.rs
@@ -105,7 +105,7 @@ fn rust_tuf_identity_consistent_snapshot_true() {
 
 fn test_key_rotation<D>(dir: PathBuf)
 where
-    D: DataInterchange + Sync,
+    D: DataInterchange,
 {
     block_on(async {
         let mut suite = TestKeyRotation::<D>::new(dir);
@@ -116,7 +116,7 @@ where
 /// TestKeyRotation is the main driver for running the key rotation tests.
 struct TestKeyRotation<D>
 where
-    D: DataInterchange + Sync,
+    D: DataInterchange,
 {
     /// The paths to each test step directory.
     test_steps: Vec<PathBuf>,
@@ -131,7 +131,7 @@ where
 
 impl<D> TestKeyRotation<D>
 where
-    D: DataInterchange + Sync,
+    D: DataInterchange,
 {
     fn new(test_dir: PathBuf) -> Self {
         let mut test_steps = Vec::new();
@@ -207,7 +207,7 @@ where
 /// Extract the initial key ids from the first step.
 async fn extract_keys<D>(dir: &Path) -> Vec<PublicKey>
 where
-    D: DataInterchange + Sync,
+    D: DataInterchange,
 {
     let remote = init_remote::<D>(dir);
 
@@ -230,7 +230,7 @@ where
 
 fn init_remote<D>(dir: &Path) -> FileSystemRepository<D>
 where
-    D: DataInterchange + Sync,
+    D: DataInterchange,
 {
     FileSystemRepositoryBuilder::new(dir)
         .metadata_prefix(Path::new("repository"))

--- a/tuf/src/client.rs
+++ b/tuf/src/client.rs
@@ -68,7 +68,7 @@ use crate::verify::Verified;
 #[derive(Debug)]
 pub struct Client<D, L, R>
 where
-    D: DataInterchange + Sync,
+    D: DataInterchange,
     L: RepositoryProvider<D> + RepositoryStorage<D>,
     R: RepositoryProvider<D>,
 {
@@ -80,7 +80,7 @@ where
 
 impl<D, L, R> Client<D, L, R>
 where
-    D: DataInterchange + Sync,
+    D: DataInterchange,
     L: RepositoryProvider<D> + RepositoryStorage<D>,
     R: RepositoryProvider<D>,
 {
@@ -1128,7 +1128,7 @@ where
 #[derive(Debug)]
 pub struct Parts<D, L, R>
 where
-    D: DataInterchange + Sync,
+    D: DataInterchange,
     L: RepositoryProvider<D> + RepositoryStorage<D>,
     R: RepositoryProvider<D>,
 {
@@ -1157,7 +1157,7 @@ async fn fetch_metadata_from_local_or_else_remote<'a, D, L, R, M>(
     remote: &'a Repository<R, D>,
 ) -> Result<(bool, RawSignedMetadata<D, M>)>
 where
-    D: DataInterchange + Sync,
+    D: DataInterchange,
     L: RepositoryProvider<D> + RepositoryStorage<D>,
     R: RepositoryProvider<D>,
     M: Metadata + 'static,

--- a/tuf/src/database.rs
+++ b/tuf/src/database.rs
@@ -17,11 +17,11 @@ use crate::verify::{self, Verified};
 use crate::Result;
 
 /// Contains trusted TUF metadata and can be used to verify other metadata and targets.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct Database<D: DataInterchange> {
     trusted_root: Verified<RootMetadata>,
-    trusted_snapshot: Option<Verified<SnapshotMetadata>>,
     trusted_targets: Option<Verified<TargetsMetadata>>,
+    trusted_snapshot: Option<Verified<SnapshotMetadata>>,
     trusted_timestamp: Option<Verified<TimestampMetadata>>,
     trusted_delegations: HashMap<MetadataPath, Verified<TargetsMetadata>>,
     interchange: PhantomData<D>,
@@ -1037,6 +1037,19 @@ impl<D: DataInterchange> Database<D> {
                 path: MetadataPath::targets(),
                 version: MetadataVersion::None,
             }),
+        }
+    }
+}
+
+impl<D: DataInterchange> Clone for Database<D> {
+    fn clone(&self) -> Self {
+        Self {
+            trusted_root: self.trusted_root.clone(),
+            trusted_targets: self.trusted_targets.clone(),
+            trusted_snapshot: self.trusted_snapshot.clone(),
+            trusted_timestamp: self.trusted_timestamp.clone(),
+            trusted_delegations: self.trusted_delegations.clone(),
+            interchange: PhantomData,
         }
     }
 }

--- a/tuf/src/interchange/mod.rs
+++ b/tuf/src/interchange/mod.rs
@@ -5,14 +5,13 @@ pub use cjson::{Json, JsonPretty};
 
 use serde::de::DeserializeOwned;
 use serde::ser::Serialize;
-use std::fmt::Debug;
 
 use crate::Result;
 
 /// The format used for data interchange, serialization, and deserialization.
-pub trait DataInterchange: Debug + PartialEq + Clone {
+pub trait DataInterchange: Sync {
     /// The type of data that is contained in the `signed` portion of metadata.
-    type RawData: Serialize + DeserializeOwned + Clone + PartialEq;
+    type RawData: Serialize + DeserializeOwned + PartialEq;
 
     /// The data interchange's extension.
     fn extension() -> &'static str;

--- a/tuf/src/repo_builder.rs
+++ b/tuf/src/repo_builder.rs
@@ -205,7 +205,7 @@ struct Staged<D: DataInterchange, M: Metadata> {
 
 struct RepoContext<'a, D, R>
 where
-    D: DataInterchange + Sync,
+    D: DataInterchange,
     R: RepositoryStorage<D>,
 {
     repo: R,
@@ -228,7 +228,7 @@ where
 
 impl<'a, D, R> RepoContext<'a, D, R>
 where
-    D: DataInterchange + Sync,
+    D: DataInterchange,
     R: RepositoryStorage<D>,
 {
     fn root_keys_changed(&self, root: &Verified<RootMetadata>) -> bool {
@@ -309,7 +309,7 @@ where
 /// This helper builder simplifies the process of creating new metadata.
 pub struct RepoBuilder<'a, D, R, S = Root>
 where
-    D: DataInterchange + Sync,
+    D: DataInterchange,
     R: RepositoryStorage<D>,
     S: State,
 {
@@ -319,7 +319,7 @@ where
 
 impl<'a, D, R> RepoBuilder<'a, D, R, Root>
 where
-    D: DataInterchange + Sync,
+    D: DataInterchange,
     R: RepositoryStorage<D>,
 {
     /// Create a [RepoBuilder] for creating metadata for a new repository.
@@ -762,7 +762,7 @@ where
 
 impl<'a, D, R> RepoBuilder<'a, D, R, Targets<D>>
 where
-    D: DataInterchange + Sync,
+    D: DataInterchange,
     R: RepositoryStorage<D>,
 {
     /// Whether or not to include the length of the targets, and any delegated targets, in the
@@ -1022,7 +1022,7 @@ where
 
 impl<'a, D, R> RepoBuilder<'a, D, R, Snapshot<D>>
 where
-    D: DataInterchange + Sync,
+    D: DataInterchange,
     R: RepositoryStorage<D>,
 {
     /// Whether or not to include the length of the targets, and any delegated targets, in the
@@ -1180,7 +1180,7 @@ where
 
 impl<'a, D, R> RepoBuilder<'a, D, R, Timestamp<D>>
 where
-    D: DataInterchange + Sync,
+    D: DataInterchange,
     R: RepositoryStorage<D>,
 {
     /// Whether or not to include the length of the snapshot, and any delegated snapshot, in the
@@ -1338,7 +1338,7 @@ where
 
 impl<'a, D, R> RepoBuilder<'a, D, R, Done<D>>
 where
-    D: DataInterchange + Sync,
+    D: DataInterchange,
     R: RepositoryStorage<D>,
 {
     /// Commit the metadata for this repository, then write all metadata to the repository. Before

--- a/tuf/src/repository/ephemeral.rs
+++ b/tuf/src/repository/ephemeral.rs
@@ -76,7 +76,7 @@ where
 
 impl<D> RepositoryProvider<D> for EphemeralRepository<D>
 where
-    D: DataInterchange + Sync,
+    D: DataInterchange,
 {
     fn fetch_metadata<'a>(
         &'a self,
@@ -113,7 +113,7 @@ where
 
 impl<D> RepositoryStorage<D> for EphemeralRepository<D>
 where
-    D: DataInterchange + Sync,
+    D: DataInterchange,
 {
     fn store_metadata<'a>(
         &'a self,
@@ -156,7 +156,7 @@ pub enum CommitError {
 
 impl<D> EphemeralBatchUpdate<'_, D>
 where
-    D: DataInterchange + Sync,
+    D: DataInterchange,
 {
     /// Write all the metadata and targets in the [EphemeralBatchUpdate] to the source
     /// [EphemeralRepository] in a single batch operation.
@@ -182,7 +182,7 @@ where
 
 impl<D> RepositoryProvider<D> for EphemeralBatchUpdate<'_, D>
 where
-    D: DataInterchange + Sync,
+    D: DataInterchange,
 {
     fn fetch_metadata<'a>(
         &'a self,
@@ -229,7 +229,7 @@ where
 
 impl<D> RepositoryStorage<D> for EphemeralBatchUpdate<'_, D>
 where
-    D: DataInterchange + Sync,
+    D: DataInterchange,
 {
     fn store_metadata<'a>(
         &'a self,

--- a/tuf/src/repository/error_repo.rs
+++ b/tuf/src/repository/error_repo.rs
@@ -35,7 +35,7 @@ impl<R> ErrorRepository<R> {
 impl<D, R> RepositoryProvider<D> for ErrorRepository<R>
 where
     R: RepositoryProvider<D> + Sync,
-    D: DataInterchange + Sync,
+    D: DataInterchange,
 {
     fn fetch_metadata<'a>(
         &'a self,
@@ -56,7 +56,7 @@ where
 impl<D, R> RepositoryStorage<D> for ErrorRepository<R>
 where
     R: RepositoryStorage<D> + Sync,
-    D: DataInterchange + Sync,
+    D: DataInterchange,
 {
     fn store_metadata<'a>(
         &'a self,

--- a/tuf/src/repository/file_system.rs
+++ b/tuf/src/repository/file_system.rs
@@ -202,7 +202,7 @@ where
 
 impl<D> RepositoryProvider<D> for FileSystemRepository<D>
 where
-    D: DataInterchange + Sync,
+    D: DataInterchange,
 {
     fn fetch_metadata<'a>(
         &'a self,
@@ -224,7 +224,7 @@ where
 
 impl<D> RepositoryStorage<D> for FileSystemRepository<D>
 where
-    D: DataInterchange + Sync + Send,
+    D: DataInterchange,
 {
     fn store_metadata<'a>(
         &'a self,
@@ -336,7 +336,7 @@ pub enum CommitError {
 
 impl<'a, D> FileSystemBatchUpdate<'a, D>
 where
-    D: DataInterchange + Sync,
+    D: DataInterchange,
 {
     /// Write all the metadata and targets the [FileSystemBatchUpdate] to the source
     /// [FileSystemRepository] in a single batch operation.
@@ -379,7 +379,7 @@ where
 
 impl<D> RepositoryProvider<D> for FileSystemBatchUpdate<'_, D>
 where
-    D: DataInterchange + Sync,
+    D: DataInterchange,
 {
     fn fetch_metadata<'a>(
         &'a self,
@@ -412,7 +412,7 @@ where
 
 impl<D> RepositoryStorage<D> for FileSystemBatchUpdate<'_, D>
 where
-    D: DataInterchange + Sync,
+    D: DataInterchange,
 {
     fn store_metadata<'a>(
         &'a self,

--- a/tuf/src/repository/track_repo.rs
+++ b/tuf/src/repository/track_repo.rs
@@ -104,7 +104,7 @@ impl<R> TrackRepository<R> {
 impl<D, R> RepositoryStorage<D> for TrackRepository<R>
 where
     R: RepositoryStorage<D> + Sync + Send,
-    D: DataInterchange + Sync,
+    D: DataInterchange,
 {
     fn store_metadata<'a>(
         &'a self,
@@ -143,7 +143,7 @@ where
 
 impl<D, R> RepositoryProvider<D> for TrackRepository<R>
 where
-    D: DataInterchange + Sync,
+    D: DataInterchange,
     R: RepositoryProvider<D> + Sync,
 {
     fn fetch_metadata<'a>(


### PR DESCRIPTION
This patch removes a number of unnecessary `Send` and `Sync` constraints, and consolidates implementations of RepositoryProvider and RepositoryStorage.