### PR TITLE
[tuf][interop-tests] Migrate lazy_static to LazyLock

### DIFF
--- a/interop-tests/Cargo.toml
+++ b/interop-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "interop-tests"
-version = "0.1.0"
+version = "0.1.1"
 authors = [ "heartsucker <heartsucker@autistici.org>", "Erick Tryzelaar <etryzelaar@google.com>" ]
 description = "TUF library interoperation tests"
 homepage = "https://github.com/theupdateframework/rust-tuf"
@@ -11,18 +11,18 @@ license = "MIT/Apache-2.0"
 publish = false
 
 [dependencies]
-chrono = { version = "0.4.23", features = [ "serde" ] }
-data-encoding = "2.0.0-rc.2"
-futures-executor = "0.3.1"
+chrono = { version = "0.4.42", features = [ "serde" ] }
+data-encoding = "2.9.0"
+futures-executor = "0.3.31"
 serde = "1"
 serde_derive = "1"
 serde_json = "1"
 tuf = { path = "../tuf" }
-walkdir = "2.3.2"
+walkdir = "2.5.0"
 
 [dev-dependencies]
 assert_matches = "1.5.0"
-futures-util = { version = "0.3.1", features = [ "io" ] }
+futures-util = { version = "0.3.31", features = [ "io" ] }
 pretty_assertions = "1"
 tempfile = "3"
 

--- a/tuf/Cargo.toml
+++ b/tuf/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "tuf"
 edition = "2021"
-version = "0.3.0-beta13"
-rust-version = "1.71.1"
+version = "0.3.0-beta14"
+rust-version = "1.80.0"
 authors = [ "heartsucker <heartsucker@autistici.org>", "Erick Tryzelaar <etryzelaar@google.com>" ]
 description = "Library for The Update Framework (TUF)"
 homepage = "https://github.com/theupdateframework/rust-tuf"
@@ -18,12 +18,12 @@ name = "tuf"
 path = "./src/lib.rs"
 
 [dependencies]
-chrono = { version = "0.4.34", features = [ "serde" ] }
-data-encoding = "2.0.0-rc.2"
-futures-io = "0.3.1"
-futures-util = { version = "0.3.1", features = [ "io" ] }
-http = "0.2.0"
-hyper = { version = "0.14.15", default-features = false, features = [ "stream", "client", "http1" ], optional = true }
+chrono = { version = "0.4.42", features = [ "serde" ] }
+data-encoding = "2.9.0"
+futures-io = "0.3.31"
+futures-util = { version = "0.3.31", features = [ "io" ] }
+http = "0.2.4"
+hyper = { version = "0.14.19", default-features = false, features = [ "stream", "client", "http1" ], optional = true }
 itoa = "1.0"
 log = "0.4"
 percent-encoding = "2.1"
@@ -32,14 +32,13 @@ serde = "1"
 serde_derive = "1"
 serde_json = "1"
 tempfile = "3"
-thiserror = "1.0"
+thiserror = "2.0"
 untrusted = "0.9"
 url = "2"
 
 [dev-dependencies]
 assert_matches = "1.5.0"
-futures-executor = "0.3.1"
-lazy_static = "1"
+futures-executor = "0.3.31"
 maplit = "1"
 pretty_assertions = "1"
 

--- a/tuf/src/client.rs
+++ b/tuf/src/client.rs
@@ -1309,28 +1309,26 @@ mod test {
     use assert_matches::assert_matches;
     use chrono::prelude::*;
     use futures_executor::block_on;
-    use lazy_static::lazy_static;
     use maplit::hashmap;
     use pretty_assertions::assert_eq;
     use serde_json::json;
     use std::collections::HashMap;
     use std::iter::once;
+    use std::sync::LazyLock;
 
-    lazy_static! {
-        static ref KEYS: Vec<Ed25519PrivateKey> = {
-            let keys: &[&[u8]] = &[
-                include_bytes!("../tests/ed25519/ed25519-1.pk8.der"),
-                include_bytes!("../tests/ed25519/ed25519-2.pk8.der"),
-                include_bytes!("../tests/ed25519/ed25519-3.pk8.der"),
-                include_bytes!("../tests/ed25519/ed25519-4.pk8.der"),
-                include_bytes!("../tests/ed25519/ed25519-5.pk8.der"),
-                include_bytes!("../tests/ed25519/ed25519-6.pk8.der"),
-            ];
-            keys.iter()
-                .map(|b| Ed25519PrivateKey::from_pkcs8(b).unwrap())
-                .collect()
-        };
-    }
+    static KEYS: LazyLock<Vec<Ed25519PrivateKey>> = LazyLock::new(|| {
+        let keys: &[&[u8]] = &[
+            include_bytes!("../tests/ed25519/ed25519-1.pk8.der"),
+            include_bytes!("../tests/ed25519/ed25519-2.pk8.der"),
+            include_bytes!("../tests/ed25519/ed25519-3.pk8.der"),
+            include_bytes!("../tests/ed25519/ed25519-4.pk8.der"),
+            include_bytes!("../tests/ed25519/ed25519-5.pk8.der"),
+            include_bytes!("../tests/ed25519/ed25519-6.pk8.der"),
+        ];
+        keys.iter()
+            .map(|b| Ed25519PrivateKey::from_pkcs8(b).unwrap())
+            .collect()
+    });
 
     #[allow(clippy::enum_variant_names)]
     enum ConstructorMode {

--- a/tuf/src/database.rs
+++ b/tuf/src/database.rs
@@ -1088,24 +1088,22 @@ mod test {
     };
     use crate::pouf::Pouf1;
     use assert_matches::assert_matches;
-    use lazy_static::lazy_static;
     use std::iter::once;
+    use std::sync::LazyLock;
 
-    lazy_static! {
-        static ref KEYS: Vec<Ed25519PrivateKey> = {
-            let keys: &[&[u8]] = &[
-                include_bytes!("../tests/ed25519/ed25519-1.pk8.der"),
-                include_bytes!("../tests/ed25519/ed25519-2.pk8.der"),
-                include_bytes!("../tests/ed25519/ed25519-3.pk8.der"),
-                include_bytes!("../tests/ed25519/ed25519-4.pk8.der"),
-                include_bytes!("../tests/ed25519/ed25519-5.pk8.der"),
-                include_bytes!("../tests/ed25519/ed25519-6.pk8.der"),
-            ];
-            keys.iter()
-                .map(|b| Ed25519PrivateKey::from_pkcs8(b).unwrap())
-                .collect()
-        };
-    }
+    static KEYS: LazyLock<Vec<Ed25519PrivateKey>> = LazyLock::new(|| {
+        let keys: &[&[u8]] = &[
+            include_bytes!("../tests/ed25519/ed25519-1.pk8.der"),
+            include_bytes!("../tests/ed25519/ed25519-2.pk8.der"),
+            include_bytes!("../tests/ed25519/ed25519-3.pk8.der"),
+            include_bytes!("../tests/ed25519/ed25519-4.pk8.der"),
+            include_bytes!("../tests/ed25519/ed25519-5.pk8.der"),
+            include_bytes!("../tests/ed25519/ed25519-6.pk8.der"),
+        ];
+        keys.iter()
+            .map(|b| Ed25519PrivateKey::from_pkcs8(b).unwrap())
+            .collect()
+    });
 
     #[test]
     fn root_trusted_keys_success() {

--- a/tuf/src/repo_builder.rs
+++ b/tuf/src/repo_builder.rs
@@ -1582,27 +1582,25 @@ mod tests {
         },
         futures_executor::block_on,
         futures_util::io::{AsyncReadExt, Cursor},
-        lazy_static::lazy_static,
         maplit::hashmap,
         pretty_assertions::assert_eq,
         std::collections::BTreeMap,
+        std::sync::LazyLock,
     };
 
-    lazy_static! {
-        static ref KEYS: Vec<Ed25519PrivateKey> = {
-            let keys: &[&[u8]] = &[
-                include_bytes!("../tests/ed25519/ed25519-1.pk8.der"),
-                include_bytes!("../tests/ed25519/ed25519-2.pk8.der"),
-                include_bytes!("../tests/ed25519/ed25519-3.pk8.der"),
-                include_bytes!("../tests/ed25519/ed25519-4.pk8.der"),
-                include_bytes!("../tests/ed25519/ed25519-5.pk8.der"),
-                include_bytes!("../tests/ed25519/ed25519-6.pk8.der"),
-            ];
-            keys.iter()
-                .map(|b| Ed25519PrivateKey::from_pkcs8(b).unwrap())
-                .collect()
-        };
-    }
+    static KEYS: LazyLock<Vec<Ed25519PrivateKey>> = LazyLock::new(|| {
+        let keys: &[&[u8]] = &[
+            include_bytes!("../tests/ed25519/ed25519-1.pk8.der"),
+            include_bytes!("../tests/ed25519/ed25519-2.pk8.der"),
+            include_bytes!("../tests/ed25519/ed25519-3.pk8.der"),
+            include_bytes!("../tests/ed25519/ed25519-4.pk8.der"),
+            include_bytes!("../tests/ed25519/ed25519-5.pk8.der"),
+            include_bytes!("../tests/ed25519/ed25519-6.pk8.der"),
+        ];
+        keys.iter()
+            .map(|b| Ed25519PrivateKey::from_pkcs8(b).unwrap())
+            .collect()
+    });
 
     fn create_root(
         version: u32,


### PR DESCRIPTION
* Use LazyLock (stable after 1.80.0)
* Require 1.80.0 as the minimum Rust version
* While on it: Update most dependencies
* Bump version to 0.3.0-beta14