### PR TITLE
Update *ring* to 0.17 and untrusted to 0.9. 

### DIFF
--- a/tuf/Cargo.toml
+++ b/tuf/Cargo.toml
@@ -26,13 +26,13 @@ hyper = { version = "0.14.15", default-features = false, features = [ "stream", 
 itoa = "1.0"
 log = "0.4"
 percent-encoding = "2.1"
-ring = { version = "0.16" }
+ring = { version = "0.17" }
 serde = "1"
 serde_derive = "1"
 serde_json = "1"
 tempfile = "3"
 thiserror = "1.0"
-untrusted = "0.7"
+untrusted = "0.9"
 url = "2"
 
 [dev-dependencies]


### PR DESCRIPTION
Intentionally use "0.17" as the version spec instead of the latest version "0.17.7" to help projects depending on rust-tuf who want to go through a two step ring 0.16.20 -> 0.17.0 -> 0.17.7 update process.

Since *ring* 0.17 uses untrusted 0.9 currently, update rust-tuf to use that same version.