### PR TITLE
Update dependencies to resolve some warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
     "tuf",
     "interop-tests",

--- a/tuf/Cargo.toml
+++ b/tuf/Cargo.toml
@@ -17,7 +17,7 @@ name = "tuf"
 path = "./src/lib.rs"
 
 [dependencies]
-chrono = { version = "0.4.23", features = [ "serde" ] }
+chrono = { version = "0.4.34", features = [ "serde" ] }
 data-encoding = "2.0.0-rc.2"
 futures-io = "0.3.1"
 futures-util = { version = "0.3.1", features = [ "io" ] }

--- a/tuf/src/repo_builder.rs
+++ b/tuf/src/repo_builder.rs
@@ -37,10 +37,10 @@ mod private {
     impl<D: Pouf> Sealed for Done<D> {}
 }
 
-const DEFAULT_ROOT_EXPIRATION_DAYS: Duration = Duration::days(365);
-const DEFAULT_TARGETS_EXPIRATION_DAYS: Duration = Duration::days(90);
-const DEFAULT_SNAPSHOT_EXPIRATION_DAYS: Duration = Duration::days(7);
-const DEFAULT_TIMESTAMP_EXPIRATION_DAYS: Duration = Duration::days(1);
+const DEFAULT_ROOT_EXPIRATION: Duration = Duration::days(365);
+const DEFAULT_TARGETS_EXPIRATION: Duration = Duration::days(90);
+const DEFAULT_SNAPSHOT_EXPIRATION: Duration = Duration::days(7);
+const DEFAULT_TIMESTAMP_EXPIRATION: Duration = Duration::days(1);
 
 /// Trait to track each of the [RepoBuilder] building states.
 ///
@@ -420,10 +420,10 @@ where
                 trusted_snapshot_keys: vec![],
                 trusted_timestamp_keys: vec![],
                 time_version: None,
-                root_expiration_duration: DEFAULT_ROOT_EXPIRATION_DAYS,
-                targets_expiration_duration: DEFAULT_TARGETS_EXPIRATION_DAYS,
-                snapshot_expiration_duration: DEFAULT_SNAPSHOT_EXPIRATION_DAYS,
-                timestamp_expiration_duration: DEFAULT_TIMESTAMP_EXPIRATION_DAYS,
+                root_expiration_duration: DEFAULT_ROOT_EXPIRATION,
+                targets_expiration_duration: DEFAULT_TARGETS_EXPIRATION,
+                snapshot_expiration_duration: DEFAULT_SNAPSHOT_EXPIRATION,
+                timestamp_expiration_duration: DEFAULT_TIMESTAMP_EXPIRATION,
                 _pouf: PhantomData,
             },
             state: Root {
@@ -509,10 +509,10 @@ where
                 trusted_snapshot_keys: vec![],
                 trusted_timestamp_keys: vec![],
                 time_version: None,
-                root_expiration_duration: DEFAULT_ROOT_EXPIRATION_DAYS,
-                targets_expiration_duration: DEFAULT_TARGETS_EXPIRATION_DAYS,
-                snapshot_expiration_duration: DEFAULT_SNAPSHOT_EXPIRATION_DAYS,
-                timestamp_expiration_duration: DEFAULT_TIMESTAMP_EXPIRATION_DAYS,
+                root_expiration_duration: DEFAULT_ROOT_EXPIRATION,
+                targets_expiration_duration: DEFAULT_TARGETS_EXPIRATION,
+                snapshot_expiration_duration: DEFAULT_SNAPSHOT_EXPIRATION,
+                timestamp_expiration_duration: DEFAULT_TIMESTAMP_EXPIRATION,
                 _pouf: PhantomData,
             },
             state: Root { builder },

--- a/tuf/src/repo_builder.rs
+++ b/tuf/src/repo_builder.rs
@@ -37,10 +37,10 @@ mod private {
     impl<D: Pouf> Sealed for Done<D> {}
 }
 
-const DEFAULT_ROOT_EXPIRATION_DAYS: i64 = 365;
-const DEFAULT_TARGETS_EXPIRATION_DAYS: i64 = 90;
-const DEFAULT_SNAPSHOT_EXPIRATION_DAYS: i64 = 7;
-const DEFAULT_TIMESTAMP_EXPIRATION_DAYS: i64 = 1;
+const DEFAULT_ROOT_EXPIRATION_DAYS: Duration = Duration::days(365);
+const DEFAULT_TARGETS_EXPIRATION_DAYS: Duration = Duration::days(90);
+const DEFAULT_SNAPSHOT_EXPIRATION_DAYS: Duration = Duration::days(7);
+const DEFAULT_TIMESTAMP_EXPIRATION_DAYS: Duration = Duration::days(1);
 
 /// Trait to track each of the [RepoBuilder] building states.
 ///
@@ -420,10 +420,10 @@ where
                 trusted_snapshot_keys: vec![],
                 trusted_timestamp_keys: vec![],
                 time_version: None,
-                root_expiration_duration: Duration::days(DEFAULT_ROOT_EXPIRATION_DAYS),
-                targets_expiration_duration: Duration::days(DEFAULT_TARGETS_EXPIRATION_DAYS),
-                snapshot_expiration_duration: Duration::days(DEFAULT_SNAPSHOT_EXPIRATION_DAYS),
-                timestamp_expiration_duration: Duration::days(DEFAULT_TIMESTAMP_EXPIRATION_DAYS),
+                root_expiration_duration: DEFAULT_ROOT_EXPIRATION_DAYS,
+                targets_expiration_duration: DEFAULT_TARGETS_EXPIRATION_DAYS,
+                snapshot_expiration_duration: DEFAULT_SNAPSHOT_EXPIRATION_DAYS,
+                timestamp_expiration_duration: DEFAULT_TIMESTAMP_EXPIRATION_DAYS,
                 _pouf: PhantomData,
             },
             state: Root {
@@ -509,10 +509,10 @@ where
                 trusted_snapshot_keys: vec![],
                 trusted_timestamp_keys: vec![],
                 time_version: None,
-                root_expiration_duration: Duration::days(DEFAULT_ROOT_EXPIRATION_DAYS),
-                targets_expiration_duration: Duration::days(DEFAULT_TARGETS_EXPIRATION_DAYS),
-                snapshot_expiration_duration: Duration::days(DEFAULT_SNAPSHOT_EXPIRATION_DAYS),
-                timestamp_expiration_duration: Duration::days(DEFAULT_TIMESTAMP_EXPIRATION_DAYS),
+                root_expiration_duration: DEFAULT_ROOT_EXPIRATION_DAYS,
+                targets_expiration_duration: DEFAULT_TARGETS_EXPIRATION_DAYS,
+                snapshot_expiration_duration: DEFAULT_SNAPSHOT_EXPIRATION_DAYS,
+                timestamp_expiration_duration: DEFAULT_TIMESTAMP_EXPIRATION_DAYS,
                 _pouf: PhantomData,
             },
             state: Root { builder },


### PR DESCRIPTION
This stops cargo from complaining about us using the old resolver, and from chrono complaining about us using some functions that were once deprecated, then undeprecated.