### PR TITLE
fix broken doc link

### DIFF
--- a/tuf/src/repo_builder.rs
+++ b/tuf/src/repo_builder.rs
@@ -781,7 +781,7 @@ where
     ///
     /// This will hash the file with [HashAlgorithm::Sha256].
     ///
-    /// See [RepoBuilder<Targets>::add_target] for more details.
+    /// See `RepoBuilder<Targets>::add_target` for more details.
     pub async fn add_target<Rd>(
         self,
         target_path: TargetPath,


### PR DESCRIPTION
I couldn't find a way to make the link actually work, so I switched it to text.