### PR TITLE
Crypto: Parse and format Ed25519 SPKI directly instead of using derp.

### DIFF
--- a/tuf/Cargo.toml
+++ b/tuf/Cargo.toml
@@ -19,7 +19,6 @@ path = "./src/lib.rs"
 [dependencies]
 chrono = { version = "0.4.23", features = [ "serde" ] }
 data-encoding = "2.0.0-rc.2"
-derp = "0.0.14"
 futures-io = "0.3.1"
 futures-util = { version = "0.3.1", features = [ "io" ] }
 http = "0.2.0"

--- a/tuf/src/error.rs
+++ b/tuf/src/error.rs
@@ -212,7 +212,3 @@ pub enum Error {
         role: MetadataPath,
     },
 }
-
-pub(crate) fn derp_error_to_error(err: derp::Error) -> Error {
-    Error::Encoding(format!("DER: {:?}", err))
-}


### PR DESCRIPTION
 Remove the `derp` dependency.

The header value was obtained from `head -c14 tests/ed25519/ed25519-1.spki.der | hexdump -C`.

This will allow the version of untrusted used by rust-tuf to be upgraded when *ring* is updated to 0.17 without having multiple versions of untrusted in the dependency tree.