### PR TITLE
Add handling of additional fields

### DIFF
--- a/tuf/src/metadata.rs
+++ b/tuf/src/metadata.rs
@@ -2583,6 +2583,61 @@ mod test {
         assert_eq!(decoded, root);
     }
 
+    #[test]
+    fn serde_root_metadata_additional_fields() {
+        let jsn = json!({
+            "_type": "root",
+            "spec_version": "1.0",
+            "version": 1,
+            "expires": "2017-01-01T00:00:00Z",
+            "consistent_snapshot": true,
+            "keys": {
+                "09557ed63f91b5b95917d46f66c63ea79bdaef1b008ba823808bca849f1d18a1": {
+                    "keytype": "ed25519",
+                    "scheme": "ed25519",
+                    "keyid_hash_algorithms": ["sha256", "sha512"],
+                    "keyval": {
+                        "public": "1410ae3053aa70bbfa98428a879d64d3002a3578f7dfaaeb1cb0764e860f7e0b",
+                    },
+                },
+            },
+            "roles": {
+                "root": {
+                    "threshold": 1,
+                    "keyids": ["09557ed63f91b5b95917d46f66c63ea79bdaef1b008ba823808bca849f1d18a1"],
+                },
+                "snapshot": {
+                    "threshold": 1,
+                    "keyids": ["09557ed63f91b5b95917d46f66c63ea79bdaef1b008ba823808bca849f1d18a1"],
+                },
+                "targets": {
+                    "threshold": 1,
+                    "keyids": ["09557ed63f91b5b95917d46f66c63ea79bdaef1b008ba823808bca849f1d18a1"],
+                },
+                "timestamp": {
+                    "threshold": 1,
+                    "keyids": ["09557ed63f91b5b95917d46f66c63ea79bdaef1b008ba823808bca849f1d18a1"],
+                },
+            },
+            // additional_fields
+            "custom": {
+                "foo": 42,
+                "bar": "baz",
+            },
+            "quux": true,
+        });
+
+        let root: RootMetadata = serde_json::from_value(jsn.clone()).unwrap();
+        assert_eq!(
+            root.additional_fields()["custom"],
+            json!({"foo": 42, "bar": "baz"})
+        );
+        assert_eq!(root.additional_fields()["quux"], json!(true));
+
+        // make sure additional_fields are passed through serialization as well
+        assert_eq!(jsn, serde_json::to_value(&root).unwrap());
+    }
+
     fn jsn_root_metadata_without_keyid_hash_algos() -> serde_json::Value {
         json!({
             "_type": "root",
@@ -2885,6 +2940,41 @@ mod test {
         assert_eq!(decoded, timestamp);
     }
 
+    #[test]
+    fn serde_timestamp_metadata_additional_fields() {
+        let jsn = json!({
+            "_type": "timestamp",
+            "spec_version": "1.0",
+            "version": 1,
+            "expires": "2017-01-01T00:00:00Z",
+            "meta": {
+                "snapshot.json": {
+                    "version": 1,
+                    "length": 100,
+                    "hashes": {
+                        "sha256": "",
+                    },
+                },
+            },
+            // additional_fields
+            "custom": {
+                "foo": 42,
+                "bar": "baz",
+            },
+            "quux": true,
+        });
+
+        let timestamp: TimestampMetadata = serde_json::from_value(jsn.clone()).unwrap();
+        assert_eq!(
+            timestamp.additional_fields()["custom"],
+            json!({"foo": 42, "bar": "baz"})
+        );
+        assert_eq!(timestamp.additional_fields()["quux"], json!(true));
+
+        // make sure additional_fields are passed through serialization as well
+        assert_eq!(jsn, serde_json::to_value(&timestamp).unwrap());
+    }
+
     // Deserialize timestamp metadata with optional length and hashes
     #[test]
     fn serde_timestamp_metadata_without_length_and_hashes() {
@@ -2904,7 +2994,7 @@ mod test {
                 "snapshot.json": {
                     "version": 1
                 },
-            }
+            },
         });
 
         let encoded = serde_json::to_value(&timestamp).unwrap();
@@ -2997,6 +3087,41 @@ mod test {
         assert_eq!(encoded, jsn);
         let decoded: SnapshotMetadata = serde_json::from_value(encoded).unwrap();
         assert_eq!(decoded, snapshot);
+    }
+
+    #[test]
+    fn serde_snapshot_metadata_additional_fields() {
+        let jsn = json!({
+            "_type": "snapshot",
+            "spec_version": "1.0",
+            "version": 1,
+            "expires": "2017-01-01T00:00:00Z",
+            "meta": {
+                "targets.json": {
+                    "version": 1,
+                    "length": 100,
+                    "hashes": {
+                        "sha256": "",
+                    },
+                },
+            },
+            // additional_fields
+            "custom": {
+                "foo": 42,
+                "bar": "baz",
+            },
+            "quux": true,
+        });
+
+        let snapshot: SnapshotMetadata = serde_json::from_value(jsn.clone()).unwrap();
+        assert_eq!(
+            snapshot.additional_fields()["custom"],
+            json!({"foo": 42, "bar": "baz"})
+        );
+        assert_eq!(snapshot.additional_fields()["quux"], json!(true));
+
+        // make sure additional_fields are passed through serialization as well
+        assert_eq!(jsn, serde_json::to_value(&snapshot).unwrap());
     }
 
     // Deserialize snapshot metadata with optional length and hashes
@@ -3118,6 +3243,66 @@ mod test {
             let decoded: TargetsMetadata = serde_json::from_value(encoded).unwrap();
             assert_eq!(decoded, targets);
         })
+    }
+
+    #[test]
+    fn serde_targets_metadata_additional_fields() {
+        let jsn = json!({
+                "_type": "targets",
+                "spec_version": "1.0",
+                "version": 1,
+                "expires": "2017-01-01T00:00:00Z",
+                "targets": {
+                    "insert-target-from-slice": {
+                        "length": 3,
+                        "hashes": {
+                            "sha256": "2c26b46b68ffc68ff99b453c1d30413413422d706483\
+                                bfa0f98a5e886266e7ae",
+                        },
+                    },
+                    "insert-target-description-from-slice-with-custom": {
+                        "length": 3,
+                        "hashes": {
+                            "sha256": "2c26b46b68ffc68ff99b453c1d30413413422d706483\
+                                bfa0f98a5e886266e7ae",
+                        },
+                    },
+                    "insert-target-from-reader": {
+                        "length": 3,
+                        "hashes": {
+                            "sha256": "2c26b46b68ffc68ff99b453c1d30413413422d706483\
+                                bfa0f98a5e886266e7ae",
+                        },
+                    },
+                    "insert-target-description-from-reader-with-custom": {
+                        "length": 3,
+                        "hashes": {
+                            "sha256": "2c26b46b68ffc68ff99b453c1d30413413422d706483\
+                                bfa0f98a5e886266e7ae",
+                        },
+                        "custom": {
+                            "foo": 1,
+                            "bar": "baz",
+                        },
+                    },
+                },
+            // additional_fields
+            "custom": {
+                "foo": 42,
+                "bar": "baz",
+            },
+            "quux": true,
+        });
+
+        let targets: TargetsMetadata = serde_json::from_value(jsn.clone()).unwrap();
+        assert_eq!(
+            targets.additional_fields()["custom"],
+            json!({"foo": 42, "bar": "baz"})
+        );
+        assert_eq!(targets.additional_fields()["quux"], json!(true));
+
+        // make sure additional_fields are passed through serialization as well
+        assert_eq!(jsn, serde_json::to_value(&targets).unwrap());
     }
 
     #[test]

--- a/tuf/src/metadata.rs
+++ b/tuf/src/metadata.rs
@@ -718,6 +718,7 @@ impl RootMetadataBuilder {
             RoleDefinition::new(self.snapshot_threshold, self.snapshot_key_ids)?,
             RoleDefinition::new(self.targets_threshold, self.targets_key_ids)?,
             RoleDefinition::new(self.timestamp_threshold, self.timestamp_key_ids)?,
+            Default::default(),
         )
     }
 
@@ -766,6 +767,7 @@ pub struct RootMetadata {
     snapshot: RoleDefinition<SnapshotMetadata>,
     targets: RoleDefinition<TargetsMetadata>,
     timestamp: RoleDefinition<TimestampMetadata>,
+    additional_fields: HashMap<String, serde_json::Value>,
 }
 
 impl RootMetadata {
@@ -779,6 +781,7 @@ impl RootMetadata {
         snapshot: RoleDefinition<SnapshotMetadata>,
         targets: RoleDefinition<TargetsMetadata>,
         timestamp: RoleDefinition<TimestampMetadata>,
+        additional_fields: HashMap<String, serde_json::Value>,
     ) -> Result<Self> {
         if version < 1 {
             return Err(Error::MetadataVersionMustBeGreaterThanZero(
@@ -795,6 +798,7 @@ impl RootMetadata {
             snapshot,
             targets,
             timestamp,
+            additional_fields,
         })
     }
 
@@ -859,6 +863,11 @@ impl RootMetadata {
     /// An immutable reference to the timestamp role's definition.
     pub fn timestamp(&self) -> &RoleDefinition<TimestampMetadata> {
         &self.timestamp
+    }
+
+    /// An immutable reference to any additional fields on the metadata.
+    pub fn additional_fields(&self) -> &HashMap<String, serde_json::Value> {
+        &self.additional_fields
     }
 }
 
@@ -1125,7 +1134,12 @@ impl TimestampMetadataBuilder {
 
     /// Construct a new `TimestampMetadata`.
     pub fn build(self) -> Result<TimestampMetadata> {
-        TimestampMetadata::new(self.version, self.expires, self.snapshot)
+        TimestampMetadata::new(
+            self.version,
+            self.expires,
+            self.snapshot,
+            Default::default(),
+        )
     }
 
     /// Construct a new `SignedMetadata<D, TimestampMetadata>`.
@@ -1146,6 +1160,7 @@ pub struct TimestampMetadata {
     version: u32,
     expires: DateTime<Utc>,
     snapshot: MetadataDescription<SnapshotMetadata>,
+    additional_fields: HashMap<String, serde_json::Value>,
 }
 
 impl TimestampMetadata {
@@ -1154,6 +1169,7 @@ impl TimestampMetadata {
         version: u32,
         expires: DateTime<Utc>,
         snapshot: MetadataDescription<SnapshotMetadata>,
+        additional_fields: HashMap<String, serde_json::Value>,
     ) -> Result<Self> {
         if version < 1 {
             return Err(Error::MetadataVersionMustBeGreaterThanZero(
@@ -1165,12 +1181,18 @@ impl TimestampMetadata {
             version,
             expires,
             snapshot,
+            additional_fields,
         })
     }
 
     /// An immutable reference to the snapshot description.
     pub fn snapshot(&self) -> &MetadataDescription<SnapshotMetadata> {
         &self.snapshot
+    }
+
+    /// An immutable reference to any additional fields on the metadata.
+    pub fn additional_fields(&self) -> &HashMap<String, serde_json::Value> {
+        &self.additional_fields
     }
 }
 
@@ -1383,7 +1405,7 @@ impl SnapshotMetadataBuilder {
 
     /// Construct a new `SnapshotMetadata`.
     pub fn build(self) -> Result<SnapshotMetadata> {
-        SnapshotMetadata::new(self.version, self.expires, self.meta)
+        SnapshotMetadata::new(self.version, self.expires, self.meta, Default::default())
     }
 
     /// Construct a new `SignedMetadata<D, SnapshotMetadata>`.
@@ -1420,6 +1442,7 @@ pub struct SnapshotMetadata {
     version: u32,
     expires: DateTime<Utc>,
     meta: HashMap<MetadataPath, MetadataDescription<TargetsMetadata>>,
+    additional_fields: HashMap<String, serde_json::Value>,
 }
 
 impl SnapshotMetadata {
@@ -1428,6 +1451,7 @@ impl SnapshotMetadata {
         version: u32,
         expires: DateTime<Utc>,
         meta: HashMap<MetadataPath, MetadataDescription<TargetsMetadata>>,
+        additional_fields: HashMap<String, serde_json::Value>,
     ) -> Result<Self> {
         if version < 1 {
             return Err(Error::MetadataVersionMustBeGreaterThanZero(
@@ -1439,12 +1463,18 @@ impl SnapshotMetadata {
             version,
             expires,
             meta,
+            additional_fields,
         })
     }
 
     /// An immutable reference to the metadata paths and descriptions.
     pub fn meta(&self) -> &HashMap<MetadataPath, MetadataDescription<TargetsMetadata>> {
         &self.meta
+    }
+
+    /// An immutable reference to any additional fields on the metadata.
+    pub fn additional_fields(&self) -> &HashMap<String, serde_json::Value> {
+        &self.additional_fields
     }
 }
 

--- a/tuf/src/metadata.rs
+++ b/tuf/src/metadata.rs
@@ -1844,6 +1844,7 @@ pub struct TargetsMetadata {
     expires: DateTime<Utc>,
     targets: HashMap<TargetPath, TargetDescription>,
     delegations: Delegations,
+    additional_fields: HashMap<String, serde_json::Value>,
 }
 
 impl TargetsMetadata {
@@ -1853,6 +1854,7 @@ impl TargetsMetadata {
         expires: DateTime<Utc>,
         targets: HashMap<TargetPath, TargetDescription>,
         delegations: Delegations,
+        additional_fields: HashMap<String, serde_json::Value>,
     ) -> Result<Self> {
         if version < 1 {
             return Err(Error::MetadataVersionMustBeGreaterThanZero(
@@ -1865,6 +1867,7 @@ impl TargetsMetadata {
             expires,
             targets,
             delegations,
+            additional_fields,
         })
     }
 
@@ -1876,6 +1879,11 @@ impl TargetsMetadata {
     /// An immutable reference to the optional delegations.
     pub fn delegations(&self) -> &Delegations {
         &self.delegations
+    }
+
+    /// An immutable reference to any additional fields on the metadata.
+    pub fn additional_fields(&self) -> &HashMap<String, serde_json::Value> {
+        &self.additional_fields
     }
 }
 
@@ -1993,6 +2001,7 @@ impl TargetsMetadataBuilder {
             self.expires,
             self.targets,
             self.delegations.unwrap_or_default(),
+            Default::default(),
         )
     }
 
@@ -3260,6 +3269,7 @@ mod test {
             Utc.ymd(2038, 1, 1).and_hms(0, 0, 0),
             hashmap!(),
             Delegations::default(),
+            Default::default(),
         )
         .unwrap();
 

--- a/tuf/src/pouf/pouf1/shims.rs
+++ b/tuf/src/pouf/pouf1/shims.rs
@@ -52,6 +52,8 @@ pub struct RootMetadata {
     #[serde(deserialize_with = "deserialize_reject_duplicates::deserialize")]
     keys: BTreeMap<crypto::KeyId, crypto::PublicKey>,
     roles: RoleDefinitions,
+    #[serde(flatten)]
+    additional_fields: BTreeMap<String, serde_json::Value>,
 }
 
 impl RootMetadata {
@@ -73,6 +75,7 @@ impl RootMetadata {
                 targets: meta.targets().clone(),
                 timestamp: meta.timestamp().clone(),
             },
+            additional_fields: meta.additional_fields().clone().into_iter().collect(),
         })
     }
 
@@ -109,6 +112,7 @@ impl RootMetadata {
             self.roles.snapshot,
             self.roles.targets,
             self.roles.timestamp,
+            self.additional_fields.into_iter().collect(),
         )
     }
 }
@@ -172,6 +176,8 @@ pub struct TimestampMetadata {
     version: u32,
     expires: String,
     meta: TimestampMeta,
+    #[serde(flatten)]
+    additional_fields: BTreeMap<String, serde_json::Value>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -191,6 +197,7 @@ impl TimestampMetadata {
             meta: TimestampMeta {
                 snapshot: metadata.snapshot().clone(),
             },
+            additional_fields: metadata.additional_fields().clone().into_iter().collect(),
         })
     }
 
@@ -213,6 +220,7 @@ impl TimestampMetadata {
             self.version,
             parse_datetime(&self.expires)?,
             self.meta.snapshot,
+            self.additional_fields.into_iter().collect(),
         )
     }
 }
@@ -226,6 +234,8 @@ pub struct SnapshotMetadata {
     expires: String,
     #[serde(deserialize_with = "deserialize_reject_duplicates::deserialize")]
     meta: BTreeMap<String, metadata::MetadataDescription<metadata::TargetsMetadata>>,
+    #[serde(flatten)]
+    additional_fields: BTreeMap<String, serde_json::Value>,
 }
 
 impl SnapshotMetadata {
@@ -240,6 +250,7 @@ impl SnapshotMetadata {
                 .iter()
                 .map(|(p, d)| (format!("{}.json", p), d.clone()))
                 .collect(),
+            additional_fields: metadata.additional_fields().clone().into_iter().collect(),
         })
     }
 
@@ -277,6 +288,7 @@ impl SnapshotMetadata {
                     Ok((p, d))
                 })
                 .collect::<Result<_>>()?,
+            self.additional_fields.into_iter().collect(),
         )
     }
 }

--- a/tuf/src/pouf/pouf1/shims.rs
+++ b/tuf/src/pouf/pouf1/shims.rs
@@ -291,6 +291,8 @@ pub struct TargetsMetadata {
     targets: BTreeMap<metadata::TargetPath, metadata::TargetDescription>,
     #[serde(default, skip_serializing_if = "metadata::Delegations::is_empty")]
     delegations: metadata::Delegations,
+    #[serde(flatten)]
+    additional_fields: BTreeMap<String, serde_json::Value>,
 }
 
 impl TargetsMetadata {
@@ -306,6 +308,11 @@ impl TargetsMetadata {
                 .map(|(p, d)| (p.clone(), d.clone()))
                 .collect(),
             delegations: metadata.delegations().clone(),
+            additional_fields: metadata
+                .additional_fields()
+                .iter()
+                .map(|(p, d)| (p.clone(), d.clone()))
+                .collect(),
         })
     }
 
@@ -329,6 +336,7 @@ impl TargetsMetadata {
             parse_datetime(&self.expires)?,
             self.targets.into_iter().collect(),
             self.delegations,
+            self.additional_fields.into_iter().collect(),
         )
     }
 }


### PR DESCRIPTION
From the [TUF spec](https://theupdateframework.github.io/specification/latest/#document-formats):

> All of the formats described below include the ability to add more attribute-value fields to objects for backwards-compatible format changes. Implementers who encounter undefined attribute-value pairs in the format must include the data when calculating hashes or verifying signatures and must preserve the data when re-serializing.

This adjust the primary metadata structs to include an `additional_fields` member that collects any unknown top-level keys. Those fields are then available to users of the library as well as present when the struct is re-serialized to JSON.