### PR TITLE
remove dependency on serde_derive 

### DIFF
--- a/interop-tests/Cargo.toml
+++ b/interop-tests/Cargo.toml
@@ -15,7 +15,6 @@ chrono = { version = "0.4.23", features = [ "serde" ] }
 data-encoding = "2.0.0-rc.2"
 futures-executor = "0.3.1"
 serde = "1"
-serde_derive = "1"
 serde_json = "1"
 tuf = { path = "../tuf" }
 walkdir = "2.3.2"

--- a/interop-tests/src/lib.rs
+++ b/interop-tests/src/lib.rs
@@ -1,6 +1,6 @@
 use chrono::offset::{TimeZone, Utc};
 use data_encoding::HEXLOWER;
-use serde_derive::Deserialize;
+use serde::Deserialize;
 use std::collections::{BTreeMap, HashMap};
 use std::fs::{self, File};
 use std::path::{Path, PathBuf};

--- a/interop-tests/src/pretty.rs
+++ b/interop-tests/src/pretty.rs
@@ -70,7 +70,7 @@ impl Pouf for JsonPretty {
 
     /// ```
     /// # use interop_tests::JsonPretty;
-    /// # use serde_derive::Deserialize;
+    /// # use serde::Deserialize;
     /// # use serde_json::json;
     /// # use std::collections::HashMap;
     /// # use tuf::pouf::Pouf;
@@ -95,7 +95,7 @@ impl Pouf for JsonPretty {
 
     /// ```
     /// # use interop_tests::JsonPretty;
-    /// # use serde_derive::Serialize;
+    /// # use serde::Serialize;
     /// # use serde_json::json;
     /// # use std::collections::HashMap;
     /// # use tuf::pouf::Pouf;

--- a/tuf/Cargo.toml
+++ b/tuf/Cargo.toml
@@ -28,8 +28,7 @@ itoa = "1.0"
 log = "0.4"
 percent-encoding = "2.1"
 ring = { version = "0.17" }
-serde = "1"
-serde_derive = "1"
+serde = { version = "1.0.204", features = ["derive"] }
 serde_json = "1"
 tempfile = "3"
 thiserror = "1.0"

--- a/tuf/src/crypto.rs
+++ b/tuf/src/crypto.rs
@@ -10,10 +10,9 @@ use {
         signature::{Ed25519KeyPair, KeyPair, ED25519},
     },
     serde::{
-        de::{Deserialize, Deserializer, Error as DeserializeError},
-        ser::{Error as SerializeError, Serialize, Serializer},
+        de::Error as DeserializeError, ser::Error as SerializeError, Deserialize, Deserializer,
+        Serialize, Serializer,
     },
-    serde_derive::{Deserialize, Serialize},
     std::{
         cmp::Ordering,
         collections::HashMap,

--- a/tuf/src/metadata.rs
+++ b/tuf/src/metadata.rs
@@ -3,9 +3,10 @@
 use chrono::offset::Utc;
 use chrono::{DateTime, Duration};
 use futures_io::AsyncRead;
-use serde::de::{Deserialize, DeserializeOwned, Deserializer, Error as DeserializeError};
-use serde::ser::{Error as SerializeError, Serialize, Serializer};
-use serde_derive::{Deserialize, Serialize};
+use serde::{
+    de::DeserializeOwned, de::Error as DeserializeError, ser::Error as SerializeError, Deserialize,
+    Deserializer, Serialize, Serializer,
+};
 use std::borrow::{Borrow, Cow};
 use std::collections::{HashMap, HashSet};
 use std::fmt::{self, Debug, Display};

--- a/tuf/src/pouf/pouf1/mod.rs
+++ b/tuf/src/pouf/pouf1/mod.rs
@@ -202,7 +202,7 @@ impl Pouf for Pouf1 {
     }
 
     /// ```
-    /// # use serde_derive::Deserialize;
+    /// # use serde::Deserialize;
     /// # use serde_json::json;
     /// # use std::collections::HashMap;
     /// # use tuf::pouf::{Pouf, Pouf1};
@@ -226,7 +226,7 @@ impl Pouf for Pouf1 {
     }
 
     /// ```
-    /// # use serde_derive::Serialize;
+    /// # use serde::Serialize;
     /// # use serde_json::json;
     /// # use std::collections::HashMap;
     /// # use tuf::pouf::{Pouf, Pouf1};

--- a/tuf/src/pouf/pouf1/shims.rs
+++ b/tuf/src/pouf/pouf1/shims.rs
@@ -6,7 +6,7 @@ use {
         Result,
     },
     chrono::{offset::Utc, prelude::*},
-    serde_derive::{Deserialize, Serialize},
+    serde::{Deserialize, Serialize},
     std::{
         collections::{BTreeMap, HashSet},
         marker::PhantomData,

--- a/tuf/src/repository/file_system.rs
+++ b/tuf/src/repository/file_system.rs
@@ -126,7 +126,7 @@ where
     ///
     /// Warning: The current implementation makes no effort to prevent manipulations of the
     /// underlying filesystem, either in-process, or by an external process.
-    pub fn batch_update(&self) -> FileSystemBatchUpdate<D> {
+    pub fn batch_update(&self) -> FileSystemBatchUpdate<'_, D> {
         FileSystemBatchUpdate {
             initial_parent_version: *self.version.read().unwrap(),
             parent_repo: self,

--- a/tuf/src/verify.rs
+++ b/tuf/src/verify.rs
@@ -1,7 +1,7 @@
 //! The `verify` module performs signature verification.
 
 use log::{debug, warn};
-use serde_derive::Deserialize;
+use serde::Deserialize;
 use std::collections::HashMap;
 
 use crate::crypto::{KeyId, PublicKey, Signature};


### PR DESCRIPTION
it's a better pattern to use the feature tag from serde so that we don't get a potential version mismatch